### PR TITLE
Add user-created custom skills alongside public skills

### DIFF
--- a/apps/app/src/graph/agents/main-agent.ts
+++ b/apps/app/src/graph/agents/main-agent.ts
@@ -61,8 +61,8 @@ import { createMCPClient, createMCPClientAndGetTools } from '../mcp';
 import { createFileProcessingTool } from '../nodes/tools-node/file-processing-tool';
 import { createListRoomFilesTool } from '../nodes/tools-node/list-room-files-tool';
 import {
-  listSkillsTool,
-  searchSkillsTool,
+  createListSkillsTool,
+  createSearchSkillsTool,
 } from '../nodes/tools-node/skills-tools';
 import { getComposioTools } from '../nodes/tools-node/tools';
 
@@ -658,6 +658,22 @@ Promise<ReactAgent<any>> => {
         return t.invoke(input);
       },
     });
+  });
+
+  // Build the skills tools — they merge public registry results with the
+  // user's custom skills under /workspace/data/user-skills/. The factories
+  // need the wrapped sandbox_run tool to ls the folder, and the user DID
+  // to scope the per-user listing cache.
+  const skillsSandboxRunTool = wrappedSandboxTools.find(
+    (t) => t.name === 'sandbox_run',
+  );
+  const listSkillsTool = createListSkillsTool({
+    sandboxRunTool: skillsSandboxRunTool,
+    userDid,
+  });
+  const searchSkillsTool = createSearchSkillsTool({
+    sandboxRunTool: skillsSandboxRunTool,
+    userDid,
   });
 
   // Conditionally create BlockNote (editor) agent tool if editorRoomId is provided

--- a/apps/app/src/graph/agents/main-agent.ts
+++ b/apps/app/src/graph/agents/main-agent.ts
@@ -1,7 +1,4 @@
-import {
-  parserActionTool,
-  parserBrowserTool,
-} from '@ixo/common';
+import { parserActionTool, parserBrowserTool } from '@ixo/common';
 import { type IRunnableConfigWithRequiredFields } from '@ixo/matrix';
 import { OpenIdTokenProvider } from '@ixo/oracles-chain-client';
 import { SqliteSaver } from '@ixo/sqlite-saver';
@@ -321,8 +318,7 @@ Promise<ReactAgent<any>> => {
 
   if (ucanService?.hasSigningKey() && configurable.configs?.user?.did) {
     try {
-      const composioBaseUrl =
-        configService.getOrThrow('COMPOSIO_BASE_URL') 
+      const composioBaseUrl = configService.getOrThrow('COMPOSIO_BASE_URL');
 
       const invocation = await ucanService.createServiceInvocation(
         composioBaseUrl,

--- a/apps/app/src/graph/nodes/chat-node/prompt.ts
+++ b/apps/app/src/graph/nodes/chat-node/prompt.ts
@@ -167,14 +167,17 @@ Use the Memory Agent tool for:
 
 ### What Are Skills?
 
-Skills are specialized knowledge folders located at \`/workspace/skills/{skill-slug}/\`. Each contains:
-- **SKILL.md files**: The primary instruction set with best practices
+Skills are specialized knowledge folders. Each contains:
+- **SKILL.md**: The primary instruction set with best practices
 - **Supporting files**: Examples, templates, helper scripts, or reference materials
 - **Condensed expertise**: Solutions to common pitfalls and proven patterns
 
-Skills include both public (system-maintained, read-only) and custom (user-uploaded, domain- or task-specific). **User-uploaded skills have the highest priority.** Multiple skills may apply to one task.
+There are two sources, and \`list_skills\` / \`search_skills\` return both in one merged list with a \`source\` field:
 
-When you **load** or **execute** a skill, dependencies (from \`requirements.txt\`, \`package.json\`, etc.) are installed automatically. You do **not** need to run install steps yourself. Only install manually if you **encounter errors** or need a **new package** the skill does not provide.
+1. **User skills** (\`source: "user"\`) — custom skills the user has authored for themselves, persisted under \`/workspace/data/user-skills/{slug}/\`. These survive sandbox restarts (R2-backed mount). **Always prefer a user skill when one matches the task**, even if a public skill also applies.
+2. **Public skills** (\`source: "public"\`) — verified skills from the IXO registry, materialised at \`/workspace/skills/{slug}/\` on demand.
+
+When you **load** or **execute** a public skill, dependencies (from \`requirements.txt\`, \`package.json\`, etc.) are installed automatically. **For user skills, dependencies are NOT auto-installed** — if a user skill needs packages, install them yourself with the commands the skill specifies (or read its SKILL.md and \`exec pip3 install --break-system-packages …\` / \`bun install\`).
 
 ### Skill Discovery & Selection
 
@@ -184,11 +187,15 @@ Before touching any tools, analyze the request:
 - Can you use code to solve this?
 
 Use \`list_skills\` and \`search_skills\` to find skills. Each result includes:
-- Skill name and description (with trigger conditions)
-- Location path: \`/workspace/skills/{skill-slug}\`
-- CID (Content Identifier) — used **only** for \`load_skill\`, \`exec\`, and \`read_skill\`. Never use CID as a file path.
+- \`title\` — skill name (or slug for user skills)
+- \`description\` — what the skill does
+- \`path\` — absolute sandbox path to the skill folder
+- \`source\` — \`"user"\` or \`"public"\`
+- \`cid\` — present **only** for public skills. Required by \`load_skill\`. Never use a CID as a file path.
 
-**Common triggers**: document/report → docx, presentation/slides → pptx, spreadsheet → xlsx, PDF → pdf, website/app → frontend-design
+**User skills come first** in the merged list. If a user-skill match exists, use it.
+
+**Common public-skill triggers**: document/report → docx, presentation/slides → pptx, spreadsheet → xlsx, PDF → pdf, website/app → frontend-design
 
 ### Reading Skills Effectively
 
@@ -207,12 +214,14 @@ When combining multiple skills: read all relevant SKILL.md files first, identify
 
 **Every skill-based task MUST follow this complete sequence:**
 
-1. **Identify** — \`search_skills\` / \`list_skills\` to find the skill and CID
-2. **Load** — \`load_skill\` with CID to download skill files to sandbox
-3. **Read** — \`read_skill\` with full path (e.g. \`/workspace/skills/pptx/SKILL.md\`)
-4. **Create inputs** — \`sandbox_write\` for JSON/config in \`/workspace\` (never inside skills folder)
-5. **Execute** — \`exec\` to run scripts as specified in the skill
-6. **Output** — Ensure file is in \`/workspace/data/output/\` (create directory if needed)
+1. **Identify** — \`search_skills\` / \`list_skills\` to find the skill. Note its \`source\` field.
+2. **Load** —
+   - If \`source: "public"\`: call \`load_skill\` with the CID. This downloads and extracts the skill into \`/workspace/skills/{slug}/\`.
+   - If \`source: "user"\`: **SKIP this step**. User skills are already on disk under \`/workspace/data/user-skills/{slug}/\` and \`load_skill\` cannot reach them.
+3. **Read** — \`read_skill\` with the full path from the listing (e.g. \`/workspace/skills/pptx/SKILL.md\` for public, \`/workspace/data/user-skills/my-skill/SKILL.md\` for user).
+4. **Create inputs** — \`sandbox_write\` for JSON/config in \`/workspace/data\` (never inside the public \`/workspace/skills/\` folder — it's read-only).
+5. **Execute** — \`sandbox_run\` (\`exec\`) to run scripts as specified in the skill.
+6. **Output** — Ensure file is in \`/workspace/data/output/\` (create directory if needed).
 7. **Share** — \`artifact_get_presigned_url\` with full path to get previewUrl and downloadUrl. The UI shows the file automatically from the tool result. Reply with a nice markdown message. **Do not paste long URLs or file paths in chat.**
 
 **Step 7 is mandatory for every file creation. The UI renders the preview from the tool result automatically.**
@@ -268,34 +277,58 @@ Before creating any file:
 
 **The workflow is NOT complete until you call \`artifact_get_presigned_url\`.**
 
+### Creating a User Skill
+
+When the user explicitly asks you to make a new skill for them — or you spot a repeated workflow that would clearly benefit from one — author it directly with the sandbox tools. There is no separate \`create_skill\` tool: a skill is just a folder with a \`SKILL.md\`.
+
+**Before creating, always check whether the folder already exists.** If a skill with the same slug exists, treat it as an update (overwrite \`SKILL.md\`) rather than a create. \`list_skills\` (with \`refresh: true\`) is the source of truth.
+
+**Steps:**
+1. **Pick a slug** — short, lowercase, hyphenated (e.g. \`weekly-status-report\`). Confirm it's free by checking the latest \`list_skills\` output for any existing entry with \`source: "user"\` and matching \`title\`.
+2. **Check the folder** — run \`sandbox_run\` once with \`code: "ls -d /workspace/data/user-skills/<slug> 2>/dev/null && echo EXISTS || echo NEW"\`. Treat \`EXISTS\` as an update; treat \`NEW\` as a fresh create. Either way, the parent folder \`/workspace/data/user-skills\` is auto-created — you don't need to mkdir it yourself, the listing tool does that.
+3. **Write SKILL.md** — \`sandbox_write\` to \`/workspace/data/user-skills/<slug>/SKILL.md\`. Required. Use the same SKILL.md structure as public skills: a short H1 title, a one-line description, then sections covering When To Use / How To Run / Inputs / Outputs / Pitfalls.
+4. **Add supporting files (optional)** — scripts, templates, examples in the same folder via \`sandbox_write\`. Keep the layout flat unless the skill genuinely needs subfolders.
+5. **Refresh the listing** — call \`list_skills\` with \`refresh: true\`. This both confirms the new skill is discoverable and primes the per-user cache.
+6. **Confirm to the user** — reply with the slug + a one-line summary of what the skill does. Do not paste the full SKILL.md back at them.
+
+**Deleting a user skill:** \`sandbox_run\` with \`code: "rm -rf /workspace/data/user-skills/<slug>"\`, then \`list_skills\` with \`refresh: true\`.
+
+**Updating a user skill:** \`sandbox_write\` overwrites in place. Refresh the listing afterwards.
+
+**Cache hygiene:** any time you write to or delete under \`/workspace/data/user-skills/\`, your **next** \`list_skills\` (or \`search_skills\`) call must pass \`refresh: true\` so the change shows up.
+
 ### Sandbox File System
 
-**Inputs** (read-only):
+**Read-only**:
 - \`/workspace/uploads/\` — User-uploaded files
-- \`/workspace/skills/\` — Skills (read-only, never create files here)
+- \`/workspace/skills/\` — Public skills, materialised on demand. **Never create files here** — \`load_skill\` recursively chowns the tree to root and would clobber anything you put there.
 
-**Working Directory**:
-- \`/workspace/\` — Temporary workspace for iteration
-- Users cannot see this directory
+**Read/write, persistent (R2-backed mount)**:
+- \`/workspace/data/\` — Anything written here survives sandbox restarts. Default working area for inputs, intermediate files, and skill artefacts.
+- \`/workspace/data/user-skills/{slug}/\` — Custom user skills you author. Persistent.
+- \`/workspace/data/output/\` — Final deliverables only. Must copy finished work here before \`artifact_get_presigned_url\`.
 
-**Outputs**:
-- \`/workspace/data/output/\` — Final deliverables only. Must copy finished work here.
+**Read/write, ephemeral (lost on sandbox restart)**:
+- \`/workspace/\` and any subfolder *not* under \`/workspace/data/\` — temporary working area. Don't put user skills here; they'll vanish.
 
 **Path Rules:**
-- Always use **absolute paths** with leading slash (\`/workspace/...\` not \`workspace/...\`)
-- Skills folder is **read-only** — creating files there will fail with permission errors
+- Always use **absolute paths** with leading slash (\`/workspace/...\` not \`workspace/...\`).
+- \`/workspace/skills/\` is read-only — creating files there will fail or be reverted.
+- Only \`/workspace/data/**\` persists across restarts. Anywhere else is gone after the sandbox sleeps.
 - \`artifact_get_presigned_url\` returns \`previewUrl\` + \`downloadUrl\`. The UI renders the file automatically. **Never use file paths as links** — they are internal sandbox paths, not valid URLs.
 - When passing values to tool calls (URLs, tokens, credentials), always pass the **complete** value — never truncate or abbreviate.
 
 **Installing packages:**
 - Python: \`pip3 install --break-system-packages package-name\`
 - Node.js: use \`bun\` or \`npm\`
+- For user skills, you must run installs yourself; they are not auto-installed the way public-skill dependencies are.
 
 ### Troubleshooting
 
-- **Can't find skill?** — Check CID, try \`list_skills\` / \`search_skills\`, consider combining skills. If still nothing, try \`COMPOSIO_SEARCH_TOOLS\` — the user might need an external app action, not a skill.
+- **Can't find skill?** — Check CID, try \`list_skills\` / \`search_skills\`, consider combining skills. If the user just created one, retry with \`refresh: true\`. If still nothing, try \`COMPOSIO_SEARCH_TOOLS\` — the user might need an external app action, not a skill.
 - **Skill conflicts with user request?** — Priority: User intent > Skill standards > Your judgment. If user says "quick draft", deliver a quick draft, not a polished report.
-- **Permission denied?** — Skills folder is read-only. Create files in \`/workspace\` or output folder. Use full absolute paths.
+- **Permission denied?** — Public skills folder (\`/workspace/skills/\`) is read-only. Write to \`/workspace/data/\` instead. Use full absolute paths.
+- **User skill missing after a while?** — Should not happen; \`/workspace/data/\` is persistent. Refresh the listing first (\`refresh: true\`) before assuming it was deleted.
 - **Unavailable library?** — Check if it can be installed (pip, npm). Look for alternatives in the skill docs.
 
 ---

--- a/apps/app/src/graph/nodes/chat-node/prompt.ts
+++ b/apps/app/src/graph/nodes/chat-node/prompt.ts
@@ -251,17 +251,24 @@ User: "Analyze data and create slides"
 → artifact_get_presigned_url → UI shows file. Reply with nice message.
 </example-execution-pattern:multi-step>
 
-**Running a User Skill:**
+**Running a User Skill (Composio-backed, e.g. GitHub / Gmail):**
 <example-execution-pattern:user-skill>
-User: "Run my weekly revenue report"
-→ list_skills → find entry with source: "user", title: "weekly-revenue-report"
+User: "Run my weekly PR status"
+→ list_skills → find entry with source: "user", title: "weekly-pr-status"
 → SKIP load_skill (user skills are pre-loaded — on disk already)
-→ read_skill /workspace/data/user-skills/weekly-revenue-report/SKILL.md
+→ read_skill /workspace/data/user-skills/weekly-pr-status/SKILL.md
 → Install packages if the skill's Prerequisites says so (not auto-installed for user skills)
-→ Follow the Workflow section step-by-step; reference supporting files as directed
-→ Output to /workspace/data/output/
+→ SKILL.md Prerequisites lists Composio tools (e.g. GITHUB_LIST_PULL_REQUESTS)
+  → COMPOSIO_MANAGE_CONNECTIONS to verify GitHub is connected for this user
+    - Not connected? Tell the user to authorize in the UI, then STOP and wait for
+      their next message confirming completion. Do not retry blindly.
+  → COMPOSIO_EXECUTE_TOOL with the exact slug + parameters from SKILL.md
+→ Back in sandbox: sandbox_write the Composio result, run processing scripts
+→ Output formatted markdown / PDF / etc. to /workspace/data/output/
 → artifact_get_presigned_url → UI shows file. Reply with nice message.
 </example-execution-pattern:user-skill>
+
+For skills without external SaaS steps, skip the Composio block and run the Workflow directly.
 
 ### Flow-Triggered Skills (Editor Only)
 
@@ -298,9 +305,10 @@ A user skill is a **reusable procedure** the user owns. You package it once, and
 - You'd need to hardcode today's specific values (a date, a specific record, one-time URLs). Skills encode **patterns with parameters**, not snapshots of a single moment.
 - The inputs vary so unpredictably that the skill couldn't tell a future agent what to expect.
 
-**Before writing — always do these two checks**:
+**Before writing — always do these three checks**:
 1. Run \`list_skills\` with \`refresh: true\` and scan for a user skill that already covers this. If one matches, update it; don't make \`weekly-report\` when \`weekly-status-report\` exists.
 2. Run \`sandbox_run\` with \`code: "ls -d /workspace/data/user-skills/<slug> 2>/dev/null && echo EXISTS || echo NEW"\`. \`EXISTS\` → update mode (overwrite SKILL.md, reuse the folder). \`NEW\` → fresh create. The parent \`/workspace/data/user-skills\` is auto-created when \`list_skills\` runs — never \`mkdir\` the parent yourself.
+3. **If the skill will touch an external SaaS app** (Gmail, GitHub, Slack, Linear, Calendar, Notion, etc.), call \`COMPOSIO_SEARCH_TOOLS\` to discover the specific tool slugs you'll use (e.g. \`GITHUB_LIST_PULL_REQUESTS\`, \`GMAIL_SEND_EMAIL\`). Encode those exact slugs in the skill's Prerequisites and Workflow sections — future runs re-use the right tool without re-discovery. Only fall back to raw fetch/curl scripts in the sandbox if Composio has no tool for the integration.
 
 **Authoring steps**:
 
@@ -319,12 +327,14 @@ A user skill is a **reusable procedure** the user owns. You package it once, and
 
    ## Prerequisites
    - **Inputs**: <What the caller must provide. Name them.>
+   - **Composio integrations** (if any): list the exact Composio tool slugs this skill uses, e.g. \`GITHUB_LIST_PULL_REQUESTS\`, \`GMAIL_SEND_EMAIL\`. The running agent MUST verify each is connected via \`COMPOSIO_MANAGE_CONNECTIONS\` before executing; if not connected, it MUST pause, ask the user to authorize, and wait for confirmation before continuing.
    - **Secrets**: <Required secrets by name. They're injected as \`x-us-<name>\` env vars.>
    - **Packages** (if any): <exact install command, e.g. \`pip3 install --break-system-packages foo\`.>
 
    ## Workflow
-   1. <Exact step. Absolute paths. No "figure out X" — encode the decision.>
-   2. <...>
+   1. <For external SaaS data, use the Composio tool slug from Prerequisites — \`COMPOSIO_EXECUTE_TOOL\` with the exact slug and input schema. Return the raw result for processing in the next step.>
+   2. <Back in the sandbox: \`sandbox_write\` the Composio output to a working file, then run scripts / templates to shape the final artefact. Keep external calls and local processing as separate steps so failures are easy to isolate.>
+   3. <...>
 
    ## Output
    - <File type, location under \`/workspace/data/output/\`, what's inside.>
@@ -334,6 +344,8 @@ A user skill is a **reusable procedure** the user owns. You package it once, and
    \`\`\`
 
    **Keep SKILL.md tight — aim for under 150 lines.** If you have a long reference (tables, sample templates, API schema), put it in a sibling file like \`templates/invoice.md\` or \`reference/api.md\` and link to it from SKILL.md. The agent will read sibling files on demand; bloating SKILL.md wastes tokens on every load.
+
+   **Composio over raw scripts:** if a Composio tool exists for the integration, reference the Composio slug in the Workflow — don't tell the agent to write a raw \`curl\`/\`fetch\` script. Composio handles auth, rate limits, and schema; a raw script re-invents all three and breaks when the user's token rotates.
 
 3. **Add supporting files (optional)** via \`sandbox_write\`:
    - \`scripts/<name>.py\` or \`.ts\` — runnable helpers the workflow calls.
@@ -345,7 +357,9 @@ A user skill is a **reusable procedure** the user owns. You package it once, and
 
 5. **Refresh the listing** — call \`list_skills\` with \`refresh: true\`. Check that the new skill appears with a sensible \`title\` and \`description\`.
 
-6. **Tell the user** — one concise line: slug + what it does + an example trigger phrase. Example: *"Saved as \`weekly-revenue-report\`. Next time you ask for your weekly numbers, I'll pull Stripe and format it the same way."* Do **not** paste the whole SKILL.md back.
+6. **Export as a downloadable archive** — \`sandbox_run\` with \`code: "tar czf /workspace/data/output/<slug>.tar.gz -C /workspace/data/user-skills <slug>"\`, then \`artifact_get_presigned_url\` on \`/workspace/data/output/<slug>.tar.gz\`. This gives the user a portable backup they can download, share, or check into version control. Do the same on **update**: overwrite the existing tarball so the archive always reflects the latest version. Skip only if \`sandbox_run\` fails (noisy sandbox issue) — a missing archive shouldn't block the create.
+
+7. **Tell the user** — one concise line: slug + what it does + an example trigger phrase + the download link. Example: *"Saved as \`weekly-revenue-report\` — ask for your weekly numbers any time. [Download the skill archive](presigned-url)."* Do **not** paste the whole SKILL.md back.
 
 **Before saving — a good skill is**: parameterized (inputs from user/env, nothing hardcoded), self-contained (a future agent reading only SKILL.md knows what to do), reusable across similar future requests, and writes to a deterministic path under \`/workspace/data/output/\`. It is **not** a log of one conversation, a bundle of unrelated procedures, or a snapshot of today's specific values.
 

--- a/apps/app/src/graph/nodes/chat-node/prompt.ts
+++ b/apps/app/src/graph/nodes/chat-node/prompt.ts
@@ -146,7 +146,7 @@ Use the Memory Agent tool for:
 - Match user's communication style and expertise level
 - Reference shared history when relevant
 - **Always translate technical identifiers** to natural language
-- **After executing tools, ALWAYS respond with a clear summary** of what was done (e.g., "I've updated the block status to credential_ready and stored the credential"). Never output a refusal, apology, or "I can't provide that" after tools have already executed successfully — the operation is complete and the user needs confirmation, not a refusal.
+- **After executing tools, respond with a clear summary** of what was done (e.g., "I've updated the block status to credential_ready and stored the credential").
 
 **Task Discipline:**
 - When delegating to sub-agents (Editor Agent, Memory Agent, etc.), give clear,
@@ -234,8 +234,8 @@ User: "Create a professional report"
 → search_skills to find docx skill + CID
 → load_skill with CID
 → read_skill /workspace/skills/docx/SKILL.md
-→ sandbox_write for input data in /workspace
-→ exec to run skill scripts
+→ sandbox_write for input data in /workspace/data
+→ sandbox_run to execute skill scripts
 → Output to /workspace/data/output/report.docx
 → artifact_get_presigned_url → UI shows file. Reply with nice message.
 </example-execution-pattern:create-document>
@@ -263,17 +263,11 @@ User: "Run my weekly revenue report"
 → artifact_get_presigned_url → UI shows file. Reply with nice message.
 </example-execution-pattern:user-skill>
 
-### Flow-Triggered Skill Execution (Form Submit → Skill)
+### Flow-Triggered Skills (Editor Only)
 
-When a form.submit action block triggers with skill name, CID, and form answers:
-1. **Read flow context FIRST** — \`call_editor_agent\` with "read_flow_context" to get flow-level settings and metadata (custom parameters set by template creators). These settings may be required environment variables for the skill.
-2. **Read flow blocks** — \`call_editor_agent\` with "list_blocks" to understand all blocks in the flow (their types, IDs, roles).
-3. **Load & read** the skill SKILL.md to understand the script sequence and required env vars.
-4. **Execute** skill scripts with: form data from the trigger, flow settings from step 1, and the skill CID passed to sandbox_run (required for secrets injection).
-5. **Update blocks** with skill outputs. For flowLink blocks, update the \`links\` array with \`externalUrl\`. For action blocks with long/opaque values (credentials, JWTs, tokens), use \`apply_sandbox_output_to_block\` with dot-notation fieldMapping. Do NOT pass credentials through edit_block — they will be truncated.
-6. **Execute action** to trigger action blocks (e.g. form.submit, protocol.select).
+When a form.submit action block triggers a skill: **first** \`call_editor_agent\` with \`read_flow_context\` (flow-level env vars like protocolDid) **then** \`list_blocks\` (block IDs and roles). Both are mandatory — skills often require flow settings. Then run the canonical workflow, passing the skill CID to \`sandbox_run\` for secret injection.
 
-**CRITICAL: Steps 1-2 are mandatory.** Flow settings often contain parameters like protocolDid that skills need.
+For long or opaque skill outputs destined for editor blocks (credentials, JWTs, tokens), use \`apply_sandbox_output_to_block\` with dot-notation \`fieldMapping\`. Never route those through \`edit_block\` — the values get truncated.
 
 ### Quality Checklist
 
@@ -353,20 +347,12 @@ A user skill is a **reusable procedure** the user owns. You package it once, and
 
 6. **Tell the user** — one concise line: slug + what it does + an example trigger phrase. Example: *"Saved as \`weekly-revenue-report\`. Next time you ask for your weekly numbers, I'll pull Stripe and format it the same way."* Do **not** paste the whole SKILL.md back.
 
-**What makes a good skill — checklist before you hit save**:
-- ✅ **Parameterized** — inputs come from the user or environment, not hardcoded.
-- ✅ **Self-contained** — a future agent reading only SKILL.md knows what to do.
-- ✅ **Reusable** — works for the next 10 similar requests, not just today's.
-- ✅ **Observable** — deterministic output path under \`/workspace/data/output/\`.
-- ❌ **Not** a log of "what I did once" — abstract the pattern.
-- ❌ **Not** bundling 5 unrelated things together — split them.
-- ❌ **Not** overfitting to the specific conversation (no hardcoded names, dates, IDs).
+**Before saving — a good skill is**: parameterized (inputs from user/env, nothing hardcoded), self-contained (a future agent reading only SKILL.md knows what to do), reusable across similar future requests, and writes to a deterministic path under \`/workspace/data/output/\`. It is **not** a log of one conversation, a bundle of unrelated procedures, or a snapshot of today's specific values.
 
-**Updating a user skill** — \`sandbox_write\` overwrites in place. Bump any version note at the top if the behaviour changed meaningfully. Refresh the listing afterwards.
-
-**Deleting a user skill** — \`sandbox_run\` with \`code: "rm -rf /workspace/data/user-skills/<slug>"\`, then \`list_skills\` with \`refresh: true\`. Confirm the user intended to delete before acting.
-
-**Cache hygiene** — any time you write, update, or delete under \`/workspace/data/user-skills/\`, your **next** \`list_skills\` or \`search_skills\` call must pass \`refresh: true\`. Otherwise you'll see stale results for up to 5 minutes.
+**Updating / deleting**:
+- Update: \`sandbox_write\` overwrites in place.
+- Delete: \`sandbox_run\` with \`code: "rm -rf /workspace/data/user-skills/<slug>"\`. Confirm with the user before deleting.
+- After **any** write or delete under \`user-skills/\`, your next \`list_skills\` or \`search_skills\` must pass \`refresh: true\`. Otherwise listings are stale for up to 5 minutes.
 
 ### Sandbox File System
 
@@ -406,7 +392,7 @@ A user skill is a **reusable procedure** the user owns. You package it once, and
 
 ## 🧭 Routing Decision Logic
 
-**🚨 Firecrawl vs Sandbox — get this right:**
+**Firecrawl vs Sandbox:**
 - **Sandbox** = API calls, JSON endpoints, REST/GraphQL, programmatic data fetching, code execution. Use for ANY URL that contains \`/api/\`, \`/v1/\`, \`/v2/\`, \`/v3/\`, or returns structured data (JSON/XML). Write a script with fetch/curl/requests.
 - **Firecrawl** = Human-readable web pages ONLY. Web search, scraping articles, blog posts, news pages. NEVER for API endpoints.
 

--- a/apps/app/src/graph/nodes/chat-node/prompt.ts
+++ b/apps/app/src/graph/nodes/chat-node/prompt.ts
@@ -199,16 +199,16 @@ Use \`list_skills\` and \`search_skills\` to find skills. Each result includes:
 
 ### Reading Skills Effectively
 
-When reading a SKILL.md, focus on:
-1. **Required libraries/tools** — what's needed (auto-installed, but good to know)
-2. **File structure patterns** — how output should be organized
-3. **Common pitfalls** — mistakes to avoid
-4. **Quality standards** — what makes output "good" vs "acceptable"
-5. **Specific syntax/APIs** — exact code patterns to follow
-6. **Workflow order** — recommended sequence of operations
-7. **Helper scripts** — the skill may include scripts you can run directly
+**Scan before you deep-read.** Well-authored SKILL.md files keep the head concise (title → description → When to use) so you can decide quickly whether to use the skill. Only read past "When to use" if the skill is actually relevant.
 
-When combining multiple skills: read all relevant SKILL.md files first, identify overlapping concerns, then execute following combined guidance.
+When you commit to a skill, focus on:
+1. **Prerequisites** — required inputs, secrets, packages. Missing any? Ask or install before starting.
+2. **Workflow order** — the exact sequence of steps. Don't improvise.
+3. **Pitfalls** — known gotchas. These save hours.
+4. **Supporting files** — templates, scripts, examples referenced from SKILL.md. Read them only when the workflow calls for them (progressive disclosure).
+5. **Output format and path** — where the final artefact lands.
+
+When combining multiple skills: read the head of each first, identify overlapping concerns, then execute with the combined guidance. Don't load deep content from skills that only partially apply.
 
 ### Canonical Execution Workflow
 
@@ -251,6 +251,18 @@ User: "Analyze data and create slides"
 → artifact_get_presigned_url → UI shows file. Reply with nice message.
 </example-execution-pattern:multi-step>
 
+**Running a User Skill:**
+<example-execution-pattern:user-skill>
+User: "Run my weekly revenue report"
+→ list_skills → find entry with source: "user", title: "weekly-revenue-report"
+→ SKIP load_skill (user skills are pre-loaded — on disk already)
+→ read_skill /workspace/data/user-skills/weekly-revenue-report/SKILL.md
+→ Install packages if the skill's Prerequisites says so (not auto-installed for user skills)
+→ Follow the Workflow section step-by-step; reference supporting files as directed
+→ Output to /workspace/data/output/
+→ artifact_get_presigned_url → UI shows file. Reply with nice message.
+</example-execution-pattern:user-skill>
+
 ### Flow-Triggered Skill Execution (Form Submit → Skill)
 
 When a form.submit action block triggers with skill name, CID, and form answers:
@@ -279,23 +291,82 @@ Before creating any file:
 
 ### Creating a User Skill
 
-When the user explicitly asks you to make a new skill for them — or you spot a repeated workflow that would clearly benefit from one — author it directly with the sandbox tools. There is no separate \`create_skill\` tool: a skill is just a folder with a \`SKILL.md\`.
+A user skill is a **reusable procedure** the user owns. You package it once, and future invocations (by you or by the user) re-run it without re-deriving the steps. A skill is just a folder under \`/workspace/data/user-skills/{slug}/\` containing a \`SKILL.md\` and (optionally) supporting files. There is no \`create_skill\` tool — you author skills with \`sandbox_write\` + \`sandbox_run\`.
 
-**Before creating, always check whether the folder already exists.** If a skill with the same slug exists, treat it as an update (overwrite \`SKILL.md\`) rather than a create. \`list_skills\` (with \`refresh: true\`) is the source of truth.
+**Create a skill when**:
+- The user explicitly asks you to ("save this as a skill", "make a template for this").
+- You notice a workflow that will clearly recur — weekly reports, standardized document generation, repeatable multi-step processes.
+- A public skill almost fits but needs user-specific wrapping (e.g. the user always wants their Stripe revenue formatted a particular way).
 
-**Steps:**
-1. **Pick a slug** — short, lowercase, hyphenated (e.g. \`weekly-status-report\`). Confirm it's free by checking the latest \`list_skills\` output for any existing entry with \`source: "user"\` and matching \`title\`.
-2. **Check the folder** — run \`sandbox_run\` once with \`code: "ls -d /workspace/data/user-skills/<slug> 2>/dev/null && echo EXISTS || echo NEW"\`. Treat \`EXISTS\` as an update; treat \`NEW\` as a fresh create. Either way, the parent folder \`/workspace/data/user-skills\` is auto-created — you don't need to mkdir it yourself, the listing tool does that.
-3. **Write SKILL.md** — \`sandbox_write\` to \`/workspace/data/user-skills/<slug>/SKILL.md\`. Required. Use the same SKILL.md structure as public skills: a short H1 title, a one-line description, then sections covering When To Use / How To Run / Inputs / Outputs / Pitfalls.
-4. **Add supporting files (optional)** — scripts, templates, examples in the same folder via \`sandbox_write\`. Keep the layout flat unless the skill genuinely needs subfolders.
-5. **Refresh the listing** — call \`list_skills\` with \`refresh: true\`. This both confirms the new skill is discoverable and primes the per-user cache.
-6. **Confirm to the user** — reply with the slug + a one-line summary of what the skill does. Do not paste the full SKILL.md back at them.
+**Do NOT create a skill when**:
+- The task is one-off ("summarize this email", "translate this paragraph"). Just do the task.
+- A user or public skill already covers it — **update** the existing one instead of making a near-duplicate.
+- You'd need to hardcode today's specific values (a date, a specific record, one-time URLs). Skills encode **patterns with parameters**, not snapshots of a single moment.
+- The inputs vary so unpredictably that the skill couldn't tell a future agent what to expect.
 
-**Deleting a user skill:** \`sandbox_run\` with \`code: "rm -rf /workspace/data/user-skills/<slug>"\`, then \`list_skills\` with \`refresh: true\`.
+**Before writing — always do these two checks**:
+1. Run \`list_skills\` with \`refresh: true\` and scan for a user skill that already covers this. If one matches, update it; don't make \`weekly-report\` when \`weekly-status-report\` exists.
+2. Run \`sandbox_run\` with \`code: "ls -d /workspace/data/user-skills/<slug> 2>/dev/null && echo EXISTS || echo NEW"\`. \`EXISTS\` → update mode (overwrite SKILL.md, reuse the folder). \`NEW\` → fresh create. The parent \`/workspace/data/user-skills\` is auto-created when \`list_skills\` runs — never \`mkdir\` the parent yourself.
 
-**Updating a user skill:** \`sandbox_write\` overwrites in place. Refresh the listing afterwards.
+**Authoring steps**:
 
-**Cache hygiene:** any time you write to or delete under \`/workspace/data/user-skills/\`, your **next** \`list_skills\` (or \`search_skills\`) call must pass \`refresh: true\` so the change shows up.
+1. **Pick a slug** — \`verb-noun\` or \`noun-action\` form, lowercase, hyphens only. Good: \`weekly-revenue-report\`, \`generate-invoice-pdf\`, \`send-team-standup\`. Bad: \`helper\`, \`report\`, \`my-skill\`, \`doTheThing\`.
+
+2. **Write SKILL.md** via \`sandbox_write\` to \`/workspace/data/user-skills/<slug>/SKILL.md\`. Use this structure exactly (it's what \`list_skills\` reads for the description preview):
+
+   \`\`\`markdown
+   # <Short title in Title Case>
+
+   <One sentence, starts with a verb, describes what the skill does. This is the first thing list_skills shows — make it specific.>
+
+   ## When to use
+   - <Concrete trigger phrases or intents, one per line.>
+   - <Think: "what would the user say that should activate this?">
+
+   ## Prerequisites
+   - **Inputs**: <What the caller must provide. Name them.>
+   - **Secrets**: <Required secrets by name. They're injected as \`x-us-<name>\` env vars.>
+   - **Packages** (if any): <exact install command, e.g. \`pip3 install --break-system-packages foo\`.>
+
+   ## Workflow
+   1. <Exact step. Absolute paths. No "figure out X" — encode the decision.>
+   2. <...>
+
+   ## Output
+   - <File type, location under \`/workspace/data/output/\`, what's inside.>
+
+   ## Pitfalls
+   - <Known gotcha + how to handle it.>
+   \`\`\`
+
+   **Keep SKILL.md tight — aim for under 150 lines.** If you have a long reference (tables, sample templates, API schema), put it in a sibling file like \`templates/invoice.md\` or \`reference/api.md\` and link to it from SKILL.md. The agent will read sibling files on demand; bloating SKILL.md wastes tokens on every load.
+
+3. **Add supporting files (optional)** via \`sandbox_write\`:
+   - \`scripts/<name>.py\` or \`.ts\` — runnable helpers the workflow calls.
+   - \`templates/*\` — fillable templates.
+   - \`examples/*\` — sample input + expected output pairs.
+   Keep the tree shallow. Subdirectories only when you have 3+ files of the same kind.
+
+4. **Verify** — call \`read_skill\` on the SKILL.md you just wrote. Confirm it reads cleanly, paths are absolute, no placeholder text (\`<slug>\`, \`TODO\`, \`FIXME\`) leaked through.
+
+5. **Refresh the listing** — call \`list_skills\` with \`refresh: true\`. Check that the new skill appears with a sensible \`title\` and \`description\`.
+
+6. **Tell the user** — one concise line: slug + what it does + an example trigger phrase. Example: *"Saved as \`weekly-revenue-report\`. Next time you ask for your weekly numbers, I'll pull Stripe and format it the same way."* Do **not** paste the whole SKILL.md back.
+
+**What makes a good skill — checklist before you hit save**:
+- ✅ **Parameterized** — inputs come from the user or environment, not hardcoded.
+- ✅ **Self-contained** — a future agent reading only SKILL.md knows what to do.
+- ✅ **Reusable** — works for the next 10 similar requests, not just today's.
+- ✅ **Observable** — deterministic output path under \`/workspace/data/output/\`.
+- ❌ **Not** a log of "what I did once" — abstract the pattern.
+- ❌ **Not** bundling 5 unrelated things together — split them.
+- ❌ **Not** overfitting to the specific conversation (no hardcoded names, dates, IDs).
+
+**Updating a user skill** — \`sandbox_write\` overwrites in place. Bump any version note at the top if the behaviour changed meaningfully. Refresh the listing afterwards.
+
+**Deleting a user skill** — \`sandbox_run\` with \`code: "rm -rf /workspace/data/user-skills/<slug>"\`, then \`list_skills\` with \`refresh: true\`. Confirm the user intended to delete before acting.
+
+**Cache hygiene** — any time you write, update, or delete under \`/workspace/data/user-skills/\`, your **next** \`list_skills\` or \`search_skills\` call must pass \`refresh: true\`. Otherwise you'll see stale results for up to 5 minutes.
 
 ### Sandbox File System
 

--- a/apps/app/src/graph/nodes/tools-node/skills-tools.ts
+++ b/apps/app/src/graph/nodes/tools-node/skills-tools.ts
@@ -1,6 +1,11 @@
 /* eslint-disable no-console */
-import { tool } from '@langchain/core/tools';
+import { tool, type StructuredTool } from '@langchain/core/tools';
+import { Logger } from '@nestjs/common';
 import { getConfig } from 'src/config';
+import {
+  UserSkillsService,
+  type UserSkillEntry,
+} from 'src/user-skills/user-skills.service';
 import z from 'zod';
 
 const configService = getConfig();
@@ -20,33 +25,230 @@ type Capsule = {
   createdAt?: string;
 };
 
-interface NormalizedCapsule {
+interface MergedSkill {
   title: string;
-  cid: string;
   description: string;
   path: string;
+  source: 'user' | 'public';
+  /** Only present for public skills. User skills don't have a CID. */
+  cid?: string;
   createdAt?: string;
 }
 
-function normalizeCapsule(capsule: Capsule): NormalizedCapsule {
+function normalizePublicCapsule(capsule: Capsule): MergedSkill {
   return {
     title: capsule.name,
+    description: capsule.description ?? '',
+    path: `/workspace/skills/${capsule.name}`,
+    source: 'public',
     cid: capsule.cid,
     createdAt: capsule.createdAt
       ? new Date(capsule.createdAt).toISOString()
       : undefined,
-    description: capsule.description ?? '',
-    path: `/workspace/skills/${capsule.name}`,
   };
 }
 
-/**
- * List available skills (capsules) from the IXO skills registry with pagination.
- */
-const listSkills = async (params: { limit?: number; offset?: number }) => {
-  const limit = params.limit ?? 20;
-  const offset = params.offset ?? 0;
+function normalizeUserSkill(entry: UserSkillEntry): MergedSkill {
+  return {
+    title: entry.slug,
+    description: entry.description,
+    path: entry.path,
+    source: 'user',
+  };
+}
 
+interface SkillsToolDeps {
+  /** The wrapped sandbox_run tool. Without it, only public skills are returned. */
+  sandboxRunTool?: StructuredTool;
+  /** The user's DID. Used as the cache key for the per-user skill listing. */
+  userDid?: string;
+}
+
+/**
+ * Fetch the user's custom skills from the sandbox. Returns an empty list if
+ * the dependencies aren't available or the sandbox call fails — never throws.
+ */
+async function getUserSkills(
+  deps: SkillsToolDeps,
+  refresh: boolean,
+): Promise<MergedSkill[]> {
+  if (!deps.sandboxRunTool || !deps.userDid) return [];
+  try {
+    const entries = await UserSkillsService.getInstance().list({
+      userDid: deps.userDid,
+      sandboxRunTool: deps.sandboxRunTool,
+      refresh,
+    });
+    return entries.map(normalizeUserSkill);
+  } catch (error) {
+    Logger.warn(
+      `[skills-tools] user-skills listing failed: ${
+        error instanceof Error ? error.message : String(error)
+      }`,
+    );
+    return [];
+  }
+}
+
+export function createListSkillsTool(deps: SkillsToolDeps) {
+  return tool(
+    async (params: { limit?: number; offset?: number; refresh?: boolean }) => {
+      const limit = params.limit ?? 20;
+      const offset = params.offset ?? 0;
+      const refresh = params.refresh ?? false;
+
+      // Public skills + user skills in parallel.
+      const [publicResult, userSkills] = await Promise.all([
+        fetchPublicCapsules(limit, offset),
+        getUserSkills(deps, refresh),
+      ]);
+
+      // User skills always come first — the prompt promises "highest priority".
+      const skills: MergedSkill[] = [
+        ...userSkills,
+        ...publicResult.capsules.map(normalizePublicCapsule),
+      ];
+
+      const output = {
+        skills,
+        pagination: publicResult.pagination,
+        userSkillCount: userSkills.length,
+      };
+      console.log('listSkills output', {
+        userSkills: userSkills.length,
+        publicSkills: publicResult.capsules.length,
+        refresh,
+      });
+      return output;
+    },
+    {
+      name: 'list_skills',
+      description: `List available skills — both **user** (custom, in /workspace/data/user-skills/) and **public** (from the IXO skills registry).
+
+User skills are returned first and have priority. Use this to discover what skills exist before delegating to the Skills Agent.
+
+Each entry includes:
+- title: skill name (or slug for user skills)
+- description: skill description
+- path: absolute sandbox path to the skill folder
+- source: "user" or "public"
+- cid: only set for public skills — required by load_skill, exec, read_skill. Never use a CID as a file path.
+
+User skills are pre-loaded — DO NOT call load_skill for them. Read them directly with read_skill using the path field.
+
+After creating, updating, or deleting a user skill (via sandbox_write or sandbox_run rm under user-skills/), call this tool again with refresh: true so the new state is reflected.`,
+      schema: z.object({
+        limit: z
+          .number()
+          .min(1)
+          .max(100)
+          .optional()
+          .describe(
+            'Optional: number of public skills to return (1-100, default: 20). Does not limit user skills.',
+          ),
+        offset: z
+          .number()
+          .min(0)
+          .optional()
+          .describe(
+            'Optional: pagination offset for public skills (default: 0).',
+          ),
+        refresh: z
+          .boolean()
+          .optional()
+          .describe(
+            'Optional: bypass the per-user cache for the user-skills listing. Set to true immediately after creating, updating, or deleting a user skill.',
+          ),
+      }),
+    },
+  );
+}
+
+export function createSearchSkillsTool(deps: SkillsToolDeps) {
+  return tool(
+    async (params: { q: string; limit?: number; refresh?: boolean }) => {
+      const limit = params.limit ?? 10;
+      const refresh = params.refresh ?? false;
+      const queryLower = params.q.toLowerCase();
+
+      const [publicCapsules, userSkills] = await Promise.all([
+        searchPublicCapsules(params.q, limit),
+        getUserSkills(deps, refresh),
+      ]);
+
+      const userMatches = userSkills.filter(
+        (s) =>
+          s.title.toLowerCase().includes(queryLower) ||
+          s.description.toLowerCase().includes(queryLower),
+      );
+
+      const skills: MergedSkill[] = [
+        ...userMatches,
+        ...publicCapsules.map(normalizePublicCapsule),
+      ];
+
+      const output = {
+        query: params.q,
+        count: skills.length,
+        userSkillCount: userMatches.length,
+        skills,
+      };
+      console.log('searchSkills output', {
+        query: params.q,
+        userMatches: userMatches.length,
+        publicMatches: publicCapsules.length,
+      });
+      return output;
+    },
+    {
+      name: 'search_skills',
+      description: `Search both **user** and **public** skills by query. Use this to find skills relevant to the user's task before delegating to the Skills Agent.
+
+User-skill matches come first. Each entry includes title, description, path, source ("user" | "public"), and cid (public skills only).
+
+After creating, updating, or deleting a user skill, call again with refresh: true.`,
+      schema: z.object({
+        q: z
+          .string()
+          .min(1, 'Search query is required')
+          .describe(
+            'Search query (e.g. "pptx", "invoice", "presentation", "docx"). Required.',
+          ),
+        limit: z
+          .number()
+          .min(1)
+          .max(50)
+          .optional()
+          .describe(
+            'Optional: max public-skill results to return (1-50, default: 10). User skills are always fully searched.',
+          ),
+        refresh: z
+          .boolean()
+          .optional()
+          .describe(
+            'Optional: bypass the per-user cache for user-skills. Set to true immediately after creating, updating, or deleting a user skill.',
+          ),
+      }),
+    },
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Public registry calls
+// ---------------------------------------------------------------------------
+
+async function fetchPublicCapsules(
+  limit: number,
+  offset: number,
+): Promise<{
+  capsules: Capsule[];
+  pagination: {
+    total: number;
+    limit: number;
+    offset: number;
+    hasMore: boolean;
+  };
+}> {
   const url = new URL('/capsules', SKILLS_CAPSULES_BASE_URL);
   url.searchParams.set('limit', limit.toString());
   url.searchParams.set('offset', offset.toString());
@@ -55,8 +257,7 @@ const listSkills = async (params: { limit?: number; offset?: number }) => {
   if (!response.ok) {
     throw new Error(`List skills failed: ${response.statusText}`);
   }
-
-  const data = (await response.json()) as {
+  return (await response.json()) as {
     capsules: Capsule[];
     pagination: {
       total: number;
@@ -65,24 +266,14 @@ const listSkills = async (params: { limit?: number; offset?: number }) => {
       hasMore: boolean;
     };
   };
+}
 
-  const output = {
-    skills: data.capsules.map(normalizeCapsule),
-    pagination: data.pagination,
-  };
-
-  console.log('listSkills output', output);
-  return output;
-};
-
-/**
- * Search the IXO skills registry by query.
- */
-const searchSkills = async (params: { q: string; limit?: number }) => {
-  const limit = params.limit ?? 10;
-
+async function searchPublicCapsules(
+  q: string,
+  limit: number,
+): Promise<Capsule[]> {
   const url = new URL('/capsules/search', SKILLS_CAPSULES_BASE_URL);
-  url.searchParams.set('q', params.q);
+  url.searchParams.set('q', q);
   url.searchParams.set('limit', limit.toString());
 
   const response = await fetch(url.toString());
@@ -90,94 +281,22 @@ const searchSkills = async (params: { q: string; limit?: number }) => {
     throw new Error(`Search skills failed: ${response.statusText}`);
   }
 
-  const skillsMap = new Map<string, NormalizedCapsule>();
-
   const data = (await response.json()) as {
     query: string;
     count: number;
     capsules: Capsule[];
   };
 
+  // Same dedup-by-name-keep-newest logic the original tool used.
+  const skillsMap = new Map<string, Capsule>();
   for (const capsule of data.capsules) {
     const existing = skillsMap.get(capsule.name);
-    const isNewer = capsule.createdAt
-      ? new Date(capsule.createdAt).getTime() >
-        (existing?.createdAt ? new Date(existing.createdAt).getTime() : 0)
-      : false;
-
-    if (isNewer) {
-      skillsMap.set(capsule.name, normalizeCapsule(capsule));
-    }
+    const isNewer =
+      capsule.createdAt && existing?.createdAt
+        ? new Date(capsule.createdAt).getTime() >
+          new Date(existing.createdAt).getTime()
+        : !existing;
+    if (isNewer) skillsMap.set(capsule.name, capsule);
   }
-
-  const output = {
-    query: data.query,
-    count: data.count,
-    skills: Array.from(skillsMap.values()),
-  };
-
-  console.log('searchSkills output', output);
-  return output;
-};
-
-export const listSkillsTool = tool(listSkills, {
-  name: 'list_skills',
-  description: `List available skills (capsules) from the IXO skills registry. Use this to discover what skills exist before delegating to the Skills Agent.
-
-  Return the output in the following format:
-  - skills: list of skills
-    - title: skill name
-    - cid: skill cid
-    - description: skill description
-    - path: skill path
-  - pagination: pagination information
-    - total: total number of skills
-    - limit: limit number of skills
-    - offset: offset number of skills
-    - hasMore: boolean indicating if there are more skills
-  `,
-  schema: z.object({
-    limit: z
-      .number()
-      .min(1)
-      .max(100)
-      .optional()
-      .describe('Optional: Number of skills to return (1-100, default: 20)'),
-    offset: z
-      .number()
-      .min(0)
-      .optional()
-      .describe(
-        'Optional: Number of skills to skip for pagination (default: 0)',
-      ),
-  }),
-});
-
-export const searchSkillsTool = tool(searchSkills, {
-  name: 'search_skills',
-  description: `Search the IXO skills registry by query. Use this to find skills relevant to the user's task before delegating to the Skills Agent
-
-  Return the output in the following format:
-  - query: search query
-  - count: total number of skills found
-  - skills: list of skills
-    - title: skill name
-    - cid: skill cid
-    - description: skill description
-    - path: skill path
-  `,
-  schema: z.object({
-    q: z
-      .string()
-      .min(1, 'Search query is required')
-      .describe(
-        'Search query (e.g. "pptx", "invoice", "presentation", "docx"). Required.',
-      ),
-    limit: z
-      .number()
-      .min(1)
-      .max(50)
-      .optional()
-      .describe('Optional: Max results to return (1-50, default: 10)'),
-  }),
-});
+  return Array.from(skillsMap.values());
+}

--- a/apps/app/src/main.ts
+++ b/apps/app/src/main.ts
@@ -18,6 +18,7 @@ import { EditorMatrixClient } from './graph/agents/editor/editor-mx';
 import { initModelPricingCache } from './graph/llm-provider';
 import { SecretsService } from './secrets/secrets.service';
 import { UserMatrixSqliteSyncService } from './user-matrix-sqlite-sync-service/user-matrix-sqlite-sync-service.service';
+import { UserSkillsService } from './user-skills/user-skills.service';
 
 async function bootstrap(): Promise<void> {
   // await migrate();
@@ -104,7 +105,9 @@ async function bootstrap(): Promise<void> {
 
   // SecretsService is a manual singleton (not @Injectable) because it's accessed from
   // LangGraph agent code outside NestJS DI. Pass the cache manager here at bootstrap.
-  SecretsService.getInstance().setCacheManager(app.get<Cache>(CACHE_MANAGER));
+  const cache = app.get<Cache>(CACHE_MANAGER);
+  SecretsService.getInstance().setCacheManager(cache);
+  UserSkillsService.getInstance().setCacheManager(cache);
 
   // Load per-model pricing from provider APIs (non-blocking)
   initModelPricingCache().catch((err) =>

--- a/apps/app/src/user-skills/user-skills.service.ts
+++ b/apps/app/src/user-skills/user-skills.service.ts
@@ -88,14 +88,18 @@ export class UserSkillsService {
     sandboxRunTool: StructuredTool,
   ): Promise<UserSkillEntry[]> {
     // One round-trip:
-    //   1. mkdir -p the user-skills folder so first-time use is idempotent.
+    //   1. mkdir -p the user-skills folder so the listing is idempotent
+    //      on first use. `mkdir -p` is a no-op when the directory already
+    //      exists — it does NOT delete, replace, or modify an existing
+    //      directory or its contents. Safe to call on every invocation.
     //   2. List subdirectories that contain a SKILL.md.
-    //   3. Print up to 20 lines of each SKILL.md so we can derive a description.
+    //   3. Print up to 20 lines of each SKILL.md so we can derive a
+    //      description.
     // The cwd is /workspace/data, but we use absolute paths for clarity.
     const code = [
       'set -e',
       'DIR=/workspace/data/user-skills',
-      'mkdir -p "$DIR"',
+      'mkdir -p "$DIR"', // idempotent: no-op if $DIR already exists
       'shopt -s nullglob 2>/dev/null || true',
       'for d in "$DIR"/*/; do',
       '  [ -f "$d/SKILL.md" ] || continue',

--- a/apps/app/src/user-skills/user-skills.service.ts
+++ b/apps/app/src/user-skills/user-skills.service.ts
@@ -1,0 +1,216 @@
+import { Logger } from '@nestjs/common';
+import type { Cache } from 'cache-manager';
+import type { StructuredTool } from '@langchain/core/tools';
+
+export interface UserSkillEntry {
+  /** Folder slug under /workspace/data/user-skills/. */
+  slug: string;
+  /** First non-empty content of SKILL.md (heading + first paragraph). */
+  description: string;
+  /** Absolute sandbox path. */
+  path: string;
+}
+
+interface SandboxRunResult {
+  output: string;
+  success: boolean;
+  error?: string;
+  exitCode?: number;
+}
+
+const FIVE_MINUTES = 5 * 60 * 1000;
+
+/**
+ * Discovers and caches the per-user list of custom skills that live under
+ * /workspace/data/user-skills/ in the user's sandbox.
+ *
+ * Manual singleton (mirrors SecretsService) because it is reached from
+ * LangGraph agent code that runs outside the NestJS DI container.
+ */
+export class UserSkillsService {
+  private static instance: UserSkillsService;
+
+  private cacheManager: Cache | null = null;
+
+  private constructor() {}
+
+  static getInstance(): UserSkillsService {
+    if (!UserSkillsService.instance) {
+      UserSkillsService.instance = new UserSkillsService();
+    }
+    return UserSkillsService.instance;
+  }
+
+  setCacheManager(cache: Cache): void {
+    this.cacheManager = cache;
+  }
+
+  private cacheKey(userDid: string): string {
+    return `user-skills:list:${userDid}`;
+  }
+
+  /**
+   * Return the user's custom skills.
+   *
+   * Cached per-DID for 5 minutes. Pass `refresh: true` to bypass the cache —
+   * the agent is told to do this immediately after writing or deleting a
+   * skill file so the next listing reflects the change.
+   */
+  async list(opts: {
+    userDid: string;
+    sandboxRunTool: StructuredTool;
+    refresh?: boolean;
+  }): Promise<UserSkillEntry[]> {
+    const { userDid, sandboxRunTool, refresh } = opts;
+
+    if (!refresh && this.cacheManager) {
+      const cached = await this.cacheManager.get<UserSkillEntry[]>(
+        this.cacheKey(userDid),
+      );
+      if (cached) return cached;
+    }
+
+    const fresh = await this.fetchFromSandbox(sandboxRunTool);
+
+    if (this.cacheManager) {
+      await this.cacheManager.set(this.cacheKey(userDid), fresh, FIVE_MINUTES);
+    }
+
+    return fresh;
+  }
+
+  /** Bust the cached listing for a user. Useful after a server-side write. */
+  async invalidate(userDid: string): Promise<void> {
+    await this.cacheManager?.del(this.cacheKey(userDid));
+  }
+
+  private async fetchFromSandbox(
+    sandboxRunTool: StructuredTool,
+  ): Promise<UserSkillEntry[]> {
+    // One round-trip:
+    //   1. mkdir -p the user-skills folder so first-time use is idempotent.
+    //   2. List subdirectories that contain a SKILL.md.
+    //   3. Print up to 20 lines of each SKILL.md so we can derive a description.
+    // The cwd is /workspace/data, but we use absolute paths for clarity.
+    const code = [
+      'set -e',
+      'DIR=/workspace/data/user-skills',
+      'mkdir -p "$DIR"',
+      'shopt -s nullglob 2>/dev/null || true',
+      'for d in "$DIR"/*/; do',
+      '  [ -f "$d/SKILL.md" ] || continue',
+      '  slug=$(basename "$d")',
+      '  echo "::USER_SKILL::$slug"',
+      '  head -n 20 "$d/SKILL.md"',
+      '  echo "::END_USER_SKILL::"',
+      'done',
+    ].join('\n');
+
+    let raw: unknown;
+    try {
+      raw = await sandboxRunTool.invoke({ code });
+    } catch (error) {
+      Logger.warn(
+        `[UserSkillsService] sandbox_run failed: ${
+          error instanceof Error ? error.message : String(error)
+        }`,
+      );
+      return [];
+    }
+
+    const parsed = parseSandboxResult(raw);
+    if (!parsed.success || (parsed.exitCode != null && parsed.exitCode !== 0)) {
+      Logger.warn(
+        `[UserSkillsService] listing failed (exit ${parsed.exitCode ?? '?'}): ${
+          parsed.error ?? 'unknown'
+        }`,
+      );
+      return [];
+    }
+
+    return parseSkillBlocks(parsed.output);
+  }
+}
+
+/**
+ * Mirror of the parser in apply-sandbox-output-to-block.ts. Kept local rather
+ * than imported to avoid cross-module coupling between two unrelated tools.
+ */
+function parseSandboxResult(raw: unknown): SandboxRunResult {
+  if (typeof raw === 'string') {
+    try {
+      return JSON.parse(raw) as SandboxRunResult;
+    } catch {
+      return { output: raw, success: true };
+    }
+  }
+  if (
+    typeof raw === 'object' &&
+    raw !== null &&
+    'content' in raw &&
+    Array.isArray((raw as Record<string, unknown>).content)
+  ) {
+    const blocks = (raw as { content: Array<{ type: string; text: string }> })
+      .content;
+    const textBlock = blocks.find((b) => b.type === 'text');
+    if (textBlock) {
+      try {
+        return JSON.parse(textBlock.text) as SandboxRunResult;
+      } catch {
+        return { output: textBlock.text, success: true };
+      }
+    }
+  }
+  return raw as SandboxRunResult;
+}
+
+function parseSkillBlocks(output: string): UserSkillEntry[] {
+  const entries: UserSkillEntry[] = [];
+  const lines = output.split('\n');
+  let currentSlug: string | null = null;
+  let buffer: string[] = [];
+
+  const flush = () => {
+    if (currentSlug) {
+      entries.push({
+        slug: currentSlug,
+        description: deriveDescription(buffer),
+        path: `/workspace/data/user-skills/${currentSlug}`,
+      });
+    }
+    currentSlug = null;
+    buffer = [];
+  };
+
+  for (const line of lines) {
+    if (line.startsWith('::USER_SKILL::')) {
+      flush();
+      currentSlug = line.slice('::USER_SKILL::'.length).trim();
+    } else if (line.startsWith('::END_USER_SKILL::')) {
+      flush();
+    } else if (currentSlug) {
+      buffer.push(line);
+    }
+  }
+  flush();
+
+  return entries;
+}
+
+/**
+ * Pull the first informative line from a SKILL.md head: prefer a non-heading
+ * sentence, fall back to the H1.
+ */
+function deriveDescription(lines: string[]): string {
+  let title = '';
+  for (const raw of lines) {
+    const line = raw.trim();
+    if (!line) continue;
+    if (line.startsWith('#')) {
+      if (!title) title = line.replace(/^#+\s*/, '');
+      continue;
+    }
+    return line.length > 240 ? `${line.slice(0, 240)}…` : line;
+  }
+  return title;
+}

--- a/specs/custom-skills-plan.md
+++ b/specs/custom-skills-plan.md
@@ -1,35 +1,34 @@
 # Custom Skills — Design Plan
 
-> **Status:** Draft — planning only, no code yet.
-> **Scope:** Allow a user to create, store, and run their own **private** skills alongside the verified public skills, scoped to a single user ↔ oracle room.
+> **Status:** Draft v2 — planning only, no code yet.
+> **Scope:** Allow a user (and the agent acting on their behalf) to create their own **private** skills alongside the verified public skills, scoped per-user.
+> **Change vs v1:** dropped Matrix-based storage, dropped the create-tool / REST-endpoint debate, dropped a separate materialiser. Storage is just a sandbox folder; discovery wraps the existing `list_skills` tool; creation is "agent writes files with the tools it already has."
 
 ---
 
-## 1. Problem & Constraints
+## 1. The Insight That Simplifies Everything
 
-Today the agent consumes skills from one source only:
+The sandbox **already persists `/workspace/`** across restarts. The *only* directory that gets blown away each session is `/workspace/skills/` (because the sandbox repopulates it from the public capsule registry).
 
-- Public registry at `SKILLS_CAPSULES_BASE_URL` (defaults to `https://capsules.skills.ixo.earth`).
-- The sandbox service materialises them into `/workspace/skills/<slug>/` on demand via `load_skill(cid)`.
-- `/workspace/skills/` is **read-only** and is reconstructed by the sandbox on every session. Writing there is forbidden (`prompt.ts:269`, `prompt.ts:207`).
+Any other folder — for example `/workspace/user-skills/` — survives. So **the sandbox itself is the store**. No Matrix events, no encryption layer, no REST endpoint, no materialiser — the per-user sandbox is a per-user filesystem, and that's exactly what we need.
 
-Requirements for custom skills:
+This collapses the whole feature down to three small changes:
 
-1. **Private & isolated** — a custom skill belongs to **one user ↔ one oracle** pair. No cross-leak.
-2. **Persistent across sandbox restarts** — the sandbox workspace is ephemeral, so storage must live outside the sandbox.
-3. **Indistinguishable to the agent at call time** — from the LLM's point of view, a custom skill should feel like any other skill: discoverable, loadable, readable, executable.
-4. **Priority over public skills** — the existing prompt already promises this (`prompt.ts:169`: "User-uploaded skills have the highest priority"). We need to actually deliver it.
-5. **Safe** — user-supplied code runs in the per-user sandbox only; no escalation beyond what public skills already enjoy.
+1. Teach `list_skills` to also `ls /workspace/user-skills/` and merge the result.
+2. Make `load_skill` a no-op for user skills (they're already on disk).
+3. Tell the agent in the prompt: "to create a skill for the user, write files into `/workspace/user-skills/<slug>/`."
+
+That's it. **No new tools** for create/delete — the agent already has `sandbox_write` and `exec` from the sandbox MCP, and it already knows what a skill looks like (SKILL.md + supporting files).
 
 ---
 
 ## 2. Recommendation (Decision)
 
-**Do NOT create a new "Custom Skill Agent".** Extend the **main agent** with four new LangChain tools and one storage-service module. Reasoning:
+**Extend the main agent. No new sub-agent. No new authoring tool. Wrap the existing `list_skills` / `search_skills`.**
 
-- Custom skills are a *source* of skills, not a new *capability*. Splitting them into a sub-agent would duplicate the `load → read → exec → output` workflow the main agent already knows (`prompt.ts:200-226`). Two code paths, two prompts to keep in sync, no upside.
-- The existing prompt already has a slot for "user-uploaded skills"; the easiest win is to make `list_skills` / `search_skills` actually return them.
-- The work breaks down cleanly into **storage + materialisation + discovery**, all horizontal additions to the existing pipeline — no graph-topology change.
+- Custom skills are a *source* of skills, not a new *capability*. The main agent already runs the `find → load → read → exec → output` workflow (`prompt.ts:200-226`) — splitting it would just duplicate that.
+- The existing prompt already has a slot for "user-uploaded skills, highest priority" (`prompt.ts:169`). We just have to make the discovery tools actually return them.
+- Authoring belongs to the agent: it has the sandbox tools, and a SKILL.md is just a markdown file.
 
 ---
 
@@ -37,177 +36,226 @@ Requirements for custom skills:
 
 ```mermaid
 graph LR
-    U[User] -- "create skill" --> API[Oracle API<br/>NestJS]
-    API --> SS[UserSkillsService]
-    SS -- "encrypted state +<br/>timeline events" --> M[Matrix Room<br/>user↔oracle]
-    LG[LangGraph Agent] -- "list_user_skills<br/>search_user_skills<br/>load_user_skill" --> SS
-    SS -- "fetch + decrypt" --> M
-    SS -- "sandbox_write files" --> SB[/workspace/user-skills/]
+    LG[LangGraph Agent] -- "list_skills" --> ST[skills-tools.ts]
+    ST -- "fetch capsules" --> R[Public registry<br/>capsules.skills.ixo.earth]
+    ST -- "exec ls + cat" --> SB[Sandbox MCP]
+    SB --> US[/workspace/user-skills/]
+    ST -- "cache by user DID" --> C[(NestJS cache-manager)]
+    LG -- "sandbox_write to<br/>/workspace/user-skills/" --> SB
     LG -- "read_skill / exec" --> SB
 ```
 
-**Three moving parts:**
+**Two moving parts only:**
 
-1. **Storage layer** — Matrix room state + timeline events (re-use the `SecretsService` pattern almost verbatim).
-2. **Materialisation layer** — on-demand "install" of a stored skill into the sandbox at `/workspace/user-skills/<slug>/`.
-3. **Discovery layer** — new LangChain tools that merge user skills into the agent's view of the skill world, with user skills first.
-
----
-
-## 4. Storage: re-use the `SecretsService` pattern
-
-The existing `SecretsService` (`apps/app/src/secrets/secrets.service.ts`) already solves exactly this shape of problem: per-room, encrypted, indexed, lazily fetched, cached. We mirror it.
-
-### Matrix event schema
-
-| Event type                     | Purpose                       | `state_key` | Content                                                                                                                                  |
-| ------------------------------ | ----------------------------- | ----------- | ---------------------------------------------------------------------------------------------------------------------------------------- |
-| `ixo.room.user_skill.index`    | One per skill — index entry   | `<slug>`    | `{ manifestEventId, archiveEventId, version, publicKeyId, updatedAt }`                                                                   |
-| `ixo.room.user_skill.manifest` | Timeline event — skill meta   | —           | JWE-encrypted: `{ name, slug, description, triggers: string[], version, entrypoint, files: Array<{ path, sha256, size, eventId }> }` |
-| `ixo.room.user_skill.file`     | Timeline event — one per file | —           | JWE-encrypted payload: either inline (`{ content: "<base64>" }`) or MXC reference (`{ mxcUri }`) for files > 64 KB                    |
-
-**Why split index / manifest / files:**
-
-- Listing (`list_user_skills`) needs the index only → cheap (one `getRoomState` call, same as secrets today).
-- Reading a SKILL.md needs the manifest + one file → two timeline lookups, cached.
-- Full install only happens on `load_user_skill` — we don't pull all files unless invoked.
-
-**Deletion:** write an empty-content state event at the same `state_key` — matches how `SecretsService.getSecretIndex` filters deleted entries (`secrets.service.ts:65`).
-
-### New service
-
-Create `apps/app/src/user-skills/user-skills.service.ts` — copy the shape of `SecretsService`:
-
-- `getSkillIndex(roomId): Promise<UserSkillIndexEntry[]>`
-- `getSkillManifest(roomId, slug): Promise<UserSkillManifest>`
-- `getSkillFile(roomId, slug, path): Promise<Buffer>`
-- `putSkill(roomId, manifest, files): Promise<void>` (single high-level create/update)
-- `deleteSkill(roomId, slug): Promise<void>`
-
-Reuse the same JWE encryption key the `SecretsService` holds (`SecretsService.setEncryptionKey`), so we do not introduce new key-management surface. Key rotation TODO already tracked there; this feature inherits it.
+1. **Discovery** — `list_skills` / `search_skills` get extended to query the sandbox folder in parallel with the public registry, then merge with a `source` discriminator. Sandbox-side results are cached per-user.
+2. **Convention** — `/workspace/user-skills/<slug>/` is the agreed location. Documented in the prompt; the agent treats it as a write target for new skills and a read source for existing ones.
 
 ---
 
-## 5. Materialisation: getting the skill into the sandbox
-
-The constraint from the brief — "the skills folder gets recreated on each sandbox start" — means we cannot rely on the sandbox's own `load_skill(cid)` (which is wired to the public capsule registry). We need a parallel path that writes to a **different** directory.
-
-### Sandbox layout (new)
+## 4. Storage: just a sandbox folder
 
 ```
 /workspace/
-  uploads/       # read-only, existing
-  skills/        # read-only, existing (public skills, via load_skill cid)
-  user-skills/   # NEW — read-only conceptually, populated by us per-session
-  data/output/   # existing
+  uploads/         # read-only, existing  (user uploads)
+  skills/          # read-only, existing  (public skills, repopulated each session)
+  user-skills/     # NEW                  (custom skills, persists across sessions)
+    <slug>/
+      SKILL.md     # required
+      ...other files (scripts, templates, examples)
+  data/output/     # existing
 ```
 
-### How it gets populated
+Properties we get for free:
 
-On **first** `load_user_skill(slug)` call in a session:
+- **Per-user isolation** — already enforced by the sandbox service (each user ↔ oracle pair has its own sandbox instance).
+- **Persistence** — the sandbox already keeps `/workspace/` between sessions. We do nothing extra.
+- **No new keys / encryption surface** — sandbox-level encryption-at-rest already covers it (whatever the sandbox provides; same posture as `/workspace/uploads/`).
 
-1. `UserSkillsService.getSkillManifest(roomId, slug)` → manifest (cached after first hit).
-2. For each file in `manifest.files`, call `sandbox_write('/workspace/user-skills/<slug>/<path>', content)` via the existing sandbox MCP client.
-3. If `manifest.entrypoint` has `requirements.txt` / `package.json`, invoke `exec` with the same auto-install convention the public skills already use (the prompt at `prompt.ts:171` documents this is handled automatically — verify with the sandbox team; if not, the skill's SKILL.md can instruct a manual install).
-4. Cache "already materialised in this session" in-memory per-`threadId` to avoid re-writing on every tool call.
-
-Note: the sandbox never learns about "custom skills" as a first-class concept — we just write files to a known path using tools it already exposes. This keeps the change fully in `apps/app` and avoids a dependency on the `ai-sandbox` repo.
-
-### Why not pre-materialise at sandbox startup?
-
-Two reasons:
-
-- Sandbox startup currently happens inside `createMainAgent` (`main-agent.ts:234-246`) and adding a potentially-large synchronous copy there would slow every conversation — even ones that don't use skills.
-- Lazy materialisation matches the existing `load_skill(cid)` contract for public skills, so agent behaviour stays symmetric.
+The agent reads, writes, and deletes through the same sandbox MCP tools it already has access to (`sandbox_write`, `exec`, `read_skill`).
 
 ---
 
-## 6. Discovery: how the agent sees user skills
+## 5. Discovery: extend `list_skills` and `search_skills`
 
-Add four LangChain tools next to `listSkillsTool` / `searchSkillsTool` in `apps/app/src/graph/nodes/tools-node/skills-tools.ts`. Keep them as separate tools rather than merging — clearer intent for the LLM, easier to audit which calls hit which storage.
+These two tools live in `apps/app/src/graph/nodes/tools-node/skills-tools.ts`. Today they're standalone async functions wrapped in `tool(...)`. We need them to:
 
-| Tool                | Purpose                                                                                        |
-| ------------------- | ---------------------------------------------------------------------------------------------- |
-| `list_user_skills`  | Returns `[{ slug, description, triggers, path: '/workspace/user-skills/<slug>', source: 'user' }]` from the index only. No manifest fetch. |
-| `search_user_skills`| Substring match on name/description/triggers inside the index. Purely local — no Matrix roundtrip beyond `getSkillIndex`. |
-| `load_user_skill`   | Takes `slug` (not CID — CIDs are a public-registry concept). Materialises files under `/workspace/user-skills/<slug>/`.          |
-| `delete_user_skill` | Lets the agent remove a skill on the user's request (writes tombstone state event).             |
+1. Continue calling the public capsule registry (existing behaviour).
+2. **Also** query the per-user sandbox for `/workspace/user-skills/*`.
+3. Merge results, with user skills first.
+4. Cache the sandbox query per user so repeated calls don't hammer the sandbox.
 
-**Creation tool — design choice:** three options here, with a clear preference.
+### Tool factory change
 
-- **A. Tool-driven (`create_user_skill`).** The LLM authors SKILL.md + files and calls the tool. Pro: conversational UX. Con: LLM-written skills are usually mediocre; blast radius is an entire new tool on the main agent.
-- **B. REST/SSE endpoint on the oracle API + a CLI/Portal flow.** Pro: skills get authored by humans (or by the Skill Builder sub-agent in `qiforge-cli`). Con: no in-chat creation.
-- **C. Both — creation endpoint + an optional tool that wraps it.**
+The tools currently have no access to the sandbox MCP client or cache manager. We convert them to factories built inside `createMainAgent`, where both are already in scope:
 
-**Recommended: B first, add A later.** Rationale: rushing A means shipping a tool that lets the LLM mint code in the user's sandbox based on fuzzy intent. A REST endpoint with a typed payload (tested, reviewable, auditable) is the right v1. The agent still *lists, loads, and runs* in chat — only *authoring* moves out.
+```ts
+// skills-tools.ts
+export function createListSkillsTool(deps: {
+  sandboxMCP?: MCPClient;
+  cache: Cache;
+  userDid: string;
+}) { return tool(async (params) => { /* merged listing */ }, { name: 'list_skills', ... }); }
 
-### Agent prompt changes
+export function createSearchSkillsTool(deps: { /* same */ }) { ... }
+```
+
+`main-agent.ts` (around lines 230–246 where `sandboxMCP` is built, and 792 where tools are added) constructs them once per agent invocation.
+
+### Sandbox-side listing
+
+The sandbox MCP's `exec` tool gives us shell access. One call is enough:
+
+```bash
+# Returns slug + first 5 lines of each SKILL.md (description usually lives there)
+for d in /workspace/user-skills/*/; do
+  if [ -f "$d/SKILL.md" ]; then
+    slug=$(basename "$d")
+    echo "::SLUG::$slug"
+    head -20 "$d/SKILL.md"
+    echo "::END::"
+  fi
+done 2>/dev/null
+```
+
+Parse the output server-side, derive `{ slug, description, path }` per entry. If the directory doesn't exist, the loop produces nothing — empty list, not an error.
+
+### Cache
+
+Use the existing NestJS `cache-manager` instance (already wired for `SecretsService`).
+
+- **Key:** `user-skills:list:<userDid>`
+- **TTL:** 5 minutes — short enough to feel fresh, long enough to absorb tight `list_skills` loops.
+- **Invalidation:**
+  - Explicit `refresh: boolean` parameter on `list_skills` / `search_skills` — the agent passes `refresh: true` immediately after creating or deleting a user skill (taught via prompt).
+  - On TTL expiry. We don't try to detect agent-side `sandbox_write` calls; the prompt rule is simpler and more reliable.
+
+### Return shape
+
+Existing shape, with one new field:
+
+```ts
+type SkillEntry = {
+  title: string;          // existing
+  description: string;    // existing
+  path: string;           // existing — for user skills: /workspace/user-skills/<slug>
+  cid?: string;           // optional — only set for public skills
+  source: 'user' | 'public'; // NEW
+  createdAt?: string;     // existing
+};
+```
+
+Public skills always have `cid`; user skills never do. The prompt teaches the agent that user skills are loaded by path, not CID.
+
+### Ordering
+
+User skills come first in the merged array. Combined with the prompt's "user skills have highest priority" rule (`prompt.ts:169`), this gives the agent a strong default without us having to add ranking logic.
+
+---
+
+## 6. Loading: `load_skill` becomes a no-op for user skills
+
+`load_skill` today is a sandbox MCP tool that takes a CID, downloads the public capsule, and unpacks it into `/workspace/skills/`. For user skills there's nothing to download — the files are already on disk.
+
+Two options:
+
+- **A. Wrap `load_skill` server-side** so that if the agent passes a user-skill identifier, we short-circuit and return success.
+- **B. Don't wrap. Tell the agent in the prompt: "user skills are pre-loaded — skip `load_skill` and go straight to `read_skill`."**
+
+**Recommended: B.** Wrapping `load_skill` means intercepting an MCP tool we don't own (it lives in the sandbox MCP server, exposed by name). Cleaner to not interpose. The agent already follows prompt-level rules; one more line ("for `source: 'user'`, skip step 2 of the canonical workflow") is enough.
+
+If we later find the agent reflexively calling `load_skill` on a path/slug and getting confusing errors, we can revisit and add a thin wrapper that intercepts.
+
+---
+
+## 7. Creation & deletion: no new tools
+
+### Creating a skill
+
+The agent already has, via the sandbox MCP:
+
+- `sandbox_write(path, content)` — write any file
+- `exec(command)` — run shell commands (mkdir, chmod, etc.)
+
+A skill is a folder with a SKILL.md and optional supporting files. The agent can author all of that with the tools above. We add prompt instructions:
+
+> **Creating a skill for the user**
+>
+> When the user asks to create a new skill (or you decide one would help future tasks):
+> 1. Pick a slug: lowercase, hyphenated, unique under `/workspace/user-skills/`. Check with `list_skills` first.
+> 2. `sandbox_write` to `/workspace/user-skills/<slug>/SKILL.md` — required. Follow the same SKILL.md format as public skills.
+> 3. Add supporting files (scripts, templates) under the same folder as needed.
+> 4. Call `list_skills` with `refresh: true` so the new skill shows up in subsequent listings.
+> 5. Confirm to the user with the slug + a one-line summary.
+
+### Deleting a skill
+
+Agent uses `exec('rm -rf /workspace/user-skills/<slug>')`, then `list_skills` with `refresh: true`. Documented in the same prompt section.
+
+### Updating
+
+Same as creating — overwrite SKILL.md or replace files via `sandbox_write`. No version tracking in v1.
+
+### Why no `create_user_skill` tool
+
+- Zero new server code to maintain.
+- The agent already has the right primitives, and the SKILL.md format is markdown the LLM is good at.
+- A typed `create` tool would either (a) duplicate `sandbox_write` (pointless) or (b) try to be opinionated about structure, which constrains what kinds of skills users can build.
+
+---
+
+## 8. Agent prompt changes
 
 In `apps/app/src/graph/nodes/chat-node/prompt.ts`:
 
-- Update the skills section (~line 160) to spell out the two-tier system: "First try `list_user_skills` / `search_user_skills`; fall back to `list_skills` / `search_skills`."
-- Update the canonical workflow (line 200) to branch on source: `load_skill(cid)` for public, `load_user_skill(slug)` for user.
-- Tighten the existing promise at line 169 ("User-uploaded skills have the highest priority") by making it a hard rule: *if a user skill matches the request, the agent must prefer it, even when a public skill also matches.*
+1. **Skills section (~line 160–198):**
+   - Replace the description of skills as "from the registry" with a two-source model: public (from registry) and user (from `/workspace/user-skills/`).
+   - Spell out that `list_skills` / `search_skills` returns both, with `source: 'user' | 'public'`, and that user skills come first.
+   - Make line 169's "highest priority" promise concrete: "If a user skill matches the request, prefer it over a public skill, even if both apply."
+
+2. **Canonical workflow (lines 200–226):**
+   - Branch step 2 (Load): for `source: 'public'`, call `load_skill(cid)`. For `source: 'user'`, skip — the skill is already on disk.
+   - Step 3 (Read): same `read_skill` call works for both, just use the path from the listing.
+
+3. **Sandbox file system (lines 265–280):**
+   - Add `/workspace/user-skills/` to the list. Mark it as **read/write** (unlike `/workspace/skills/` which is read-only).
+   - Note: "User skills persist across sessions — anything you write here stays for next time."
+
+4. **New "Creating skills" subsection** as described in §7.
+
+5. **Cache hygiene rule:** "After `sandbox_write` or `exec rm` under `/workspace/user-skills/`, your next `list_skills` call must include `refresh: true`."
 
 ---
 
-## 7. API surface (NestJS)
+## 9. Implementation plan (ordered, no work begins until approved)
 
-One new controller under `apps/app/src/user-skills/`:
+| # | Step | Files touched |
+| - | ---- | ------------- |
+| 1 | Convert `listSkillsTool` / `searchSkillsTool` to factories that take `{ sandboxMCP, cache, userDid }`. Keep the public-registry path identical. | `apps/app/src/graph/nodes/tools-node/skills-tools.ts` |
+| 2 | Add sandbox-side listing helper (single `exec` call, parser, error-tolerant when `/workspace/user-skills/` is missing). | same file |
+| 3 | Add cache read/write keyed on user DID; add `refresh` param to both tools. | same file |
+| 4 | Wire factories into `createMainAgent` — pass `sandboxMCP`, the existing `cacheManager`, and `configurable.configs.user.did`. | `apps/app/src/graph/agents/main-agent.ts` (around tool list ~line 792) |
+| 5 | Update agent prompt: two-source model, branch on `source`, `/workspace/user-skills/` in filesystem section, new "Creating skills" subsection, refresh-after-write rule. | `apps/app/src/graph/nodes/chat-node/prompt.ts` (lines 160–280) |
+| 6 | Tests: tool returns merged result, cache hits/misses, `refresh: true` busts cache, missing folder yields empty. Mock the sandbox MCP `exec` response. | `apps/app/src/graph/nodes/tools-node/skills-tools.spec.ts` |
+| 7 | Docs: update `docs/playbook/04-working-with-skills.md` "Building Your First Skill" section to describe the in-chat flow. Update `specs/playbook-progress.md`. | docs only |
 
-```
-POST   /user-skills                 # create or update
-GET    /user-skills                 # list (index only)
-GET    /user-skills/:slug           # full manifest + file list
-GET    /user-skills/:slug/files/*   # single file download
-DELETE /user-skills/:slug
-```
-
-**Auth:** reuse the existing Matrix access-token + DID middleware (already gates `/messages`, `/sessions`). No new auth primitive.
-
-**Upload format:** `multipart/form-data` with one `manifest.json` field + N file parts; or a single `.zip` that the server unpacks. Zip keeps the UX aligned with how public capsules ship today.
-
-**Validation rules** (server-side, non-negotiable):
-
-- Slug: `[a-z0-9][a-z0-9-]{0,62}` — not already in use in this room.
-- Total archive size: configurable cap (default 5 MB) — keeps Matrix events healthy.
-- File count cap (default 50) — prevents pathological layouts.
-- SKILL.md **required**; must be ≤ 64 KB (so it fits inline in one timeline event).
-- File extension allowlist or an explicit denylist (`.exe`, `.so`, …) — TBD, lean denylist since the sandbox itself is the security boundary.
+All of this ships as one small PR. No new module, no new service, no new controller, no DB migration.
 
 ---
 
-## 8. Implementation plan (ordered, no work begins until approved)
+## 10. Open questions (flag before build)
 
-| # | Step                                                                                  | Files touched                                                                                            |
-| - | ------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------- |
-| 1 | **Storage service** — `UserSkillsService` with `getSkillIndex`/`get*`/`put`/`delete`  | `apps/app/src/user-skills/user-skills.service.ts` (new), `apps/app/src/app.module.ts`                    |
-| 2 | **Materialiser** — helper that writes manifest files into the sandbox                 | `apps/app/src/user-skills/user-skill-materialiser.ts` (new)                                              |
-| 3 | **LangChain tools** — `list_user_skills`, `search_user_skills`, `load_user_skill`, `delete_user_skill` | `apps/app/src/graph/nodes/tools-node/skills-tools.ts`                                   |
-| 4 | **Wire tools into main agent**                                                        | `apps/app/src/graph/agents/main-agent.ts` (tool list around line 792)                                    |
-| 5 | **Prompt updates** — two-tier discovery, priority rule, branch on source              | `apps/app/src/graph/nodes/chat-node/prompt.ts` (lines 160-226, 268-280)                                  |
-| 6 | **REST controller + DTOs**                                                            | `apps/app/src/user-skills/user-skills.controller.ts` (new)                                               |
-| 7 | **Tests** — storage round-trip (mock Matrix), tool invocation snapshot, materialiser integration | `apps/app/src/user-skills/*.spec.ts`, `apps/app/src/graph/nodes/tools-node/skills-tools.spec.ts` |
-| 8 | **Docs** — new `docs/playbook/04a-custom-skills.md`, update `04-working-with-skills.md`, update `specs/playbook-progress.md` | docs only |
-| 9 | **(Deferred)** Tool-driven creation (option A above) — only once B has shipped and we understand the failure modes | same files as step 3 |
-
-Ship 1–5 as one PR (engine changes), 6–8 as a second PR (API + docs), 9 as a later follow-up.
+1. **Sandbox-folder persistence — confirm.** I'm taking it on the user's word that `/workspace/` (everything except `/workspace/skills/`) survives sandbox restarts. Quick smoke test against the actual ai-sandbox service before merging step 1: write a marker file, restart, look for it. If persistence is per-session-only, the whole plan collapses.
+2. **Sandbox-side listing performance.** A `find` / shell loop over `/workspace/user-skills/` is fine for tens of skills. If a user accumulates hundreds, parsing becomes the bottleneck, not the FS. We're well below that ceiling for v1.
+3. **Cross-oracle sharing.** A user with two different oracles has two different sandboxes — so user skills don't cross. Probably fine (each oracle is its own context); flag if product wants a cross-oracle "skill library."
+4. **Validation.** The agent is the only writer, so SKILL.md schema, slug uniqueness, and file-size limits aren't enforced anywhere. v1 trusts the LLM. If we see garbage skills accumulating, add a server-side `list_skills`-time validator that hides malformed entries (instead of blocking writes).
+5. **Public-vs-user collisions.** What if a user creates a skill named `pptx` and a public skill `pptx` also exists? Our merged list shows both with `source` flags; the agent prefers the user one per the priority rule. No collision logic needed — the `source` field is the tie-breaker.
 
 ---
 
-## 9. Open questions (flag before build)
+## 11. Non-goals (v1)
 
-1. **Sandbox cooperation.** Does the sandbox reset `/workspace/user-skills/` between sessions the same way it does `/workspace/skills/`? If yes, lazy materialisation is fine. If it *doesn't* reset, we need a cache-invalidation step on manifest `version` change. Confirm with the ai-sandbox team.
-2. **Dependency auto-install.** The prompt at `prompt.ts:171` claims deps install automatically when a skill is loaded. That claim almost certainly only holds for skills loaded via `load_skill(cid)` (the sandbox knows the capsule shape). For `user-skills/` files we wrote manually, the agent likely needs to `exec pip install -r requirements.txt` itself. Worth verifying before updating the prompt, or we lie to the LLM.
-3. **Size ceiling.** 5 MB / 50 files is a finger-in-the-air default. Gut-check with how big real-world skills in the public registry get (a quick `du -sh` per skill in `ai-skills` would tell us).
-4. **Skill Builder sub-agent overlap.** `qiforge-cli` is scoped to contain a "Skill Builder" flow (per `CLAUDE.md`). Creation endpoint (§7) should be the thing the CLI calls — avoid shipping two authoring paths.
-5. **Secret injection.** Should user skills get access to the same `x-os-*` oracle secrets that public skills do (`main-agent.ts:553-562`), or should they be sandboxed from them? Default: **no secrets for user skills** unless the user explicitly grants per-skill. Prevents a custom skill from exfiltrating oracle-operator credentials.
-
----
-
-## 10. Non-goals (v1)
-
-- No public sharing of user skills — nothing is published to `capsules.skills.ixo.earth`. If a user wants to share, they go through the public registry's PR flow manually.
-- No skill versioning beyond "the latest manifest wins." Old versions are retained as timeline events but not surfaced.
-- No skill-to-skill dependencies (user skill requires another user skill). Flat namespace per room.
-- No UI. API-only; the Portal team handles the front-end separately.
+- No publishing user skills back to the public registry.
+- No versioning — overwrite-in-place semantics.
+- No cross-oracle/cross-user sharing.
+- No UI in the Portal for managing skills (Portal team handles separately if desired).
+- No server-side authoring API. The agent does it in chat.

--- a/specs/custom-skills-plan.md
+++ b/specs/custom-skills-plan.md
@@ -34,7 +34,7 @@ That's it. **No new tools** for create/delete — the agent already has `sandbox
 
 **Extend the main agent. No new sub-agent. No new authoring tool. Wrap the existing `list_skills` / `search_skills`.**
 
-- Custom skills are a *source* of skills, not a new *capability*. The main agent already runs the `find → load → read → exec → output` workflow (`prompt.ts:200-226`) — splitting it would just duplicate that.
+- Custom skills are a _source_ of skills, not a new _capability_. The main agent already runs the `find → load → read → exec → output` workflow (`prompt.ts:200-226`) — splitting it would just duplicate that.
 - The existing prompt already has a slot for "user-uploaded skills, highest priority" (`prompt.ts:169`). We just have to make the discovery tools actually return them.
 - Authoring belongs to the agent: it has the sandbox tools, and a SKILL.md is just a markdown file.
 
@@ -146,12 +146,12 @@ Existing shape, with one new field:
 
 ```ts
 type SkillEntry = {
-  title: string;          // existing
-  description: string;    // existing
-  path: string;           // existing — for user skills: /workspace/user-skills/<slug>
-  cid?: string;           // optional — only set for public skills
+  title: string; // existing
+  description: string; // existing
+  path: string; // existing — for user skills: /workspace/user-skills/<slug>
+  cid?: string; // optional — only set for public skills
   source: 'user' | 'public'; // NEW
-  createdAt?: string;     // existing
+  createdAt?: string; // existing
 };
 ```
 
@@ -192,6 +192,7 @@ A skill is a folder with a SKILL.md and optional supporting files. The agent can
 > **Creating a skill for the user**
 >
 > When the user asks to create a new skill (or you decide one would help future tasks):
+>
 > 1. Pick a slug: lowercase, hyphenated, unique under `user-skills/`. Check with `list_skills` first.
 > 2. `sandbox_write` to `user-skills/<slug>/SKILL.md` (resolves to `/workspace/data/user-skills/<slug>/SKILL.md`) — required. Follow the same SKILL.md format as public skills.
 > 3. Add supporting files (scripts, templates) under the same folder as needed.
@@ -239,15 +240,15 @@ In `apps/app/src/graph/nodes/chat-node/prompt.ts`:
 
 ## 9. Implementation plan (ordered, no work begins until approved)
 
-| # | Step | Files touched |
-| - | ---- | ------------- |
-| 1 | Convert `listSkillsTool` / `searchSkillsTool` to factories that take `{ sandboxMCP, cache, userDid }`. Keep the public-registry path identical. | `apps/app/src/graph/nodes/tools-node/skills-tools.ts` |
-| 2 | Add sandbox-side listing helper (single `exec` call, parser, error-tolerant when `/workspace/user-skills/` is missing). | same file |
-| 3 | Add cache read/write keyed on user DID; add `refresh` param to both tools. | same file |
-| 4 | Wire factories into `createMainAgent` — pass `sandboxMCP`, the existing `cacheManager`, and `configurable.configs.user.did`. | `apps/app/src/graph/agents/main-agent.ts` (around tool list ~line 792) |
-| 5 | Update agent prompt: two-source model, branch on `source`, `/workspace/user-skills/` in filesystem section, new "Creating skills" subsection, refresh-after-write rule. | `apps/app/src/graph/nodes/chat-node/prompt.ts` (lines 160–280) |
-| 6 | Tests: tool returns merged result, cache hits/misses, `refresh: true` busts cache, missing folder yields empty. Mock the sandbox MCP `exec` response. | `apps/app/src/graph/nodes/tools-node/skills-tools.spec.ts` |
-| 7 | Docs: update `docs/playbook/04-working-with-skills.md` "Building Your First Skill" section to describe the in-chat flow. Update `specs/playbook-progress.md`. | docs only |
+| #   | Step                                                                                                                                                                    | Files touched                                                          |
+| --- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------- |
+| 1   | Convert `listSkillsTool` / `searchSkillsTool` to factories that take `{ sandboxMCP, cache, userDid }`. Keep the public-registry path identical.                         | `apps/app/src/graph/nodes/tools-node/skills-tools.ts`                  |
+| 2   | Add sandbox-side listing helper (single `exec` call, parser, error-tolerant when `/workspace/user-skills/` is missing).                                                 | same file                                                              |
+| 3   | Add cache read/write keyed on user DID; add `refresh` param to both tools.                                                                                              | same file                                                              |
+| 4   | Wire factories into `createMainAgent` — pass `sandboxMCP`, the existing `cacheManager`, and `configurable.configs.user.did`.                                            | `apps/app/src/graph/agents/main-agent.ts` (around tool list ~line 792) |
+| 5   | Update agent prompt: two-source model, branch on `source`, `/workspace/user-skills/` in filesystem section, new "Creating skills" subsection, refresh-after-write rule. | `apps/app/src/graph/nodes/chat-node/prompt.ts` (lines 160–280)         |
+| 6   | Tests: tool returns merged result, cache hits/misses, `refresh: true` busts cache, missing folder yields empty. Mock the sandbox MCP `exec` response.                   | `apps/app/src/graph/nodes/tools-node/skills-tools.spec.ts`             |
+| 7   | Docs: update `docs/playbook/04-working-with-skills.md` "Building Your First Skill" section to describe the in-chat flow. Update `specs/playbook-progress.md`.           | docs only                                                              |
 
 All of this ships as one small PR. No new module, no new service, no new controller, no DB migration.
 

--- a/specs/custom-skills-plan.md
+++ b/specs/custom-skills-plan.md
@@ -1,0 +1,213 @@
+# Custom Skills — Design Plan
+
+> **Status:** Draft — planning only, no code yet.
+> **Scope:** Allow a user to create, store, and run their own **private** skills alongside the verified public skills, scoped to a single user ↔ oracle room.
+
+---
+
+## 1. Problem & Constraints
+
+Today the agent consumes skills from one source only:
+
+- Public registry at `SKILLS_CAPSULES_BASE_URL` (defaults to `https://capsules.skills.ixo.earth`).
+- The sandbox service materialises them into `/workspace/skills/<slug>/` on demand via `load_skill(cid)`.
+- `/workspace/skills/` is **read-only** and is reconstructed by the sandbox on every session. Writing there is forbidden (`prompt.ts:269`, `prompt.ts:207`).
+
+Requirements for custom skills:
+
+1. **Private & isolated** — a custom skill belongs to **one user ↔ one oracle** pair. No cross-leak.
+2. **Persistent across sandbox restarts** — the sandbox workspace is ephemeral, so storage must live outside the sandbox.
+3. **Indistinguishable to the agent at call time** — from the LLM's point of view, a custom skill should feel like any other skill: discoverable, loadable, readable, executable.
+4. **Priority over public skills** — the existing prompt already promises this (`prompt.ts:169`: "User-uploaded skills have the highest priority"). We need to actually deliver it.
+5. **Safe** — user-supplied code runs in the per-user sandbox only; no escalation beyond what public skills already enjoy.
+
+---
+
+## 2. Recommendation (Decision)
+
+**Do NOT create a new "Custom Skill Agent".** Extend the **main agent** with four new LangChain tools and one storage-service module. Reasoning:
+
+- Custom skills are a *source* of skills, not a new *capability*. Splitting them into a sub-agent would duplicate the `load → read → exec → output` workflow the main agent already knows (`prompt.ts:200-226`). Two code paths, two prompts to keep in sync, no upside.
+- The existing prompt already has a slot for "user-uploaded skills"; the easiest win is to make `list_skills` / `search_skills` actually return them.
+- The work breaks down cleanly into **storage + materialisation + discovery**, all horizontal additions to the existing pipeline — no graph-topology change.
+
+---
+
+## 3. Architecture
+
+```mermaid
+graph LR
+    U[User] -- "create skill" --> API[Oracle API<br/>NestJS]
+    API --> SS[UserSkillsService]
+    SS -- "encrypted state +<br/>timeline events" --> M[Matrix Room<br/>user↔oracle]
+    LG[LangGraph Agent] -- "list_user_skills<br/>search_user_skills<br/>load_user_skill" --> SS
+    SS -- "fetch + decrypt" --> M
+    SS -- "sandbox_write files" --> SB[/workspace/user-skills/]
+    LG -- "read_skill / exec" --> SB
+```
+
+**Three moving parts:**
+
+1. **Storage layer** — Matrix room state + timeline events (re-use the `SecretsService` pattern almost verbatim).
+2. **Materialisation layer** — on-demand "install" of a stored skill into the sandbox at `/workspace/user-skills/<slug>/`.
+3. **Discovery layer** — new LangChain tools that merge user skills into the agent's view of the skill world, with user skills first.
+
+---
+
+## 4. Storage: re-use the `SecretsService` pattern
+
+The existing `SecretsService` (`apps/app/src/secrets/secrets.service.ts`) already solves exactly this shape of problem: per-room, encrypted, indexed, lazily fetched, cached. We mirror it.
+
+### Matrix event schema
+
+| Event type                     | Purpose                       | `state_key` | Content                                                                                                                                  |
+| ------------------------------ | ----------------------------- | ----------- | ---------------------------------------------------------------------------------------------------------------------------------------- |
+| `ixo.room.user_skill.index`    | One per skill — index entry   | `<slug>`    | `{ manifestEventId, archiveEventId, version, publicKeyId, updatedAt }`                                                                   |
+| `ixo.room.user_skill.manifest` | Timeline event — skill meta   | —           | JWE-encrypted: `{ name, slug, description, triggers: string[], version, entrypoint, files: Array<{ path, sha256, size, eventId }> }` |
+| `ixo.room.user_skill.file`     | Timeline event — one per file | —           | JWE-encrypted payload: either inline (`{ content: "<base64>" }`) or MXC reference (`{ mxcUri }`) for files > 64 KB                    |
+
+**Why split index / manifest / files:**
+
+- Listing (`list_user_skills`) needs the index only → cheap (one `getRoomState` call, same as secrets today).
+- Reading a SKILL.md needs the manifest + one file → two timeline lookups, cached.
+- Full install only happens on `load_user_skill` — we don't pull all files unless invoked.
+
+**Deletion:** write an empty-content state event at the same `state_key` — matches how `SecretsService.getSecretIndex` filters deleted entries (`secrets.service.ts:65`).
+
+### New service
+
+Create `apps/app/src/user-skills/user-skills.service.ts` — copy the shape of `SecretsService`:
+
+- `getSkillIndex(roomId): Promise<UserSkillIndexEntry[]>`
+- `getSkillManifest(roomId, slug): Promise<UserSkillManifest>`
+- `getSkillFile(roomId, slug, path): Promise<Buffer>`
+- `putSkill(roomId, manifest, files): Promise<void>` (single high-level create/update)
+- `deleteSkill(roomId, slug): Promise<void>`
+
+Reuse the same JWE encryption key the `SecretsService` holds (`SecretsService.setEncryptionKey`), so we do not introduce new key-management surface. Key rotation TODO already tracked there; this feature inherits it.
+
+---
+
+## 5. Materialisation: getting the skill into the sandbox
+
+The constraint from the brief — "the skills folder gets recreated on each sandbox start" — means we cannot rely on the sandbox's own `load_skill(cid)` (which is wired to the public capsule registry). We need a parallel path that writes to a **different** directory.
+
+### Sandbox layout (new)
+
+```
+/workspace/
+  uploads/       # read-only, existing
+  skills/        # read-only, existing (public skills, via load_skill cid)
+  user-skills/   # NEW — read-only conceptually, populated by us per-session
+  data/output/   # existing
+```
+
+### How it gets populated
+
+On **first** `load_user_skill(slug)` call in a session:
+
+1. `UserSkillsService.getSkillManifest(roomId, slug)` → manifest (cached after first hit).
+2. For each file in `manifest.files`, call `sandbox_write('/workspace/user-skills/<slug>/<path>', content)` via the existing sandbox MCP client.
+3. If `manifest.entrypoint` has `requirements.txt` / `package.json`, invoke `exec` with the same auto-install convention the public skills already use (the prompt at `prompt.ts:171` documents this is handled automatically — verify with the sandbox team; if not, the skill's SKILL.md can instruct a manual install).
+4. Cache "already materialised in this session" in-memory per-`threadId` to avoid re-writing on every tool call.
+
+Note: the sandbox never learns about "custom skills" as a first-class concept — we just write files to a known path using tools it already exposes. This keeps the change fully in `apps/app` and avoids a dependency on the `ai-sandbox` repo.
+
+### Why not pre-materialise at sandbox startup?
+
+Two reasons:
+
+- Sandbox startup currently happens inside `createMainAgent` (`main-agent.ts:234-246`) and adding a potentially-large synchronous copy there would slow every conversation — even ones that don't use skills.
+- Lazy materialisation matches the existing `load_skill(cid)` contract for public skills, so agent behaviour stays symmetric.
+
+---
+
+## 6. Discovery: how the agent sees user skills
+
+Add four LangChain tools next to `listSkillsTool` / `searchSkillsTool` in `apps/app/src/graph/nodes/tools-node/skills-tools.ts`. Keep them as separate tools rather than merging — clearer intent for the LLM, easier to audit which calls hit which storage.
+
+| Tool                | Purpose                                                                                        |
+| ------------------- | ---------------------------------------------------------------------------------------------- |
+| `list_user_skills`  | Returns `[{ slug, description, triggers, path: '/workspace/user-skills/<slug>', source: 'user' }]` from the index only. No manifest fetch. |
+| `search_user_skills`| Substring match on name/description/triggers inside the index. Purely local — no Matrix roundtrip beyond `getSkillIndex`. |
+| `load_user_skill`   | Takes `slug` (not CID — CIDs are a public-registry concept). Materialises files under `/workspace/user-skills/<slug>/`.          |
+| `delete_user_skill` | Lets the agent remove a skill on the user's request (writes tombstone state event).             |
+
+**Creation tool — design choice:** three options here, with a clear preference.
+
+- **A. Tool-driven (`create_user_skill`).** The LLM authors SKILL.md + files and calls the tool. Pro: conversational UX. Con: LLM-written skills are usually mediocre; blast radius is an entire new tool on the main agent.
+- **B. REST/SSE endpoint on the oracle API + a CLI/Portal flow.** Pro: skills get authored by humans (or by the Skill Builder sub-agent in `qiforge-cli`). Con: no in-chat creation.
+- **C. Both — creation endpoint + an optional tool that wraps it.**
+
+**Recommended: B first, add A later.** Rationale: rushing A means shipping a tool that lets the LLM mint code in the user's sandbox based on fuzzy intent. A REST endpoint with a typed payload (tested, reviewable, auditable) is the right v1. The agent still *lists, loads, and runs* in chat — only *authoring* moves out.
+
+### Agent prompt changes
+
+In `apps/app/src/graph/nodes/chat-node/prompt.ts`:
+
+- Update the skills section (~line 160) to spell out the two-tier system: "First try `list_user_skills` / `search_user_skills`; fall back to `list_skills` / `search_skills`."
+- Update the canonical workflow (line 200) to branch on source: `load_skill(cid)` for public, `load_user_skill(slug)` for user.
+- Tighten the existing promise at line 169 ("User-uploaded skills have the highest priority") by making it a hard rule: *if a user skill matches the request, the agent must prefer it, even when a public skill also matches.*
+
+---
+
+## 7. API surface (NestJS)
+
+One new controller under `apps/app/src/user-skills/`:
+
+```
+POST   /user-skills                 # create or update
+GET    /user-skills                 # list (index only)
+GET    /user-skills/:slug           # full manifest + file list
+GET    /user-skills/:slug/files/*   # single file download
+DELETE /user-skills/:slug
+```
+
+**Auth:** reuse the existing Matrix access-token + DID middleware (already gates `/messages`, `/sessions`). No new auth primitive.
+
+**Upload format:** `multipart/form-data` with one `manifest.json` field + N file parts; or a single `.zip` that the server unpacks. Zip keeps the UX aligned with how public capsules ship today.
+
+**Validation rules** (server-side, non-negotiable):
+
+- Slug: `[a-z0-9][a-z0-9-]{0,62}` — not already in use in this room.
+- Total archive size: configurable cap (default 5 MB) — keeps Matrix events healthy.
+- File count cap (default 50) — prevents pathological layouts.
+- SKILL.md **required**; must be ≤ 64 KB (so it fits inline in one timeline event).
+- File extension allowlist or an explicit denylist (`.exe`, `.so`, …) — TBD, lean denylist since the sandbox itself is the security boundary.
+
+---
+
+## 8. Implementation plan (ordered, no work begins until approved)
+
+| # | Step                                                                                  | Files touched                                                                                            |
+| - | ------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------- |
+| 1 | **Storage service** — `UserSkillsService` with `getSkillIndex`/`get*`/`put`/`delete`  | `apps/app/src/user-skills/user-skills.service.ts` (new), `apps/app/src/app.module.ts`                    |
+| 2 | **Materialiser** — helper that writes manifest files into the sandbox                 | `apps/app/src/user-skills/user-skill-materialiser.ts` (new)                                              |
+| 3 | **LangChain tools** — `list_user_skills`, `search_user_skills`, `load_user_skill`, `delete_user_skill` | `apps/app/src/graph/nodes/tools-node/skills-tools.ts`                                   |
+| 4 | **Wire tools into main agent**                                                        | `apps/app/src/graph/agents/main-agent.ts` (tool list around line 792)                                    |
+| 5 | **Prompt updates** — two-tier discovery, priority rule, branch on source              | `apps/app/src/graph/nodes/chat-node/prompt.ts` (lines 160-226, 268-280)                                  |
+| 6 | **REST controller + DTOs**                                                            | `apps/app/src/user-skills/user-skills.controller.ts` (new)                                               |
+| 7 | **Tests** — storage round-trip (mock Matrix), tool invocation snapshot, materialiser integration | `apps/app/src/user-skills/*.spec.ts`, `apps/app/src/graph/nodes/tools-node/skills-tools.spec.ts` |
+| 8 | **Docs** — new `docs/playbook/04a-custom-skills.md`, update `04-working-with-skills.md`, update `specs/playbook-progress.md` | docs only |
+| 9 | **(Deferred)** Tool-driven creation (option A above) — only once B has shipped and we understand the failure modes | same files as step 3 |
+
+Ship 1–5 as one PR (engine changes), 6–8 as a second PR (API + docs), 9 as a later follow-up.
+
+---
+
+## 9. Open questions (flag before build)
+
+1. **Sandbox cooperation.** Does the sandbox reset `/workspace/user-skills/` between sessions the same way it does `/workspace/skills/`? If yes, lazy materialisation is fine. If it *doesn't* reset, we need a cache-invalidation step on manifest `version` change. Confirm with the ai-sandbox team.
+2. **Dependency auto-install.** The prompt at `prompt.ts:171` claims deps install automatically when a skill is loaded. That claim almost certainly only holds for skills loaded via `load_skill(cid)` (the sandbox knows the capsule shape). For `user-skills/` files we wrote manually, the agent likely needs to `exec pip install -r requirements.txt` itself. Worth verifying before updating the prompt, or we lie to the LLM.
+3. **Size ceiling.** 5 MB / 50 files is a finger-in-the-air default. Gut-check with how big real-world skills in the public registry get (a quick `du -sh` per skill in `ai-skills` would tell us).
+4. **Skill Builder sub-agent overlap.** `qiforge-cli` is scoped to contain a "Skill Builder" flow (per `CLAUDE.md`). Creation endpoint (§7) should be the thing the CLI calls — avoid shipping two authoring paths.
+5. **Secret injection.** Should user skills get access to the same `x-os-*` oracle secrets that public skills do (`main-agent.ts:553-562`), or should they be sandboxed from them? Default: **no secrets for user skills** unless the user explicitly grants per-skill. Prevents a custom skill from exfiltrating oracle-operator credentials.
+
+---
+
+## 10. Non-goals (v1)
+
+- No public sharing of user skills — nothing is published to `capsules.skills.ixo.earth`. If a user wants to share, they go through the public registry's PR flow manually.
+- No skill versioning beyond "the latest manifest wins." Old versions are retained as timeline events but not surfaced.
+- No skill-to-skill dependencies (user skill requires another user skill). Flat namespace per room.
+- No UI. API-only; the Portal team handles the front-end separately.

--- a/specs/custom-skills-plan.md
+++ b/specs/custom-skills-plan.md
@@ -1,24 +1,32 @@
 # Custom Skills — Design Plan
 
-> **Status:** Draft v2 — planning only, no code yet.
+> **Status:** Draft v3 — planning only, no code yet.
 > **Scope:** Allow a user (and the agent acting on their behalf) to create their own **private** skills alongside the verified public skills, scoped per-user.
-> **Change vs v1:** dropped Matrix-based storage, dropped the create-tool / REST-endpoint debate, dropped a separate materialiser. Storage is just a sandbox folder; discovery wraps the existing `list_skills` tool; creation is "agent writes files with the tools it already has."
+> **Change vs v2:** corrected the persistence assumption after reading the `ai-sandbox` source. Only `/workspace/data/**` survives a sandbox restart (R2-backed FUSE mount); every other path under `/workspace/` is ephemeral container FS. User skills move to `/workspace/data/user-skills/<slug>/`. Plan shape is otherwise unchanged.
 
 ---
 
 ## 1. The Insight That Simplifies Everything
 
-The sandbox **already persists `/workspace/`** across restarts. The *only* directory that gets blown away each session is `/workspace/skills/` (because the sandbox repopulates it from the public capsule registry).
+The sandbox has exactly one durable area: **`/workspace/data/`**, which is an R2 bucket mounted at the container via FUSE (`sandbox.ts:724` — `MOUNT_PATH = '/workspace/data'`). Everything else under `/workspace/` lives in the container filesystem and vanishes when the sandbox sleeps or restarts — including `/workspace/skills/`, which the sandbox re-downloads on demand from the public capsule registry.
 
-Any other folder — for example `/workspace/user-skills/` — survives. So **the sandbox itself is the store**. No Matrix events, no encryption layer, no REST endpoint, no materialiser — the per-user sandbox is a per-user filesystem, and that's exactly what we need.
+Conveniently, **every MCP exec path lands with `cwd = /workspace/data`** (`sandbox.ts:905`, `sandbox.ts:507`). So if we put custom skills at `/workspace/data/user-skills/<slug>/`:
+
+- They persist across restarts (R2 mount).
+- The agent reaches them with the short relative path `user-skills/<slug>/SKILL.md`, which is what a human author would naturally write.
+- Anything the agent writes via `sandbox_run` / `sandbox_write` defaults into the persistent mount — no chance of silently creating a non-persistent sibling.
+
+So **the sandbox itself is the store**. No Matrix events, no encryption layer, no REST endpoint, no materialiser. The R2 mount handles per-user persistence and isolation already (each user has their own bucket prefix).
 
 This collapses the whole feature down to three small changes:
 
-1. Teach `list_skills` to also `ls /workspace/user-skills/` and merge the result.
+1. Teach `list_skills` to also `ls /workspace/data/user-skills/` and merge the result.
 2. Make `load_skill` a no-op for user skills (they're already on disk).
-3. Tell the agent in the prompt: "to create a skill for the user, write files into `/workspace/user-skills/<slug>/`."
+3. Tell the agent in the prompt: "to create a skill for the user, write files into `user-skills/<slug>/` (relative to its working directory) — equivalently `/workspace/data/user-skills/<slug>/`."
 
 That's it. **No new tools** for create/delete — the agent already has `sandbox_write` and `exec` from the sandbox MCP, and it already knows what a skill looks like (SKILL.md + supporting files).
+
+> ⚠️ **Hard rule:** custom skills must **NOT** live under `/workspace/skills/`. After every public-skill load, `makeReadonly` (`sandbox.ts:352`) does a recursive `chown root:root` + `chmod 644/755` across the entire `/workspace/skills/` tree. Anything we put there gets clobbered.
 
 ---
 
@@ -38,40 +46,41 @@ That's it. **No new tools** for create/delete — the agent already has `sandbox
 graph LR
     LG[LangGraph Agent] -- "list_skills" --> ST[skills-tools.ts]
     ST -- "fetch capsules" --> R[Public registry<br/>capsules.skills.ixo.earth]
-    ST -- "exec ls + cat" --> SB[Sandbox MCP]
-    SB --> US[/workspace/user-skills/]
+    ST -- "exec ls + head" --> SB[Sandbox MCP]
+    SB --> US["/workspace/data/user-skills/<br/>(R2-backed, persistent)"]
     ST -- "cache by user DID" --> C[(NestJS cache-manager)]
-    LG -- "sandbox_write to<br/>/workspace/user-skills/" --> SB
+    LG -- "sandbox_write to<br/>user-skills/&lt;slug&gt;/" --> SB
     LG -- "read_skill / exec" --> SB
 ```
 
 **Two moving parts only:**
 
 1. **Discovery** — `list_skills` / `search_skills` get extended to query the sandbox folder in parallel with the public registry, then merge with a `source` discriminator. Sandbox-side results are cached per-user.
-2. **Convention** — `/workspace/user-skills/<slug>/` is the agreed location. Documented in the prompt; the agent treats it as a write target for new skills and a read source for existing ones.
+2. **Convention** — `/workspace/data/user-skills/<slug>/` is the agreed location. Documented in the prompt; the agent treats it as a write target for new skills and a read source for existing ones.
 
 ---
 
-## 4. Storage: just a sandbox folder
+## 4. Storage: just one folder under the R2 mount
 
 ```
 /workspace/
-  uploads/         # read-only, existing  (user uploads)
-  skills/          # read-only, existing  (public skills, repopulated each session)
-  user-skills/     # NEW                  (custom skills, persists across sessions)
-    <slug>/
-      SKILL.md     # required
-      ...other files (scripts, templates, examples)
-  data/output/     # existing
+  skills/                 # ephemeral, repopulated by the sandbox from the public registry
+  data/                   # R2 mount — only persistent area
+    user-skills/          # NEW
+      <slug>/
+        SKILL.md          # required
+        ...scripts, templates, examples
+    output/               # existing (symlink to /workspace/output)
 ```
 
 Properties we get for free:
 
-- **Per-user isolation** — already enforced by the sandbox service (each user ↔ oracle pair has its own sandbox instance).
-- **Persistence** — the sandbox already keeps `/workspace/` between sessions. We do nothing extra.
-- **No new keys / encryption surface** — sandbox-level encryption-at-rest already covers it (whatever the sandbox provides; same posture as `/workspace/uploads/`).
+- **Per-user isolation** — the R2 mount uses the per-sandbox prefix `/{sandboxId}/`, and each user ↔ oracle pair has its own sandbox.
+- **Persistence** — survives sandbox sleep/restart by virtue of being R2-backed.
+- **No new keys / encryption surface** — whatever encryption-at-rest R2 / the sandbox provides for `/workspace/data/output/` is the same posture user skills inherit.
+- **Natural path** — agent's exec cwd is already `/workspace/data`, so it can write `user-skills/foo/SKILL.md` and reach the persistent location without ever typing `/workspace/data/`. Server-side code uses absolute paths to avoid any cwd ambiguity.
 
-The agent reads, writes, and deletes through the same sandbox MCP tools it already has access to (`sandbox_write`, `exec`, `read_skill`).
+The agent reads, writes, and deletes through the same sandbox MCP tools it already has access to (`sandbox_write`, `sandbox_run` / `exec`, `read_skill`).
 
 ---
 
@@ -103,21 +112,23 @@ export function createSearchSkillsTool(deps: { /* same */ }) { ... }
 
 ### Sandbox-side listing
 
-The sandbox MCP's `exec` tool gives us shell access. One call is enough:
+The sandbox MCP's `exec` (`sandbox_run`) tool gives us shell access — fresh `bash -c` per call, cwd already `/workspace/data`, runs as root, 3 min timeout (lite tier). One call is enough:
 
 ```bash
-# Returns slug + first 5 lines of each SKILL.md (description usually lives there)
-for d in /workspace/user-skills/*/; do
-  if [ -f "$d/SKILL.md" ]; then
-    slug=$(basename "$d")
-    echo "::SLUG::$slug"
-    head -20 "$d/SKILL.md"
-    echo "::END::"
-  fi
+# Run from cwd /workspace/data; absolute paths used for clarity.
+mkdir -p /workspace/data/user-skills && \
+for d in /workspace/data/user-skills/*/; do
+  [ -f "$d/SKILL.md" ] || continue
+  slug=$(basename "$d")
+  echo "::SLUG::$slug"
+  head -n 20 "$d/SKILL.md"
+  echo "::END::"
 done 2>/dev/null
 ```
 
-Parse the output server-side, derive `{ slug, description, path }` per entry. If the directory doesn't exist, the loop produces nothing — empty list, not an error.
+Parse the output server-side, derive `{ slug, description, path }` per entry. The `mkdir -p` upfront makes first-time use idempotent — if no skills exist yet, the loop produces nothing and we return an empty list.
+
+**Caveat — secret scrubbing:** `execSafe` runs `scrubSecrets` on stdout/stderr before returning. If a SKILL.md description happens to contain a substring that matches a configured secret value, it'll be replaced in the listing output. Low-probability but worth noting; if it bites in practice, we move the listing to a path-bypass channel (e.g., `read_skill` per file) instead of `exec`.
 
 ### Cache
 
@@ -154,16 +165,16 @@ User skills come first in the merged array. Combined with the prompt's "user ski
 
 ## 6. Loading: `load_skill` becomes a no-op for user skills
 
-`load_skill` today is a sandbox MCP tool that takes a CID, downloads the public capsule, and unpacks it into `/workspace/skills/`. For user skills there's nothing to download — the files are already on disk.
+`load_skill` is a sandbox MCP tool with input schema `{ cid: string }` — no path, no slug. It only ever extracts to the `SKILLS_FOLDER` constant (`'/workspace/skills'`, hard-coded at `skills.service.ts:8`), so it physically cannot touch our `/workspace/data/user-skills/`. Confirmed by reading `skills.tool.ts:300-393` and `sandbox.ts:293-353`.
 
-Two options:
+That means we don't need to wrap or intercept it. We just teach the agent in the prompt:
 
-- **A. Wrap `load_skill` server-side** so that if the agent passes a user-skill identifier, we short-circuit and return success.
-- **B. Don't wrap. Tell the agent in the prompt: "user skills are pre-loaded — skip `load_skill` and go straight to `read_skill`."**
+> Skills with `source: 'user'` are already on disk. Skip `load_skill` and go straight to `read_skill`.
 
-**Recommended: B.** Wrapping `load_skill` means intercepting an MCP tool we don't own (it lives in the sandbox MCP server, exposed by name). Cleaner to not interpose. The agent already follows prompt-level rules; one more line ("for `source: 'user'`, skip step 2 of the canonical workflow") is enough.
+Two consequences worth knowing about:
 
-If we later find the agent reflexively calling `load_skill` on a path/slug and getting confusing errors, we can revisit and add a thin wrapper that intercepts.
+- `load_skill` is idempotent **per live container only**. Because `/workspace/skills/` is ephemeral, the cached `.tar.gz` "is it loaded?" check disappears on every restart. Every cold start re-downloads + re-extracts public skills. This is fine for our purposes — we never call it for user skills — but it's a useful mental model.
+- After `load_skill` runs, `makeReadonly` chowns and chmods the **entire** `/workspace/skills/` tree (`sandbox.ts:352`). This is the structural reason the plan keeps user skills under `/workspace/data/`, not under `/workspace/skills/`.
 
 ---
 
@@ -174,22 +185,22 @@ If we later find the agent reflexively calling `load_skill` on a path/slug and g
 The agent already has, via the sandbox MCP:
 
 - `sandbox_write(path, content)` — write any file
-- `exec(command)` — run shell commands (mkdir, chmod, etc.)
+- `sandbox_run(command)` — run shell commands (mkdir, chmod, etc.) at cwd `/workspace/data`
 
 A skill is a folder with a SKILL.md and optional supporting files. The agent can author all of that with the tools above. We add prompt instructions:
 
 > **Creating a skill for the user**
 >
 > When the user asks to create a new skill (or you decide one would help future tasks):
-> 1. Pick a slug: lowercase, hyphenated, unique under `/workspace/user-skills/`. Check with `list_skills` first.
-> 2. `sandbox_write` to `/workspace/user-skills/<slug>/SKILL.md` — required. Follow the same SKILL.md format as public skills.
+> 1. Pick a slug: lowercase, hyphenated, unique under `user-skills/`. Check with `list_skills` first.
+> 2. `sandbox_write` to `user-skills/<slug>/SKILL.md` (resolves to `/workspace/data/user-skills/<slug>/SKILL.md`) — required. Follow the same SKILL.md format as public skills.
 > 3. Add supporting files (scripts, templates) under the same folder as needed.
 > 4. Call `list_skills` with `refresh: true` so the new skill shows up in subsequent listings.
 > 5. Confirm to the user with the slug + a one-line summary.
 
 ### Deleting a skill
 
-Agent uses `exec('rm -rf /workspace/user-skills/<slug>')`, then `list_skills` with `refresh: true`. Documented in the same prompt section.
+Agent uses `sandbox_run('rm -rf user-skills/<slug>')`, then `list_skills` with `refresh: true`. Documented in the same prompt section.
 
 ### Updating
 
@@ -208,7 +219,7 @@ Same as creating — overwrite SKILL.md or replace files via `sandbox_write`. No
 In `apps/app/src/graph/nodes/chat-node/prompt.ts`:
 
 1. **Skills section (~line 160–198):**
-   - Replace the description of skills as "from the registry" with a two-source model: public (from registry) and user (from `/workspace/user-skills/`).
+   - Replace the description of skills as "from the registry" with a two-source model: public (from registry, materialised in `/workspace/skills/`) and user (authored in chat, persisted in `/workspace/data/user-skills/`).
    - Spell out that `list_skills` / `search_skills` returns both, with `source: 'user' | 'public'`, and that user skills come first.
    - Make line 169's "highest priority" promise concrete: "If a user skill matches the request, prefer it over a public skill, even if both apply."
 
@@ -217,12 +228,12 @@ In `apps/app/src/graph/nodes/chat-node/prompt.ts`:
    - Step 3 (Read): same `read_skill` call works for both, just use the path from the listing.
 
 3. **Sandbox file system (lines 265–280):**
-   - Add `/workspace/user-skills/` to the list. Mark it as **read/write** (unlike `/workspace/skills/` which is read-only).
-   - Note: "User skills persist across sessions — anything you write here stays for next time."
+   - Add `/workspace/data/user-skills/` to the list. Mark it as **read/write and persistent** (contrast with `/workspace/skills/`, which is read-only and ephemeral).
+   - Note: "User skills persist across sandbox restarts because they live under the R2-backed `/workspace/data/` mount. Anything you create here stays for next time."
 
-4. **New "Creating skills" subsection** as described in §7.
+4. **New "Creating skills" subsection** as described in §7. Encourage the relative path form (`user-skills/<slug>/...`) so the model doesn't have to memorise the mount point.
 
-5. **Cache hygiene rule:** "After `sandbox_write` or `exec rm` under `/workspace/user-skills/`, your next `list_skills` call must include `refresh: true`."
+5. **Cache hygiene rule:** "After `sandbox_write` or `sandbox_run rm` under `user-skills/`, your next `list_skills` call must include `refresh: true`."
 
 ---
 
@@ -244,11 +255,14 @@ All of this ships as one small PR. No new module, no new service, no new control
 
 ## 10. Open questions (flag before build)
 
-1. **Sandbox-folder persistence — confirm.** I'm taking it on the user's word that `/workspace/` (everything except `/workspace/skills/`) survives sandbox restarts. Quick smoke test against the actual ai-sandbox service before merging step 1: write a marker file, restart, look for it. If persistence is per-session-only, the whole plan collapses.
-2. **Sandbox-side listing performance.** A `find` / shell loop over `/workspace/user-skills/` is fine for tens of skills. If a user accumulates hundreds, parsing becomes the bottleneck, not the FS. We're well below that ceiling for v1.
-3. **Cross-oracle sharing.** A user with two different oracles has two different sandboxes — so user skills don't cross. Probably fine (each oracle is its own context); flag if product wants a cross-oracle "skill library."
-4. **Validation.** The agent is the only writer, so SKILL.md schema, slug uniqueness, and file-size limits aren't enforced anywhere. v1 trusts the LLM. If we see garbage skills accumulating, add a server-side `list_skills`-time validator that hides malformed entries (instead of blocking writes).
-5. **Public-vs-user collisions.** What if a user creates a skill named `pptx` and a public skill `pptx` also exists? Our merged list shows both with `source` flags; the agent prefers the user one per the priority rule. No collision logic needed — the `source` field is the tie-breaker.
+1. ~~Sandbox-folder persistence — confirm.~~ **Resolved.** Only `/workspace/data/**` persists (R2 FUSE mount, `sandbox.ts:724`). Plan now uses `/workspace/data/user-skills/`.
+2. **FUSE quirks.** `/workspace/data/` is s3fs-FUSE in deployed environments. Concurrent writes, file locking, and atomic rename semantics are weaker than a real FS. For our workload (write a few small files, ls a directory, head a SKILL.md) this should be fine, but if we ever add concurrent-write paths (e.g. server-side and agent-side both writing to the same skill), revisit.
+3. **Cold-start latency.** First `list_skills` after a sandbox wakes from sleep pays for one `exec` round-trip plus FUSE warm-up. Acceptable for v1; if it's noticeable, the per-DID cache absorbs subsequent calls.
+4. **Secret scrubbing in listings.** `execSafe` regex-replaces secret values in stdout. If a user's SKILL.md description contains a literal that matches a configured secret, the listing shows scrubbed text. Edge case; document as a known issue.
+5. **Sandbox-side listing performance.** A `for d in user-skills/*/` loop is fine for tens of skills. If a user accumulates hundreds, parsing becomes the bottleneck — but they won't.
+6. **Cross-oracle sharing.** A user with two different oracles has two different sandboxes (different R2 prefixes), so user skills don't cross. Probably fine (each oracle is its own context); flag if product wants a cross-oracle "skill library."
+7. **Validation.** The agent is the only writer, so SKILL.md schema, slug uniqueness, and file-size limits aren't enforced anywhere. v1 trusts the LLM. If garbage skills accumulate, add a `list_skills`-time validator that hides malformed entries.
+8. **Public-vs-user collisions.** If a user creates `pptx` and a public `pptx` also exists, the merged list shows both with `source` flags and the agent prefers the user one per the priority rule. No extra logic needed.
 
 ---
 


### PR DESCRIPTION
## Summary

Extend the skills system to support user-created custom skills persisted in the sandbox's R2-backed `/workspace/data/user-skills/` directory, alongside the existing public skills from the IXO registry. User skills are discovered, listed, and executed through the same tools as public skills, with user skills prioritized in results.

## Key Changes

- **Skills discovery refactored**: Convert `listSkillsTool` and `searchSkillsTool` from standalone exports to factory functions (`createListSkillsTool`, `createSearchSkillsTool`) that accept dependencies (sandbox MCP client, user DID) and merge both public registry and user-skill results in a single call.

- **New `UserSkillsService`**: Singleton service that queries the sandbox for custom skills under `/workspace/data/user-skills/`, parses SKILL.md metadata, and caches results per-user for 5 minutes with explicit refresh support.

- **Unified skill listing**: Both discovery tools now return a merged array with a `source: 'user' | 'public'` discriminator. User skills appear first (highest priority). Public skills include `cid` (required for `load_skill`); user skills include only `path` and `slug`.

- **Sandbox integration**: Single `sandbox_run` call per listing discovers all user skills by iterating `/workspace/data/user-skills/*/SKILL.md`, extracting slug and description from file headers.

- **Agent prompt updates**: Clarify the two-source model, teach the agent to skip `load_skill` for user skills (already on disk), and document the creation workflow (write to `user-skills/<slug>/` via `sandbox_write`, then call `list_skills` with `refresh: true`).

- **Cache hygiene**: Added `refresh` parameter to both tools so the agent can bypass cache immediately after creating/deleting a skill.

## Implementation Details

- User skills persist across sandbox restarts because `/workspace/data/` is R2-backed; public skills in `/workspace/skills/` are ephemeral and re-downloaded on demand.
- No new authoring tools — the agent uses existing `sandbox_write` and `sandbox_run` to create/delete skills; SKILL.md format is identical to public skills.
- Caching uses NestJS `cache-manager` with key `user-skills:list:<userDid>` and 5-minute TTL.
- Sandbox-side listing is idempotent (creates `/workspace/data/user-skills/` if missing) and gracefully handles empty directories.
- Error handling in `UserSkillsService` logs warnings but never throws, returning empty list on sandbox failures so the agent can still access public skills.

https://claude.ai/code/session_01HYMUrkc1kc3mJtE3CbZduM