### PR TITLE
chore: add pnpm and Node.js version specifications to CI workflow

### DIFF
--- a/.github/workflows/node-ci-build.yml
+++ b/.github/workflows/node-ci-build.yml
@@ -12,3 +12,6 @@ jobs:
       contents: write
       packages: write
       pull-requests: write
+    with:
+      pnpm-version: '10.0.0'
+      node-version: '22.17.0'


### PR DESCRIPTION
- Specified pnpm version as 10.0.0 and Node.js version as 22.17.0 in the GitHub Actions workflow for consistency and compatibility.