### PR TITLE
chore: update oracles-client-sdk to version 0.2.1

### DIFF
--- a/packages/oracles-client-sdk/package.json
+++ b/packages/oracles-client-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ixo/oracles-client-sdk",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "type": "module",
   "private": false,
   "description": "Client SDK for interacting with IXO Oracles, designed for React applications",


### PR DESCRIPTION
- Modified the `mutationFn` in `useContractOracle` to accept an optional `useAuthz` parameter, enhancing flexibility in authorization handling.
- Updated the `enabled` condition in `useContractOracle` to include a check for `authzConfig?.granteeAddress`.
- Refactored `useLiveAgent` and `useLiveKitAgent` to accept an optional `overrides` parameter for base URL configuration, improving customization options.
- Added cleanup logic for the worker in `useLiveKitAgent` to prevent memory leaks.