### PR TITLE
Make Redis optional for non-critical features

### DIFF
--- a/apps/app/.env.example
+++ b/apps/app/.env.example
@@ -61,6 +61,7 @@ SANDBOX_MCP_URL=
 
 # --- Data & storage ---
 SQLITE_DATABASE_PATH=./data/oracle.sqlite
+# Optional: when unset, task scheduling, token limiting, and claim processing are disabled
 REDIS_URL=redis://localhost:6379
 # Set to "true" for TLS to DB (default: false)
 DATABASE_USE_SSL=false

--- a/apps/app/src/app.module.ts
+++ b/apps/app/src/app.module.ts
@@ -13,7 +13,7 @@ import { ThrottlerGuard, ThrottlerModule } from '@nestjs/throttler';
 import { AppController } from './app.controller';
 import { AppService } from './app.service';
 import { CallsModule } from './calls/calls.module';
-import { type ENV, EnvSchema, getConfig } from './config';
+import { type ENV, EnvSchema, getConfig, isRedisEnabled } from './config';
 import { MessagesModule } from './messages/messages.module';
 import { AuthHeaderMiddleware } from './middleware/auth-header.middleware';
 import { SubscriptionMiddleware } from './middleware/subscription.middleware';
@@ -60,7 +60,8 @@ import { WsModule } from './ws/ws.module';
     SessionsModule,
     MessagesModule,
     UcanModule,
-    TasksModule,
+    // TasksModule requires Redis for BullMQ job queues
+    ...(isRedisEnabled() ? [TasksModule] : []),
     // KnowledgeModule,
     ScheduleModule.forRoot(),
     SlackModule,
@@ -73,6 +74,10 @@ import { WsModule } from './ws/ws.module';
       provide: RedisService,
       useFactory: (configService: ConfigService<ENV>) => {
         const config = getConfig(configService);
+        if (!isRedisEnabled()) {
+          Logger.log('RedisService disabled (REDIS_URL not configured)');
+          return null;
+        }
         if (config.get('DISABLE_CREDITS')) {
           Logger.log('RedisService disabled (DISABLE_CREDITS=true)');
           return null;
@@ -85,6 +90,12 @@ import { WsModule } from './ws/ws.module';
       provide: ClaimProcessingService,
       useFactory: (configService: ConfigService<ENV>) => {
         const config = getConfig(configService);
+        if (!isRedisEnabled()) {
+          Logger.log(
+            'ClaimProcessingService disabled (REDIS_URL not configured)',
+          );
+          return null;
+        }
         if (config.get('DISABLE_CREDITS')) {
           Logger.log('ClaimProcessingService disabled (DISABLE_CREDITS=true)');
           return null;
@@ -104,9 +115,13 @@ export class AppModule implements NestModule {
   constructor(private readonly configService: ConfigService<ENV>) {}
   configure(consumer: MiddlewareConsumer) {
     const disableCredits = this.configService.get('DISABLE_CREDITS', false);
+    const skipSubscription = disableCredits || !isRedisEnabled();
 
-    if (disableCredits) {
-      Logger.log('Subscription middleware disabled (DISABLE_CREDITS=true)');
+    if (skipSubscription) {
+      const reason = !isRedisEnabled()
+        ? 'REDIS_URL not configured'
+        : 'DISABLE_CREDITS=true';
+      Logger.log(`Subscription middleware disabled (${reason})`);
       consumer
         .apply(AuthHeaderMiddleware)
         .exclude(

--- a/apps/app/src/config.ts
+++ b/apps/app/src/config.ts
@@ -59,7 +59,7 @@ export const EnvSchema = z.object({
   SUBSCRIPTION_URL: z.string().optional(),
   FIRECRAWL_MCP_URL: z.url(),
   DOMAIN_INDEXER_URL: z.url(),
-  REDIS_URL: z.string(),
+  REDIS_URL: z.string().optional(),
   SECP_MNEMONIC: z.string(),
   RPC_URL: z.string(),
   MATRIX_VALUE_PIN: z.string(),
@@ -116,6 +116,15 @@ export function getConfig(configService?: ConfigService<ENV>) {
       return svc.getOrThrow(key as any);
     },
   };
+}
+
+/**
+ * Returns true when a REDIS_URL is configured.
+ * Used to conditionally enable Redis-dependent features
+ * (BullMQ task queues, token/credit limiting, etc.).
+ */
+export function isRedisEnabled(): boolean {
+  return !!process.env.REDIS_URL;
 }
 
 let _singleton: ConfigService<ENV> | undefined;

--- a/apps/app/src/graph/agents/main-agent.ts
+++ b/apps/app/src/graph/agents/main-agent.ts
@@ -9,7 +9,7 @@ import {
   type ReactAgent,
   type StructuredTool,
 } from 'langchain';
-import { getConfig } from 'src/config';
+import { getConfig, isRedisEnabled } from 'src/config';
 import { type UcanService } from 'src/ucan/ucan.service';
 
 import { createPageContextMiddleware } from '../middlewares/page-context-middleware';
@@ -756,7 +756,7 @@ Promise<ReactAgent<any>> => {
     createPageContextMiddleware(),
   ];
 
-  if (!disableCredits) {
+  if (!disableCredits && isRedisEnabled()) {
     middleware.push(createTokenLimiterMiddleware());
   }
 

--- a/apps/app/src/graph/middlewares/token-limiter-middelware.ts
+++ b/apps/app/src/graph/middlewares/token-limiter-middelware.ts
@@ -5,7 +5,7 @@ import {
   AIMessageChunk,
   createMiddleware,
 } from 'langchain';
-import { getConfig } from 'src/config';
+import { getConfig, isRedisEnabled } from 'src/config';
 import { TokenLimiter, TokenLimiterError } from 'src/utils/token-limit-handler';
 import { getModelPricing } from '../llm-provider';
 import { contextSchema, type TChatNodeContext } from '../types';
@@ -17,8 +17,8 @@ const createTokenLimiterMiddleware = (): AgentMiddleware => {
     contextSchema: contextSchema as unknown as InteropZodObject,
     beforeModel: async (state, runtime) => {
       const disableCredits = config.get('DISABLE_CREDITS');
-      if (disableCredits) {
-        Logger.debug('Token limiting skipped (DISABLE_CREDITS=true)');
+      if (disableCredits || !isRedisEnabled()) {
+        Logger.debug('Token limiting skipped (credits disabled or no Redis)');
         return state;
       }
       if (!runtime.context) {
@@ -57,8 +57,8 @@ const createTokenLimiterMiddleware = (): AgentMiddleware => {
           throw new Error('Runtime context required for token limiting');
         }
         const disableCredits = config.get('DISABLE_CREDITS');
-        if (disableCredits) {
-          Logger.debug('Token limiting skipped (DISABLE_CREDITS=true)');
+        if (disableCredits || !isRedisEnabled()) {
+          Logger.debug('Token limiting skipped (credits disabled or no Redis)');
           return state;
         }
 

--- a/apps/app/src/main.ts
+++ b/apps/app/src/main.ts
@@ -12,7 +12,7 @@ import { DocumentBuilder, SwaggerModule } from '@nestjs/swagger';
 import type { Cache } from 'cache-manager';
 import helmet from 'helmet';
 import { AppModule } from './app.module';
-import { type ENV } from './config';
+import { type ENV, isRedisEnabled } from './config';
 import { UcanService } from './ucan/ucan.service';
 import { EditorMatrixClient } from './graph/agents/editor/editor-mx';
 import { initModelPricingCache } from './graph/llm-provider';
@@ -188,6 +188,16 @@ async function bootstrap(): Promise<void> {
   Logger.log(
     `Credits disabled: ${configService.get('DISABLE_CREDITS')}. type: ${typeof configService.get('DISABLE_CREDITS')}`,
   );
+
+  if (!isRedisEnabled()) {
+    Logger.warn('--- Redis is NOT configured (REDIS_URL not set) ---');
+    Logger.warn('The following features are disabled:');
+    Logger.warn('  • TasksModule (BullMQ job queues / scheduled tasks)');
+    Logger.warn('  • TokenLimiter (credit/token tracking)');
+    Logger.warn('  • ClaimProcessingService (on-chain credit claims)');
+    Logger.warn('  • RedisService (direct Redis client)');
+    Logger.warn('Set REDIS_URL to enable these features.');
+  }
 }
 
 function registerGracefulShutdown({

--- a/apps/app/src/messages/messages.module.ts
+++ b/apps/app/src/messages/messages.module.ts
@@ -5,6 +5,7 @@ import { MainAgentGraph } from 'src/graph';
 import { type ENV } from 'src/types';
 // SseService is provided globally by SseModule, no need to import or provide here.
 import { MatrixManager } from '@ixo/matrix';
+import { isRedisEnabled } from 'src/config';
 import { TasksModule } from 'src/tasks/tasks.module';
 import { UcanModule } from 'src/ucan/ucan.module';
 import { CheckpointStorageSyncModule } from 'src/user-matrix-sqlite-sync-service/user-matrix-sqlite-sync-service.module';
@@ -14,7 +15,12 @@ import { MessagesController } from './messages.controller';
 import { MessagesService } from './messages.service';
 
 @Module({
-  imports: [CheckpointStorageSyncModule, TasksModule, UcanModule],
+  imports: [
+    CheckpointStorageSyncModule,
+    // TasksModule requires Redis for BullMQ job queues
+    ...(isRedisEnabled() ? [TasksModule] : []),
+    UcanModule,
+  ],
   controllers: [MessagesController],
   providers: [
     MessagesService,

--- a/apps/app/src/messages/messages.service.ts
+++ b/apps/app/src/messages/messages.service.ts
@@ -49,6 +49,7 @@ import {
   type ApprovalClassification,
 } from 'src/tasks/processors/processor-utils';
 import { TasksService } from 'src/tasks/task.service';
+import { isRedisEnabled } from 'src/config';
 import { type ENV } from 'src/types';
 import { UcanService } from 'src/ucan/ucan.service';
 import { UserMatrixSqliteSyncService } from 'src/user-matrix-sqlite-sync-service/user-matrix-sqlite-sync-service.service';
@@ -781,7 +782,11 @@ export class MessagesService implements OnModuleInit, OnModuleDestroy {
           );
 
         // Deduct credits for file processing API calls
-        if (totalUsage && !this.config.get('DISABLE_CREDITS')) {
+        if (
+          totalUsage &&
+          !this.config.get('DISABLE_CREDITS') &&
+          isRedisEnabled()
+        ) {
           try {
             const credits =
               totalUsage.cost > 0


### PR DESCRIPTION
## Summary
This PR makes Redis an optional dependency by conditionally disabling Redis-dependent features when `REDIS_URL` is not configured. This allows the application to run in environments where Redis is not available, with graceful degradation of non-critical features.

## Key Changes

- **Config changes**: Made `REDIS_URL` optional in the environment schema and added `isRedisEnabled()` helper function to check if Redis is configured
- **Module loading**: Conditionally load `TasksModule` only when Redis is enabled in both `AppModule` and `MessagesModule`
- **Service initialization**: Updated `RedisService` and `ClaimProcessingService` providers to return `null` when Redis is not configured
- **Middleware**: Updated subscription middleware to skip when Redis is disabled (in addition to existing `DISABLE_CREDITS` check)
- **Token limiting**: Modified token limiter middleware to skip when Redis is not available
- **Credit deduction**: Added Redis availability check before attempting to deduct credits for file processing
- **Logging**: Added comprehensive warning messages at startup to inform users which features are disabled when Redis is not configured
- **Documentation**: Updated `.env.example` with clarification that Redis is optional

## Notable Implementation Details

- The `isRedisEnabled()` function checks `process.env.REDIS_URL` directly rather than relying on the config service, ensuring it works consistently across the application
- Features disabled when Redis is unavailable:
  - TasksModule (BullMQ job queues / scheduled tasks)
  - TokenLimiter (credit/token tracking)
  - ClaimProcessingService (on-chain credit claims)
  - RedisService (direct Redis client)
- The application continues to function with core features intact when Redis is not available

https://claude.ai/code/session_01HWA6x5AYQ56B9GNsYGc48V