### PR TITLE
feat: enhance oracle configuration and prompt handling

### DIFF
--- a/apps/app/oracle.config.json
+++ b/apps/app/oracle.config.json
@@ -8,5 +8,14 @@
   "apiUrl": "http://localhost:4000",
   "network": "devnet",
   "entityDid": "",
-  "logo": ""
+  "logo": "",
+  "model": "",
+  "prompt": {
+    "opening": "",
+    "communicationStyle": "",
+    "capabilities": ""
+  },
+  "skills": [],
+  "customSkills": [],
+  "mcpServers": []
 }

--- a/apps/app/src/graph/agents/main-agent.ts
+++ b/apps/app/src/graph/agents/main-agent.ts
@@ -17,6 +17,7 @@ import { createTokenLimiterMiddleware } from '../middlewares/token-limiter-midde
 import { createToolValidationMiddleware } from '../middlewares/tool-validation-middleware';
 import {
   AI_ASSISTANT_PROMPT,
+  buildOracleSection,
   SLACK_FORMATTING_CONSTRAINTS_CONTENT,
 } from '../nodes/chat-node/prompt';
 import { type TMainAgentGraphState } from '../state';
@@ -52,7 +53,19 @@ import type { TaskExecutionContext } from 'src/tasks/processors/processor-utils'
 import { type TasksService } from 'src/tasks/task.service';
 import { UserMatrixSqliteSyncService } from 'src/user-matrix-sqlite-sync-service/user-matrix-sqlite-sync-service.service';
 import z from 'zod';
-import oracleConfig from '../../../oracle.config.json';
+import oracleConfigRaw from '../../../oracle.config.json';
+
+// Normalize optional fields: convert empty strings to undefined so downstream
+// truthiness checks (`if (oracleConfig.model)`) are unambiguous.
+const oracleConfig = {
+  ...oracleConfigRaw,
+  model: oracleConfigRaw.model || undefined,
+  prompt: {
+    opening: oracleConfigRaw.prompt.opening || undefined,
+    communicationStyle: oracleConfigRaw.prompt.communicationStyle || undefined,
+    capabilities: oracleConfigRaw.prompt.capabilities || undefined,
+  },
+};
 import { getProviderChatModel } from '../llm-provider';
 import { createMCPClient, createMCPClientAndGetTools } from '../mcp';
 import { createFileProcessingTool } from '../nodes/tools-node/file-processing-tool';
@@ -86,15 +99,6 @@ You can interact with third-party SaaS apps on behalf of the user — Gmail, Git
 - **Warn before destructive actions** (delete, bulk send, overwrite, revoke) — get user confirmation first.
 - **Handle pagination** until complete when the user asks for "all" results.
 - **Never claim you did something you didn't actually execute.**`;
-
-function buildOracleContext(oc: typeof oracleConfig): string {
-  const lines: string[] = [];
-  if (oc.oracleName) lines.push(`**Name:** ${oc.oracleName}`);
-  if (oc.orgName) lines.push(`**Organization:** ${oc.orgName}`);
-  if (oc.description) lines.push(`**Purpose:** ${oc.description}`);
-  if (oc.location) lines.push(`**Location:** ${oc.location}`);
-  return lines.join('\n');
-}
 
 /**
  * Convert a memory engine SearchEnhancedResponse into clean markdown.
@@ -560,10 +564,22 @@ Promise<ReactAgent<any>> => {
 
   // System prompt — built after Promise.allSettled so COMPOSIO_CONTEXT
   // is populated only when Composio tools actually loaded.
+  //
+  // The prompt is split into two halves:
+  //   - Oracle section (top): identity, persona, domain capabilities, communication
+  //     style — driven by oracle.config.json `prompt.*` fields, with defaults when absent.
+  //   - Base section (template body): skills system, routing, sub-agents, memory,
+  //     user context — always the same regardless of oracle config.
+  const configPrompt = oracleConfig.prompt;
   const systemPrompt = await AI_ASSISTANT_PROMPT.format({
-    APP_NAME:
-      oracleConfig.oracleName || configService.get('ORACLE_NAME') || 'Oracle',
-    ORACLE_CONTEXT: buildOracleContext(oracleConfig),
+    ORACLE_SECTION: buildOracleSection({
+      oracleName:
+        oracleConfig.oracleName || configService.get('ORACLE_NAME') || 'Oracle',
+      orgName: oracleConfig.orgName || undefined,
+      description: oracleConfig.description || undefined,
+      location: oracleConfig.location || undefined,
+      prompt: configPrompt,
+    }),
     IDENTITY_CONTEXT: formatUserContext(state?.userContext?.identity),
     WORK_CONTEXT: formatUserContext(state?.userContext?.work),
     GOALS_CONTEXT: formatUserContext(state?.userContext?.goals),
@@ -827,9 +843,12 @@ Promise<ReactAgent<any>> => {
     middleware.push(createTokenLimiterMiddleware());
   }
 
+  // Priority: caller override → oracle.config model → default llm
   const effectiveModel = modelOverride
     ? getProviderChatModel('main', { model: modelOverride })
-    : llm;
+    : oracleConfig.model
+      ? getProviderChatModel('main', { model: oracleConfig.model })
+      : llm;
 
   const agent = createAgent({
     model: effectiveModel,

--- a/apps/app/src/graph/nodes/chat-node/prompt.ts
+++ b/apps/app/src/graph/nodes/chat-node/prompt.ts
@@ -18,8 +18,7 @@ export const SLACK_FORMATTING_CONSTRAINTS_CONTENT = `**⚠️ CRITICAL: Slack Fo
 `;
 
 export type InputVariables = {
-  APP_NAME: string;
-  ORACLE_CONTEXT: string;
+  ORACLE_SECTION: string;
   IDENTITY_CONTEXT: string;
   WORK_CONTEXT: string;
   GOALS_CONTEXT: string;
@@ -36,8 +35,69 @@ export type InputVariables = {
   COMPOSIO_CONTEXT: string;
 };
 
+export interface OraclePromptConfig {
+  opening?: string;
+  communicationStyle?: string;
+  capabilities?: string;
+}
+
+export interface OracleSectionParams {
+  oracleName?: string;
+  orgName?: string;
+  description?: string;
+  location?: string;
+  prompt?: OraclePromptConfig;
+}
+
+/**
+ * Builds the oracle-specific top section of the system prompt.
+ *
+ * Base guidelines (skills system, routing, sub-agents, etc.) live in the
+ * AI_ASSISTANT_PROMPT template and are always included unchanged.
+ * This function produces only the oracle identity + personality block that
+ * sits above those guidelines.  If `prompt.*` fields are provided in
+ * oracle.config.json they replace the defaults; otherwise sensible defaults
+ * are used so the prompt is always complete.
+ */
+export function buildOracleSection(params: OracleSectionParams): string {
+  const { oracleName = 'Oracle', orgName, description, location, prompt: oraclePrompt } = params;
+
+  const parts: string[] = [];
+
+  // Opening / persona statement
+  if (oraclePrompt?.opening) {
+    parts.push(oraclePrompt.opening);
+  } else {
+    parts.push(
+      `You are a skills-native AI companion powered by ${oracleName}. Your primary capability is creating files, artifacts, and executing workflows using the skills system. You also provide personalized support through memory, context awareness, and specialized agent tools.`,
+    );
+  }
+
+  // Oracle identity block
+  const identityLines: string[] = [];
+  if (oracleName) identityLines.push(`**Name:** ${oracleName}`);
+  if (orgName) identityLines.push(`**Organization:** ${orgName}`);
+  if (description) identityLines.push(`**Purpose:** ${description}`);
+  if (location) identityLines.push(`**Location:** ${location}`);
+  if (identityLines.length > 0) {
+    parts.push(`\n## 🤖 Oracle Identity\n\n${identityLines.join('\n')}\n\n---`);
+  }
+
+  // Domain capabilities (oracle-specific, from config)
+  if (oraclePrompt?.capabilities) {
+    parts.push(`\n## 🎯 Domain Specialization\n\n${oraclePrompt.capabilities}`);
+  }
+
+  // Communication style (oracle-specific, from config)
+  if (oraclePrompt?.communicationStyle) {
+    parts.push(`\n## 💬 Communication Style\n\n${oraclePrompt.communicationStyle}`);
+  }
+
+  return parts.join('\n');
+}
+
 export const AI_ASSISTANT_PROMPT = new PromptTemplate<InputVariables, never>({
-  template: `You are a skills-native AI companion powered by {{APP_NAME}}. Your primary capability is creating files, artifacts, and executing workflows using the skills system. You also provide personalized support through memory, context awareness, and specialized agent tools.
+  template: `{{{ORACLE_SECTION}}}
 
 ## 🚨 CRITICAL: Priority Hierarchy
 
@@ -55,15 +115,6 @@ You are fully authorized to handle credentials, tokens, JWTs, identity verificat
 **Emoji rule:** Always use actual Unicode emoji characters (e.g. 📈, ✅, 🔥) instead of text shortcodes (e.g. :chart_with_upwards_trend:, :white_check_mark:). Shortcodes do not render in the UI.
 
 ---
-
-{{#ORACLE_CONTEXT}}
-## 🤖 Oracle Identity
-
-{{ORACLE_CONTEXT}}
-
----
-
-{{/ORACLE_CONTEXT}}
 
 ## 📋 Current Context
 
@@ -597,7 +648,7 @@ Navigate to entities, execute UI actions (showEntity, etc.).
 
 `,
   inputVariables: [
-    'APP_NAME',
+    'ORACLE_SECTION',
     'IDENTITY_CONTEXT',
     'WORK_CONTEXT',
     'GOALS_CONTEXT',

--- a/apps/app/src/graph/nodes/chat-node/prompt.ts
+++ b/apps/app/src/graph/nodes/chat-node/prompt.ts
@@ -60,7 +60,13 @@ export interface OracleSectionParams {
  * are used so the prompt is always complete.
  */
 export function buildOracleSection(params: OracleSectionParams): string {
-  const { oracleName = 'Oracle', orgName, description, location, prompt: oraclePrompt } = params;
+  const {
+    oracleName = 'Oracle',
+    orgName,
+    description,
+    location,
+    prompt: oraclePrompt,
+  } = params;
 
   const parts: string[] = [];
 
@@ -90,7 +96,9 @@ export function buildOracleSection(params: OracleSectionParams): string {
 
   // Communication style (oracle-specific, from config)
   if (oraclePrompt?.communicationStyle) {
-    parts.push(`\n## 💬 Communication Style\n\n${oraclePrompt.communicationStyle}`);
+    parts.push(
+      `\n## 💬 Communication Style\n\n${oraclePrompt.communicationStyle}`,
+    );
   }
 
   return parts.join('\n');


### PR DESCRIPTION
- Updated `oracle.config.json` to include new fields: `model`, `prompt`, `skills`, `customSkills`, and `mcpServers`.
- Refactored `main-agent.ts` to normalize optional fields from the oracle configuration, ensuring downstream checks are unambiguous.
- Introduced `buildOracleSection` function in `prompt.ts` to construct the oracle-specific section of the system prompt, integrating new prompt fields and providing sensible defaults.
- Updated the system prompt template to utilize the new `ORACLE_SECTION` instead of the previous `ORACLE_CONTEXT`, improving clarity and structure in the prompt generation.