### PR TITLE
fix(ucan): try all resolved Ed25519 keys when verifying delegations

### DIFF
--- a/apps/app/package.json
+++ b/apps/app/package.json
@@ -36,7 +36,7 @@
     "@ixo/oracles-events": "1.0.4",
     "@ixo/slack": "1.0.0",
     "@ixo/sqlite-saver": "^1.0.52",
-    "@ixo/ucan": "1.2.2",
+    "@ixo/ucan": "1.2.3",
     "@langchain/community": "^1.1.27",
     "@langchain/core": "^1.1.42",
     "@langchain/langgraph": "^1.2.9",

--- a/packages/ucan/package.json
+++ b/packages/ucan/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@ixo/ucan",
   "description": "UCAN authorization for any service - built on ucanto",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "private": false,
   "publishConfig": {
     "access": "public"

--- a/packages/ucan/src/validator/validator.ts
+++ b/packages/ucan/src/validator/validator.ts
@@ -246,13 +246,22 @@ export async function createUCANValidator(
       );
     }
 
-    const keyDid = resolved.ok[0];
-    if (!keyDid) {
-      throw new Error(`No valid key found for server DID ${options.serverDid}`);
+    // DID docs may publish multiple Ed25519 verification methods; pick the
+    // first one that parses as a valid Ed25519 verifier.
+    let parseError: unknown;
+    for (const keyDid of resolved.ok) {
+      try {
+        serverVerifier = ed25519.Verifier.parse(keyDid);
+        return serverVerifier;
+      } catch (err) {
+        parseError = err;
+      }
     }
 
-    serverVerifier = ed25519.Verifier.parse(keyDid);
-    return serverVerifier;
+    throw new Error(
+      `No valid Ed25519 key found for server DID ${options.serverDid}` +
+        (parseError instanceof Error ? `: ${parseError.message}` : ''),
+    );
   }
 
   // Create DID resolver for use during validation (for issuers in delegation chain)
@@ -373,33 +382,37 @@ export async function createUCANValidator(
       };
     }
 
-    const didKey = resolved.ok[0]!;
-    const realVerifier = ed25519.Verifier.parse(didKey);
-
-    // Get the UCAN View from the delegation for signature verification.
-    // delegation.data returns the @ipld/dag-ucan View which has .model and .signature
+    // A did:ixo DID document may publish multiple Ed25519 verification methods.
+    // Try each resolved key until one verifies the signature; only report failure
+    // when none of them match.
     const ucanView = delegation.data;
+    let didKey: string | undefined;
+    let sigValid = false;
 
-    // Create a wrapper verifier: uses the issuer's original DID for the
-    // DID equality check inside UCAN.verifySignature, but delegates actual
-    // cryptographic verification to the resolved did:key verifier.
-    // This is necessary because did:ixo issuers sign with Ed25519 keys but
-    // the UCAN's iss field contains did:ixo, not did:key.
-    const wrappedVerifier = {
-      did: () => issuerDid,
-      verify: (payload: Uint8Array, signature: unknown) =>
-        realVerifier.verify(
-          payload,
-          // eslint-disable-next-line @typescript-eslint/no-explicit-any -- SigAlg type mismatch between @ipld/dag-ucan and @ucanto/principal
-          signature as any,
-        ),
-    };
+    for (const candidateKey of resolved.ok) {
+      const realVerifier = ed25519.Verifier.parse(candidateKey);
+      const wrappedVerifier = {
+        did: () => issuerDid,
+        verify: (payload: Uint8Array, signature: unknown) =>
+          realVerifier.verify(
+            payload,
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any -- SigAlg type mismatch between @ipld/dag-ucan and @ucanto/principal
+            signature as any,
+          ),
+      };
 
-    const sigValid = await UCAN.verifySignature(
-      ucanView,
-      wrappedVerifier as any,
-    );
-    if (!sigValid) {
+      try {
+        if (await UCAN.verifySignature(ucanView, wrappedVerifier as any)) {
+          sigValid = true;
+          didKey = candidateKey;
+          break;
+        }
+      } catch {
+        // Try the next key
+      }
+    }
+
+    if (!sigValid || !didKey) {
       return {
         ok: false,
         error: {
@@ -419,12 +432,14 @@ export async function createUCANValidator(
           const proofAudResolved = await resolveDIDKey(
             proofAudience as `did:${string}:${string}`,
           );
-          const proofAudKey =
+          const proofAudKeys =
             'ok' in proofAudResolved && proofAudResolved.ok
-              ? proofAudResolved.ok[0]
-              : null;
+              ? proofAudResolved.ok
+              : [];
 
-          if (didKey !== proofAudKey) {
+          // Match if the issuer key we just verified appears anywhere in the
+          // proof audience's resolved key set (DIDs may publish multiple keys).
+          if (!proofAudKeys.some((k) => k === didKey)) {
             return {
               ok: false,
               error: {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -107,8 +107,8 @@ importers:
         specifier: ^1.0.52
         version: 1.0.52(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.215.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.7.0(@opentelemetry/api@1.9.0))(openai@6.34.0(ws@8.18.2)(zod@4.3.6))(ws@8.18.2)
       '@ixo/ucan':
-        specifier: 1.2.2
-        version: 1.2.2(@cosmjs/crypto@0.33.1)(@cosmjs/encoding@0.33.1)(typescript@5.9.3)
+        specifier: 1.2.3
+        version: 1.2.3(@cosmjs/crypto@0.33.1)(@cosmjs/encoding@0.33.1)(typescript@5.9.3)
       '@langchain/community':
         specifier: ^1.1.27
         version: 1.1.27(8ec1bea159d308e660084c4e1aea3d0c)
@@ -3260,8 +3260,8 @@ packages:
   '@ixo/typescript-config@1.0.0':
     resolution: {integrity: sha512-reavFCnQlEY3efgDMBJoUbHJUIhlpFgf/LS0Q1Vqz+y/mbXymItF82unAzcmRFjb5fE+ANgYpj0k22njWs/tzg==}
 
-  '@ixo/ucan@1.2.2':
-    resolution: {integrity: sha512-ifVz7k6VCZD564OFaV4nTtMveBWgbJSNbYmuIo1my5cYVonG3UC494fgsW8md02POts8nwgBWdHk2MfWUXMhvw==}
+  '@ixo/ucan@1.2.3':
+    resolution: {integrity: sha512-JHAhNwvjJ1MqPsTWdgQoTVmZhpdS+CsRDmEj9cSL+AtEXdGXlCZPIwdVA/u5jgGZ4kuGJAzOC+29u7PK1MNmhA==}
     peerDependencies:
       '@cosmjs/crypto': '>=0.32.0'
       '@cosmjs/encoding': '>=0.32.0'
@@ -16523,7 +16523,7 @@ snapshots:
       '@dnd-kit/core': 6.3.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@ixo/matrix-crdt': 1.1.0(lib0@0.2.114)(matrix-js-sdk@37.13.0)(y-protocols@1.0.6(yjs@13.6.27))(yjs@13.6.27)
       '@ixo/surveys': 0.1.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@ixo/ucan': 1.2.2(@cosmjs/crypto@0.33.1)(@cosmjs/encoding@0.33.1)(typescript@5.9.3)
+      '@ixo/ucan': 1.2.3(@cosmjs/crypto@0.33.1)(@cosmjs/encoding@0.33.1)(typescript@5.9.3)
       '@mantine/core': 7.17.8(@mantine/hooks@7.17.8(react@18.3.1))(@types/react@18.3.27)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@mantine/hooks': 7.17.8(react@18.3.1)
       '@tabler/icons-react': 3.35.0(react@18.3.1)
@@ -16795,7 +16795,7 @@ snapshots:
 
   '@ixo/typescript-config@1.0.0': {}
 
-  '@ixo/ucan@1.2.2(@cosmjs/crypto@0.33.1)(@cosmjs/encoding@0.33.1)(typescript@5.9.3)':
+  '@ixo/ucan@1.2.3(@cosmjs/crypto@0.33.1)(@cosmjs/encoding@0.33.1)(typescript@5.9.3)':
     dependencies:
       '@ucanto/client': 9.0.2
       '@ucanto/core': 10.4.6


### PR DESCRIPTION
  DID docs may publish multiple Ed25519 verification methods. The validator
  only tried resolved.ok[0], rejecting valid signatures whenever a user signed
  with any key past the first one.