### PR TITLE
fix(messages): make sandbox archival mandatory for all processed attachments

### DIFF
--- a/packages/oracle-runtime/package.json
+++ b/packages/oracle-runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ixo/oracle-runtime",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "Plugin-based runtime for QiForge oracles",
   "private": false,
   "publishConfig": {

--- a/packages/oracle-runtime/src/modules/messages/file-processing.service.test.ts
+++ b/packages/oracle-runtime/src/modules/messages/file-processing.service.test.ts
@@ -127,8 +127,18 @@ describe('FileProcessingService', () => {
   beforeEach(() => {
     vi.resetAllMocks();
     fetchSpy = vi.spyOn(globalThis, 'fetch');
+    // Sandbox archival is mandatory — every accepted attachment is uploaded.
+    // Default fetch handles the upload endpoint; AI calls are mocked
+    // per-test with mockResolvedValueOnce (once-mocks take precedence).
+    fetchSpy.mockImplementation(async (input: unknown) => {
+      const url = String(input);
+      if (url.endsWith('/artifacts/upload')) {
+        return jsonResponse({ path: '/workspace/output/uploaded' });
+      }
+      throw new Error(`Unexpected fetch in test: ${url}`);
+    });
     ucanService = {
-      createServiceInvocation: vi.fn().mockResolvedValue(null),
+      createServiceInvocation: vi.fn().mockResolvedValue('ucan-token'),
     } satisfies Partial<UcanService>;
     creditSink = {
       deductForFileProcessing: vi.fn().mockResolvedValue(undefined),
@@ -143,7 +153,7 @@ describe('FileProcessingService', () => {
       }),
     });
     svc = new FileProcessingService(
-      makeConfig({}),
+      makeConfig({ SANDBOX_MCP_URL: 'https://sandbox.test/mcp' }),
       ucanService as unknown as UcanService,
       creditSink,
     );
@@ -395,33 +405,6 @@ describe('FileProcessingService', () => {
       expect(creditSink.deductForFileProcessing).toHaveBeenCalledTimes(1);
       expect(result.texts).toHaveLength(1);
     });
-
-    it('skips credit deduction when userDid is undefined', async () => {
-      const pngHeader = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a]);
-      matrixDownloadContent.mockResolvedValue({ data: pngHeader });
-      fetchSpy.mockResolvedValueOnce(
-        aiResponse('photo', {
-          prompt_tokens: 1,
-          completion_tokens: 1,
-          cost: 0.001,
-        }),
-      );
-
-      await svc.processAttachments(
-        [
-          makeAttachment({
-            filename: 'a.png',
-            mxcUri: 'mxc://h/a',
-            mimetype: 'image/png',
-          }),
-        ],
-        ROOM_ID,
-        undefined,
-      );
-
-      expect(creditSink.deductForFileProcessing).not.toHaveBeenCalled();
-      expect(ucanService.createServiceInvocation).not.toHaveBeenCalled();
-    });
   });
 
   describe('processAttachments — sandbox upload', () => {
@@ -436,30 +419,31 @@ describe('FileProcessingService', () => {
       } satisfies Partial<UcanService>;
       ucanService = ucan;
       return new FileProcessingService(
-        makeConfig({
-          SANDBOX_MCP_URL: opts.sandboxUrl,
-        }),
+        makeConfig(opts.sandboxUrl ? { SANDBOX_MCP_URL: opts.sandboxUrl } : {}),
         ucan as unknown as UcanService,
         creditSink,
       );
     }
 
-    it('returns undefined sandbox config when SANDBOX_MCP_URL is unset', async () => {
+    it('rejects the whole request when SANDBOX_MCP_URL is unset', async () => {
       svc = svcWithSandbox({ sandboxUrl: undefined });
       matrixDownloadContent.mockResolvedValue({
         data: Buffer.from('hi', 'utf-8'),
       });
 
-      await svc.processAttachments(
-        [makeAttachment({ mxcUri: 'mxc://h/a' })],
-        ROOM_ID,
-        USER_DID,
-      );
+      await expect(
+        svc.processAttachments(
+          [makeAttachment({ mxcUri: 'mxc://h/a' })],
+          ROOM_ID,
+          USER_DID,
+        ),
+      ).rejects.toThrow(/SANDBOX_MCP_URL/);
 
       expect(ucanService.createServiceInvocation).not.toHaveBeenCalled();
+      expect(matrixDownloadContent).not.toHaveBeenCalled();
     });
 
-    it('returns undefined sandbox config when UCAN invocation is null', async () => {
+    it('rejects the whole request when UCAN invocation is null', async () => {
       svc = svcWithSandbox({
         sandboxUrl: 'https://sandbox.test/mcp',
         invocation: null,
@@ -468,16 +452,65 @@ describe('FileProcessingService', () => {
         data: Buffer.from('hi', 'utf-8'),
       });
 
-      await svc.processAttachments(
-        [makeAttachment({ mxcUri: 'mxc://h/a' })],
+      await expect(
+        svc.processAttachments(
+          [makeAttachment({ mxcUri: 'mxc://h/a' })],
+          ROOM_ID,
+          USER_DID,
+        ),
+      ).rejects.toThrow(/UCAN invocation unavailable/);
+
+      expect(ucanService.createServiceInvocation).toHaveBeenCalledTimes(1);
+      // Failure happens before any download or upload.
+      expect(matrixDownloadContent).not.toHaveBeenCalled();
+      expect(fetchSpy).not.toHaveBeenCalled();
+    });
+
+    it('archives HTTP image URLs to the sandbox even when AI URL passthrough succeeds', async () => {
+      svc = svcWithSandbox({
+        sandboxUrl: 'https://sandbox.test/mcp',
+        invocation: 'ucan-token',
+      });
+      const pngHeader = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a]);
+      // 1: download the file. 2: AI passthrough. Uploads (file + analysis.md)
+      // fall through to the default /artifacts/upload handler.
+      fetchSpy
+        .mockResolvedValueOnce(
+          streamResponse([new Uint8Array(pngHeader)], {
+            headers: { 'content-type': 'image/png' },
+          }),
+        )
+        .mockResolvedValueOnce(
+          aiResponse('a sunset', {
+            prompt_tokens: 1,
+            completion_tokens: 1,
+            cost: 0.01,
+          }),
+        );
+
+      const result = await svc.processAttachments(
+        [
+          makeAttachment({
+            filename: 'pic.png',
+            mimetype: 'image/png',
+            mxcUri: 'https://example.com/pic.png',
+          }),
+        ],
         ROOM_ID,
         USER_DID,
       );
 
-      expect(ucanService.createServiceInvocation).toHaveBeenCalledTimes(1);
-      // No fetch to /artifacts/upload happened — only the AI call path would
-      // have fired fetch, and plain text doesn't trigger AI either.
-      expect(fetchSpy).not.toHaveBeenCalled();
+      expect(result.texts[0]).toContain('a sunset');
+      expect(result.texts[0]).toContain('saved to sandbox at');
+      expect(result.metadata[0]?.sandboxPath).toBe('/workspace/output/pic.png');
+      // download → AI passthrough → file upload → analysis.md upload
+      expect(fetchSpy).toHaveBeenCalledTimes(4);
+      expect(String(fetchSpy.mock.calls[0]?.[0])).toBe(
+        'https://example.com/pic.png',
+      );
+      expect(String(fetchSpy.mock.calls[2]?.[0])).toBe(
+        'https://sandbox.test/artifacts/upload',
+      );
     });
 
     it('returns primary text even when sandbox upload fails after AI spend', async () => {

--- a/packages/oracle-runtime/src/modules/messages/file-processing.service.ts
+++ b/packages/oracle-runtime/src/modules/messages/file-processing.service.ts
@@ -190,10 +190,11 @@ export class FileProcessingService {
   }
 
   /**
-   * Build the sandbox upload config for the current user. Returns `undefined`
-   * when sandbox archival isn't possible — `SANDBOX_MCP_URL` unset, the user
-   * has no cached UCAN delegation, or the oracle has no signing key. The
-   * caller treats `undefined` as "skip upload"; processing still happens.
+   * Build the sandbox upload config for the current user. Sandbox archival
+   * is mandatory — every accepted attachment is uploaded so the agent can
+   * keep working with the original file. Throws when the sandbox is
+   * unreachable: `SANDBOX_MCP_URL` unset, the user has no cached UCAN
+   * delegation, or the oracle has no signing key.
    *
    * Auth header shape matches `plugins/sandbox/sandbox-mcp.ts`
    * (`createDefaultAuthBuilder`) exactly — same `Authorization: Bearer <ucan>`
@@ -201,9 +202,8 @@ export class FileProcessingService {
    */
   private async buildSandboxConfig(
     userDid: string,
-  ): Promise<SandboxUploadConfig | undefined> {
-    const sandboxMcpUrl = this.config.get<string>('SANDBOX_MCP_URL');
-    if (!sandboxMcpUrl) return undefined;
+  ): Promise<SandboxUploadConfig> {
+    const sandboxMcpUrl = this.config.getOrThrow<string>('SANDBOX_MCP_URL');
 
     const invocation = await this.ucanService.createServiceInvocation(
       sandboxMcpUrl,
@@ -211,10 +211,12 @@ export class FileProcessingService {
       'ixo:sandbox',
     );
     if (!invocation) {
-      this.logger.debug(
-        `[FileProcessing] Skipping sandbox archive for ${userDid} — UCAN invocation unavailable`,
+      this.logger.warn(
+        `[FileProcessing] Cannot archive attachments for ${userDid} — UCAN invocation unavailable`,
       );
-      return undefined;
+      throw new Error(
+        'Cannot process attachments — sandbox UCAN invocation unavailable',
+      );
     }
 
     return {
@@ -296,7 +298,7 @@ export class FileProcessingService {
   async processAttachments(
     attachments: AttachmentDto[],
     roomId: string,
-    userDid?: string,
+    userDid: string,
   ): Promise<{
     texts: string[];
     metadata: ProcessedAttachment[];
@@ -322,14 +324,10 @@ export class FileProcessingService {
 
     // Mint the sandbox UCAN once per request — the cached invocation is reused
     // for every attachment so we don't re-resolve did:web or re-sign per file.
-    const sandboxConfig = userDid
-      ? await this.buildSandboxConfig(userDid)
-      : undefined;
-    if (sandboxConfig) {
-      this.logger.log(
-        `[FileProcessing] Sandbox archival enabled for this request → ${sandboxConfig.sandboxMcpUrl}`,
-      );
-    }
+    const sandboxConfig = await this.buildSandboxConfig(userDid);
+    this.logger.log(
+      `[FileProcessing] Sandbox archival enabled for this request → ${sandboxConfig.sandboxMcpUrl}`,
+    );
 
     // Process sequentially so the running download total is enforced *before*
     // the next attachment is fetched. Parallel `Promise.all` would let N
@@ -444,7 +442,7 @@ export class FileProcessingService {
     attachment: AttachmentDto,
     currentTotalSize: number,
     roomId: string,
-    sandboxConfig?: SandboxUploadConfig,
+    sandboxConfig: SandboxUploadConfig,
   ): Promise<{
     text: string | null;
     downloadedSize: number;
@@ -481,34 +479,9 @@ export class FileProcessingService {
       };
     }
 
-    // For HTTP image/video URLs, try AI URL passthrough first (no download needed).
-    const isHttpUrl =
-      attachment.mxcUri &&
-      !attachment.eventId &&
-      /^https?:\/\//i.test(attachment.mxcUri);
-    if (isHttpUrl && (category === 'image' || category === 'video')) {
-      try {
-        const { content, usage } = await this.aiProcessFromUrl(
-          attachment.mxcUri!,
-          attachment.mimetype,
-          category,
-          attachment.filename,
-        );
-        if (content && content.trim().length > 0) {
-          const text = this.formatContent(
-            'Description',
-            this.sanitizeFilename(attachment.filename),
-            content,
-          );
-          return { text, downloadedSize: 0, usage };
-        }
-      } catch (error) {
-        this.logger.warn(
-          `URL passthrough failed for "${attachment.filename}", falling back to download: ${error instanceof Error ? error.message : String(error)}`,
-        );
-      }
-    }
-
+    // Every accepted attachment is downloaded so the original bytes can be
+    // archived to the sandbox below — the agent works with the file from
+    // there, not just the extracted text.
     let buffer: Buffer;
     if (attachment.eventId) {
       buffer = await this.downloadFromMatrixEvent(roomId, attachment.eventId);
@@ -525,111 +498,140 @@ export class FileProcessingService {
 
     this.verifyMagicBytes(buffer, category, attachment);
 
-    let text: string;
+    // For HTTP image/video URLs, prefer AI URL passthrough for extraction —
+    // the provider fetches the URL itself instead of receiving a base64
+    // re-upload. The downloaded buffer is still archived to the sandbox.
+    const isHttpUrl =
+      attachment.mxcUri &&
+      !attachment.eventId &&
+      /^https?:\/\//i.test(attachment.mxcUri);
+
+    let text: string | undefined;
     let usage: AiProcessUsage | undefined;
-    switch (category) {
-      case 'document':
-        ({ text, usage } = await this.processDocument(buffer, attachment));
-        break;
-      case 'image':
-        ({ text, usage } = await this.processImage(buffer, attachment));
-        break;
-      case 'audio':
-        ({ text, usage } = await this.processAudio(buffer, attachment));
-        break;
-      case 'video':
-        ({ text, usage } = await this.processVideo(buffer, attachment));
-        break;
+    if (isHttpUrl && (category === 'image' || category === 'video')) {
+      try {
+        const passthrough = await this.aiProcessFromUrl(
+          attachment.mxcUri!,
+          attachment.mimetype,
+          category,
+          attachment.filename,
+        );
+        if (passthrough.content && passthrough.content.trim().length > 0) {
+          text = this.formatContent(
+            'Description',
+            this.sanitizeFilename(attachment.filename),
+            passthrough.content,
+          );
+          usage = passthrough.usage;
+        }
+      } catch (error) {
+        this.logger.warn(
+          `URL passthrough failed for "${attachment.filename}", falling back to buffer processing: ${error instanceof Error ? error.message : String(error)}`,
+        );
+      }
     }
 
-    if (sandboxConfig) {
-      const safeName = this.sanitizeFilename(attachment.filename);
-      const destPath = `${SANDBOX_OUTPUT_PREFIX}/${safeName}`;
-      try {
-        await this.uploadToSandbox(
-          buffer,
+    if (text === undefined) {
+      switch (category) {
+        case 'document':
+          ({ text, usage } = await this.processDocument(buffer, attachment));
+          break;
+        case 'image':
+          ({ text, usage } = await this.processImage(buffer, attachment));
+          break;
+        case 'audio':
+          ({ text, usage } = await this.processAudio(buffer, attachment));
+          break;
+        case 'video':
+          ({ text, usage } = await this.processVideo(buffer, attachment));
+          break;
+      }
+    }
+
+    const safeName = this.sanitizeFilename(attachment.filename);
+    const destPath = `${SANDBOX_OUTPUT_PREFIX}/${safeName}`;
+    try {
+      await this.uploadToSandbox(
+        buffer,
+        safeName,
+        destPath,
+        sandboxConfig,
+        attachment.mimetype,
+      );
+      const actualPath = this.sanitizeSandboxPath(destPath);
+
+      this.logger.log(
+        `Attachment "${attachment.filename}" uploaded to sandbox at ${actualPath}`,
+      );
+
+      // For AI-processed files (image/video/audio), save analysis as .md
+      let analysisPath: string | undefined;
+      if (
+        category === 'image' ||
+        category === 'video' ||
+        category === 'audio'
+      ) {
+        const analysisContent = this.buildAnalysisMarkdown(
           safeName,
-          destPath,
-          sandboxConfig,
           attachment.mimetype,
+          buffer.length,
+          category,
+          text,
         );
-        const actualPath = this.sanitizeSandboxPath(destPath);
-
-        this.logger.log(
-          `Attachment "${attachment.filename}" uploaded to sandbox at ${actualPath}`,
-        );
-
-        // For AI-processed files (image/video/audio), save analysis as .md
-        let analysisPath: string | undefined;
-        if (
-          category === 'image' ||
-          category === 'video' ||
-          category === 'audio'
-        ) {
-          const analysisContent = this.buildAnalysisMarkdown(
-            safeName,
-            attachment.mimetype,
-            buffer.length,
-            category,
-            text,
+        const analysisBuf = Buffer.from(analysisContent, 'utf-8');
+        const analysisFilename = `${safeName.replace(/\.[^.]+$/, '')}-analysis.md`;
+        const analysisDestPath = `${SANDBOX_OUTPUT_PREFIX}/${analysisFilename}`;
+        try {
+          await this.uploadToSandbox(
+            analysisBuf,
+            analysisFilename,
+            analysisDestPath,
+            sandboxConfig,
+            'text/markdown',
           );
-          const analysisBuf = Buffer.from(analysisContent, 'utf-8');
-          const analysisFilename = `${safeName.replace(/\.[^.]+$/, '')}-analysis.md`;
-          const analysisDestPath = `${SANDBOX_OUTPUT_PREFIX}/${analysisFilename}`;
-          try {
-            await this.uploadToSandbox(
-              analysisBuf,
-              analysisFilename,
-              analysisDestPath,
-              sandboxConfig,
-              'text/markdown',
-            );
-            analysisPath = this.sanitizeSandboxPath(analysisDestPath);
-            this.logger.log(
-              `Analysis for "${attachment.filename}" saved to sandbox at ${analysisPath}`,
-            );
-          } catch (error) {
-            this.logger.warn(
-              `Analysis .md upload failed for "${attachment.filename}": ${error instanceof Error ? error.message : String(error)}`,
-            );
-          }
+          analysisPath = this.sanitizeSandboxPath(analysisDestPath);
+          this.logger.log(
+            `Analysis for "${attachment.filename}" saved to sandbox at ${analysisPath}`,
+          );
+        } catch (error) {
+          this.logger.warn(
+            `Analysis .md upload failed for "${attachment.filename}": ${error instanceof Error ? error.message : String(error)}`,
+          );
         }
+      }
 
-        if (text.length > SANDBOX_TRUNCATE_LIMIT) {
-          const paths = analysisPath
-            ? `\n\n[Full analysis saved to sandbox at ${analysisPath}]\n[Original file saved to sandbox at ${actualPath}]`
-            : `\n\n[Full file saved to sandbox at ${actualPath}]`;
-          return {
-            text: text.slice(0, SANDBOX_TRUNCATE_LIMIT) + paths,
-            downloadedSize: buffer.length,
-            sandboxPath: actualPath,
-            usage,
-          };
-        }
-        const suffix = analysisPath
-          ? `\n\n[Analysis saved to sandbox at ${analysisPath}]\n[File also saved to sandbox at ${actualPath}]`
-          : `\n\n[File also saved to sandbox at ${actualPath}]`;
+      if (text.length > SANDBOX_TRUNCATE_LIMIT) {
+        const paths = analysisPath
+          ? `\n\n[Full analysis saved to sandbox at ${analysisPath}]\n[Original file saved to sandbox at ${actualPath}]`
+          : `\n\n[Full file saved to sandbox at ${actualPath}]`;
         return {
-          text: text + suffix,
+          text: text.slice(0, SANDBOX_TRUNCATE_LIMIT) + paths,
           downloadedSize: buffer.length,
           sandboxPath: actualPath,
           usage,
         };
-      } catch (error) {
-        this.logger.warn(
-          `Sandbox upload failed for "${attachment.filename}": ${error instanceof Error ? error.message : String(error)}`,
-        );
-        return {
-          text:
-            text +
-            `\n\n[Warning: sandbox upload failed — file content is included above]`,
-          downloadedSize: buffer.length,
-          usage,
-        };
       }
+      const suffix = analysisPath
+        ? `\n\n[Analysis saved to sandbox at ${analysisPath}]\n[File also saved to sandbox at ${actualPath}]`
+        : `\n\n[File also saved to sandbox at ${actualPath}]`;
+      return {
+        text: text + suffix,
+        downloadedSize: buffer.length,
+        sandboxPath: actualPath,
+        usage,
+      };
+    } catch (error) {
+      this.logger.warn(
+        `Sandbox upload failed for "${attachment.filename}": ${error instanceof Error ? error.message : String(error)}`,
+      );
+      return {
+        text:
+          text +
+          `\n\n[Warning: sandbox upload failed — file content is included above]`,
+        downloadedSize: buffer.length,
+        usage,
+      };
     }
-
-    return { text, downloadedSize: buffer.length, usage };
   }
 
   private async downloadFromMatrix(mxcUri: string): Promise<Buffer> {


### PR DESCRIPTION
## Why

Attachments processed via `processAttachments` were not always archived to the user's sandbox workspace. In particular, HTTP image/video URLs took an AI URL-passthrough early-return that never downloaded the file, so nothing landed in `/workspace/output` — the agent couldn't run code over those files afterwards. The optional-sandbox contract was also half-removed: the code threw when the sandbox was unavailable while comments and guards still described a "skip upload" path.

## What changed

- **Every accepted attachment is now downloaded and uploaded to the sandbox.** The HTTP image/video URL passthrough no longer skips the download — it remains only as a text-extraction optimization (provider fetches the URL instead of receiving a base64 re-upload), falling back to buffer-based processing if it fails. Either way the buffer is archived, and image/video/audio still get the `-analysis.md` companion.
- **Sandbox archival is mandatory.** `buildSandboxConfig` throws when `SANDBOX_MCP_URL` is unset or the UCAN invocation is unavailable, failing the request up front. Dead `if (sandboxConfig)` guards removed; stale doc comment rewritten; error message typo fixed.
- A failed upload remains soft: extracted text is returned with a warning so AI spend isn't thrown away.

## Behavior notes

- HTTP image/video URLs now count against the 50 MB total budget (previously 0 bytes downloaded).
- An unreachable sandbox / missing UCAN delegation now rejects the whole attachment request.

## Tests

- Default unit-test harness boots with sandbox configured + a default `/artifacts/upload` fetch handler.
- Flipped the two "skip gracefully" tests to assert the hard-failure contract.
- New test: HTTPS image attachments are archived even when AI URL passthrough succeeds (asserts download → AI → file upload → analysis upload sequence and `sandboxPath` metadata).
- Removed the `userDid: undefined` credit test (param is now required).

28/28 unit tests pass; `tsc --noEmit`, eslint, and prettier clean.