### PR TITLE
Update package versions for multiple modules

### DIFF
--- a/packages/events/package.json
+++ b/packages/events/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ixo/oracles-events",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "description": "Events for QiForge",
   "private": false,
   "main": "./dist/server.js",

--- a/packages/oracle-runtime/package.json
+++ b/packages/oracle-runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ixo/oracle-runtime",
-  "version": "0.0.1",
+  "version": "1.0.0",
   "description": "Plugin-based runtime for QiForge oracles",
   "private": false,
   "publishConfig": {

--- a/packages/oracles-client-sdk/package.json
+++ b/packages/oracles-client-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ixo/oracles-client-sdk",
-  "version": "1.1.34",
+  "version": "1.2.0",
   "type": "module",
   "private": false,
   "description": "Client SDK for interacting with QiForge oracles, designed for React applications",

--- a/packages/sqlite-saver/package.json
+++ b/packages/sqlite-saver/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ixo/sqlite-saver",
-  "version": "1.0.52",
+  "version": "1.0.53",
   "private": false,
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
- Bumped version of `@ixo/oracles-events` from 1.0.4 to 1.0.5.
- Updated `@ixo/oracle-runtime` version from 0.0.1 to 1.0.0.
- Increased `@ixo/oracles-client-sdk` version from 1.1.34 to 1.2.0.
- Incremented `@ixo/sqlite-saver` version from 1.0.52 to 1.0.53.

These changes reflect the latest updates and improvements across the respective packages.