### PR TITLE
feat(auth): UCAN invocation authentication + durable Matrix delegation

### DIFF
--- a/packages/oracle-runtime/package.json
+++ b/packages/oracle-runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ixo/oracle-runtime",
-  "version": "1.0.31",
+  "version": "1.0.32",
   "description": "Plugin-based runtime for QiForge oracles",
   "private": false,
   "publishConfig": {

--- a/packages/oracle-runtime/src/bootstrap/ambient-factory.ts
+++ b/packages/oracle-runtime/src/bootstrap/ambient-factory.ts
@@ -13,6 +13,7 @@ import type {
   RoomStateSnapshot,
   SecretIndex,
 } from '../plugin-api/types.js';
+import { UcanMintUnavailableError } from '../plugin-api/ucan-errors.js';
 import type {
   AmbientServices,
   BlobStoreAdapter,
@@ -86,7 +87,7 @@ export function buildAmbientServices(
         opts,
       );
       if (!result) {
-        throw new Error(
+        throw new UcanMintUnavailableError(
           `UCAN invocation mint returned null for user='${userDid}' service='${target.did}' capability='${target.capability}'. ` +
             `Likely cause: no signing key loaded, no cached delegation, or service DID unreachable.`,
         );

--- a/packages/oracle-runtime/src/bootstrap/create-oracle-app.ts
+++ b/packages/oracle-runtime/src/bootstrap/create-oracle-app.ts
@@ -357,6 +357,7 @@ export async function createOracleApp(
         'x-matrix-homeserver',
         'x-did',
         'x-request-id',
+        "x-auth-type",
         'x-timezone',
       ],
       exposedHeaders: ['X-Request-Id'],

--- a/packages/oracle-runtime/src/bootstrap/create-oracle-app.ts
+++ b/packages/oracle-runtime/src/bootstrap/create-oracle-app.ts
@@ -357,7 +357,7 @@ export async function createOracleApp(
         'x-matrix-homeserver',
         'x-did',
         'x-request-id',
-        "x-auth-type",
+        'x-auth-type',
         'x-timezone',
       ],
       exposedHeaders: ['X-Request-Id'],

--- a/packages/oracle-runtime/src/config/base-env-schema.test.ts
+++ b/packages/oracle-runtime/src/config/base-env-schema.test.ts
@@ -111,6 +111,8 @@ describe('baseEnvSchema', () => {
       'ORACLE_SECRETS',
       'SECP_MNEMONIC',
       'RPC_URL',
+      'UCAN_AUTH_MAX_TTL_SECONDS',
+      'UCAN_REAUTH_PROMPT_THROTTLE_SECONDS',
       'LLM_PROVIDER',
       'OPENAI_API_KEY',
       'OPEN_ROUTER_API_KEY',

--- a/packages/oracle-runtime/src/config/base-env-schema.ts
+++ b/packages/oracle-runtime/src/config/base-env-schema.ts
@@ -52,6 +52,22 @@ export const baseEnvSchema = z.object({
   SECP_MNEMONIC: z.string(),
   RPC_URL: z.string(),
 
+  /**
+   * Max lifetime (seconds) the oracle will accept for a user *auth* invocation
+   * (the short-lived, JWT-style bearer token the client signs to authenticate).
+   * Bounds the replay window server-side regardless of the TTL the client
+   * declares — a tampered client can't mint a long-lived auth token. Default
+   * 15 minutes.
+   */
+  UCAN_AUTH_MAX_TTL_SECONDS: z.coerce.number().default(900),
+
+  /**
+   * Throttle window (seconds) between "please re-authorize" prompts posted into
+   * a user's Matrix room when their stored delegation is missing/expired, so a
+   * de-authorized user isn't nagged on every message. Default 6 hours.
+   */
+  UCAN_REAUTH_PROMPT_THROTTLE_SECONDS: z.coerce.number().default(21600),
+
   // LLM provider selection (provider-specific keys are optional so a fork
   // can choose between OpenRouter and Nebius without setting both).
   LLM_PROVIDER: z.enum(['openrouter', 'nebius']).default('openrouter'),

--- a/packages/oracle-runtime/src/modules/auth/auth-header.middleware.test.ts
+++ b/packages/oracle-runtime/src/modules/auth/auth-header.middleware.test.ts
@@ -249,7 +249,9 @@ describe('AuthHeaderMiddleware (UCAN-only)', () => {
   it('authenticates via invocation (no delegation) and leaves ucanDelegation empty', async () => {
     const expiration = Math.floor(Date.now() / 1000) + 300;
     mockedCreateUCANValidator.mockResolvedValue(
-      makeValidator({ invocation: { ok: true, invoker: USER_DID, expiration } }),
+      makeValidator({
+        invocation: { ok: true, invoker: USER_DID, expiration },
+      }),
     );
 
     const req = makeReq(bearer('INV_TOKEN'));

--- a/packages/oracle-runtime/src/modules/auth/auth-header.middleware.test.ts
+++ b/packages/oracle-runtime/src/modules/auth/auth-header.middleware.test.ts
@@ -4,6 +4,7 @@ import type { ConfigService } from '@nestjs/config';
 import type { Request, Response, NextFunction } from 'express';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { createUCANValidator } from '@ixo/ucan';
+import type { UCANValidator, ValidateResult } from '@ixo/ucan';
 import { AuthHeaderMiddleware } from './auth-header.middleware.js';
 import type { UcanService } from '../ucan/ucan.service.js';
 
@@ -13,6 +14,7 @@ import type { UcanService } from '../ucan/ucan.service.js';
 vi.mock('@ixo/ucan', () => ({
   createUCANValidator: vi.fn(),
   createIxoDIDResolver: vi.fn(() => ({})),
+  defineCapability: vi.fn(() => ({})),
 }));
 
 const mockedCreateUCANValidator = vi.mocked(createUCANValidator);
@@ -66,6 +68,32 @@ function makeRes(): Response {
 const VALID_DELEGATION_RAW = 'eyJ.delegation.raw';
 const ORACLE_DID = 'did:ixo:oracle123';
 const USER_DID = 'did:ixo:user456';
+const OTHER_DID = 'did:ixo:other789';
+
+const FAIL_RESULT: ValidateResult = {
+  ok: false,
+  error: { code: 'INVALID_FORMAT', message: 'not mocked' },
+};
+
+/**
+ * Build a fully-typed `UCANValidator` mock. `validate` backs invocation auth,
+ * `validateDelegation` backs delegation auth — set whichever a test needs.
+ */
+function makeValidator(opts: {
+  delegation?: ValidateResult;
+  invocation?: ValidateResult;
+}): UCANValidator {
+  return {
+    serverDid: ORACLE_DID,
+    validateDelegation: async () => opts.delegation ?? FAIL_RESULT,
+    validate: async () => opts.invocation ?? FAIL_RESULT,
+  };
+}
+
+/** Headers carrying a bearer auth invocation (`X-Auth-Type: ucan`). */
+function bearer(token: string): Record<string, string> {
+  return { authorization: `Bearer ${token}`, 'x-auth-type': 'ucan' };
+}
 
 describe('AuthHeaderMiddleware (UCAN-only)', () => {
   let cache: CacheMock;
@@ -81,6 +109,7 @@ describe('AuthHeaderMiddleware (UCAN-only)', () => {
     });
     ucan = makeUcanService();
     mw = new AuthHeaderMiddleware(cache as unknown as Cache, cfg, ucan);
+    mockedCreateUCANValidator.mockReset();
   });
 
   afterEach(() => {
@@ -215,5 +244,143 @@ describe('AuthHeaderMiddleware (UCAN-only)', () => {
     expect(err).toBeInstanceOf(HttpException);
     expect(err.getStatus()).toBe(HttpStatus.UNAUTHORIZED);
     expect((req as unknown as { authData?: unknown }).authData).toBeUndefined();
+  });
+
+  it('authenticates via invocation (no delegation) and leaves ucanDelegation empty', async () => {
+    const expiration = Math.floor(Date.now() / 1000) + 300;
+    mockedCreateUCANValidator.mockResolvedValue(
+      makeValidator({ invocation: { ok: true, invoker: USER_DID, expiration } }),
+    );
+
+    const req = makeReq(bearer('INV_TOKEN'));
+    const next = vi.fn() as unknown as NextFunction;
+
+    await mw.use(req, makeRes(), next);
+
+    expect(next).toHaveBeenCalledTimes(1);
+    expect(
+      (next as unknown as ReturnType<typeof vi.fn>).mock.calls[0]?.[0],
+    ).toBeUndefined();
+    expect(req.authData.did).toBe(USER_DID);
+    expect(req.authData.ucanDelegation.raw).toBe('');
+    expect(ucan.cacheDelegation).not.toHaveBeenCalled();
+  });
+
+  it('invocation + matching delegation caches the delegation for downstream', async () => {
+    const now = Math.floor(Date.now() / 1000);
+    const delExp = now + 600;
+    mockedCreateUCANValidator.mockResolvedValue(
+      makeValidator({
+        delegation: {
+          ok: true,
+          invoker: USER_DID,
+          capability: { can: 'a', with: 'r' },
+          expiration: delExp,
+        },
+        invocation: { ok: true, invoker: USER_DID, expiration: now + 300 },
+      }),
+    );
+
+    const req = makeReq({
+      ...bearer('INV_TOKEN'),
+      'x-ucan-delegation': VALID_DELEGATION_RAW,
+    });
+    const next = vi.fn() as unknown as NextFunction;
+
+    await mw.use(req, makeRes(), next);
+
+    expect(req.authData.did).toBe(USER_DID);
+    expect(req.authData.ucanDelegation.raw).toBe(VALID_DELEGATION_RAW);
+    expect(ucan.cacheDelegation).toHaveBeenCalledWith(
+      USER_DID,
+      VALID_DELEGATION_RAW,
+      delExp,
+    );
+  });
+
+  it('ignores a delegation issued by someone other than the authenticated user', async () => {
+    const now = Math.floor(Date.now() / 1000);
+    mockedCreateUCANValidator.mockResolvedValue(
+      makeValidator({
+        delegation: {
+          ok: true,
+          invoker: OTHER_DID,
+          capability: { can: 'a', with: 'r' },
+          expiration: now + 600,
+        },
+        invocation: { ok: true, invoker: USER_DID, expiration: now + 300 },
+      }),
+    );
+
+    const req = makeReq({
+      ...bearer('INV_TOKEN'),
+      'x-ucan-delegation': VALID_DELEGATION_RAW,
+    });
+    const next = vi.fn() as unknown as NextFunction;
+
+    await mw.use(req, makeRes(), next);
+
+    // Auth still succeeds (identity = invocation signer), but the mismatched
+    // delegation is NOT trusted for downstream use.
+    expect(req.authData.did).toBe(USER_DID);
+    expect(req.authData.ucanDelegation.raw).toBe('');
+    expect(ucan.cacheDelegation).not.toHaveBeenCalled();
+  });
+
+  it('rejects an invalid invocation with 401', async () => {
+    mockedCreateUCANValidator.mockResolvedValue(
+      makeValidator({
+        invocation: {
+          ok: false,
+          error: { code: 'INVALID_SIGNATURE', message: 'bad sig' },
+        },
+      }),
+    );
+
+    const req = makeReq(bearer('INV_TOKEN'));
+    const next = vi.fn() as unknown as NextFunction;
+
+    await mw.use(req, makeRes(), next);
+
+    const err = (next as unknown as ReturnType<typeof vi.fn>).mock
+      .calls[0]?.[0] as HttpException;
+    expect(err).toBeInstanceOf(HttpException);
+    expect(err.getStatus()).toBe(HttpStatus.UNAUTHORIZED);
+    expect((req as unknown as { authData?: unknown }).authData).toBeUndefined();
+  });
+
+  it('rejects an invocation whose TTL exceeds the server maximum with 401', async () => {
+    const farFuture = Math.floor(Date.now() / 1000) + 100_000; // > 900s max
+    mockedCreateUCANValidator.mockResolvedValue(
+      makeValidator({
+        invocation: { ok: true, invoker: USER_DID, expiration: farFuture },
+      }),
+    );
+
+    const req = makeReq(bearer('INV_TOKEN'));
+    const next = vi.fn() as unknown as NextFunction;
+
+    await mw.use(req, makeRes(), next);
+
+    const err = (next as unknown as ReturnType<typeof vi.fn>).mock
+      .calls[0]?.[0] as HttpException;
+    expect(err).toBeInstanceOf(HttpException);
+    expect(err.getStatus()).toBe(HttpStatus.UNAUTHORIZED);
+  });
+
+  it('rejects an invocation with no expiration with 401', async () => {
+    mockedCreateUCANValidator.mockResolvedValue(
+      makeValidator({ invocation: { ok: true, invoker: USER_DID } }),
+    );
+
+    const req = makeReq(bearer('INV_TOKEN'));
+    const next = vi.fn() as unknown as NextFunction;
+
+    await mw.use(req, makeRes(), next);
+
+    const err = (next as unknown as ReturnType<typeof vi.fn>).mock
+      .calls[0]?.[0] as HttpException;
+    expect(err).toBeInstanceOf(HttpException);
+    expect(err.getStatus()).toBe(HttpStatus.UNAUTHORIZED);
   });
 });

--- a/packages/oracle-runtime/src/modules/auth/auth-header.middleware.ts
+++ b/packages/oracle-runtime/src/modules/auth/auth-header.middleware.ts
@@ -86,7 +86,8 @@ export class AuthHeaderMiddleware implements NestMiddleware {
   private extractInvocation(req: Request): string | undefined {
     if (req.headers['x-auth-type'] !== 'ucan') return undefined;
     const auth = req.headers['authorization'];
-    if (typeof auth !== 'string' || !auth.startsWith('Bearer ')) return undefined;
+    if (typeof auth !== 'string' || !auth.startsWith('Bearer '))
+      return undefined;
     const token = auth.slice('Bearer '.length).trim();
     return token.length > 0 ? token : undefined;
   }
@@ -251,7 +252,12 @@ export class AuthHeaderMiddleware implements NestMiddleware {
         }
         req.authData = {
           did: authedDid,
-          ucanDelegation: { raw: '', issuer: '', audience: '', capabilities: [] },
+          ucanDelegation: {
+            raw: '',
+            issuer: '',
+            audience: '',
+            capabilities: [],
+          },
         };
       }
 

--- a/packages/oracle-runtime/src/modules/auth/auth-header.middleware.ts
+++ b/packages/oracle-runtime/src/modules/auth/auth-header.middleware.ts
@@ -13,6 +13,10 @@ import { type NextFunction, type Request, type Response } from 'express';
 import * as crypto from 'node:crypto';
 import { UcanService } from '../ucan/ucan.service.js';
 import { validateUcanDelegation } from './validate-ucan-delegation.js';
+import {
+  DEFAULT_UCAN_AUTH_MAX_TTL_SECONDS,
+  validateUcanInvocation,
+} from './validate-ucan-invocation.js';
 
 declare global {
   // eslint-disable-next-line @typescript-eslint/no-namespace -- Required for declaration merging
@@ -24,7 +28,9 @@ declare global {
           /**
            * Raw base64-encoded delegation header as sent by the client.
            * Plugin code reads this from `runCtx.user.ucanDelegation.raw`
-           * to mint downstream service invocations.
+           * to mint downstream service invocations. Empty string when the
+           * request authenticated via an invocation but carried no (or an
+           * unbound) delegation — plugins branch on `raw.length === 0`.
            */
           raw: string;
           issuer: string;
@@ -39,7 +45,7 @@ declare global {
 
 const THREE_MINUTES = minutes(3);
 
-interface CachedUcanAuth {
+interface CachedDelegationAuth {
   userDid: string;
   delegation: {
     issuer: string;
@@ -49,6 +55,19 @@ interface CachedUcanAuth {
   };
 }
 
+interface CachedInvocationAuth {
+  userDid: string;
+  expiration: number;
+}
+
+/**
+ * Authenticates every request. Primary auth is a user-signed UCAN *invocation*
+ * (JWT-style bearer, `Authorization: Bearer <inv>` + `X-Auth-Type: ucan`); a
+ * bare `x-ucan-delegation` is accepted only as a migration fallback. The
+ * delegation, when present, is cached for downstream service invocations — but
+ * only when it was issued by the authenticated user (delegations are public, so
+ * we never act on someone else's just because a client presented it).
+ */
 @Injectable()
 export class AuthHeaderMiddleware implements NestMiddleware {
   private readonly logger = new Logger(AuthHeaderMiddleware.name);
@@ -63,15 +82,75 @@ export class AuthHeaderMiddleware implements NestMiddleware {
     return crypto.createHash('sha256').update(token, 'utf8').digest('hex');
   }
 
-  private async validateUcanDelegation(ucanHeader: string): Promise<{
-    userDid: string;
-    delegation: {
-      issuer: string;
-      audience: string;
-      capabilities: unknown[];
-      expiration?: number;
+  /** Pull the bearer invocation out of the request, if present and well-formed. */
+  private extractInvocation(req: Request): string | undefined {
+    if (req.headers['x-auth-type'] !== 'ucan') return undefined;
+    const auth = req.headers['authorization'];
+    if (typeof auth !== 'string' || !auth.startsWith('Bearer ')) return undefined;
+    const token = auth.slice('Bearer '.length).trim();
+    return token.length > 0 ? token : undefined;
+  }
+
+  /**
+   * Validate a user auth invocation. Caches the result by token hash with TTL =
+   * the invocation's own expiry, so the same token (reused by the client until
+   * it expires, JWT-style) doesn't re-hit Blocksync on every request.
+   */
+  private async validateInvocation(
+    invocation: string,
+  ): Promise<CachedInvocationAuth | null> {
+    const oracleDid = this.configService.get<string>('ORACLE_DID');
+    if (!oracleDid) {
+      this.logger.warn(
+        '[UCAN] ORACLE_DID not configured, cannot validate invocation',
+      );
+      return null;
+    }
+
+    const cacheKey = `ucan_inv_${this.hashToken(invocation)}`;
+    const cached = await this.cacheManager.get<CachedInvocationAuth>(cacheKey);
+    if (cached && cached.expiration * 1000 > Date.now()) {
+      return cached;
+    }
+
+    const blocksyncUri = this.configService.getOrThrow<string>(
+      'BLOCKSYNC_GRAPHQL_URL',
+    );
+    const maxTtlSeconds =
+      Number(this.configService.get('UCAN_AUTH_MAX_TTL_SECONDS')) ||
+      DEFAULT_UCAN_AUTH_MAX_TTL_SECONDS;
+
+    const outcome = await validateUcanInvocation(invocation, {
+      oracleDid,
+      blocksyncUri,
+      maxTtlSeconds,
+    });
+    if (!outcome.ok) {
+      this.logger.warn(`[UCAN] Invocation validation failed: ${outcome.error}`);
+      return null;
+    }
+
+    const result: CachedInvocationAuth = {
+      userDid: outcome.result.userDid,
+      expiration: outcome.result.expiration,
     };
-  } | null> {
+    // TTL = the token's own remaining lifetime, so we never serve a cached
+    // result past the point the token itself would have expired.
+    const ttl = result.expiration * 1000 - Date.now();
+    if (ttl > 0) {
+      await this.cacheManager.set(cacheKey, result, ttl);
+    }
+    this.logger.debug(`[UCAN] Invocation auth for DID: ${result.userDid}`);
+    return result;
+  }
+
+  /**
+   * Validate a delegation header (cached by hash). Returns the validated
+   * invoker + delegation metadata, or null on failure.
+   */
+  private async validateDelegation(
+    ucanHeader: string,
+  ): Promise<CachedDelegationAuth | null> {
     const oracleDid = this.configService.get<string>('ORACLE_DID');
     if (!oracleDid) {
       this.logger.warn(
@@ -79,6 +158,10 @@ export class AuthHeaderMiddleware implements NestMiddleware {
       );
       return null;
     }
+
+    const cacheKey = `ucan_auth_${this.hashToken(ucanHeader)}`;
+    const cached = await this.cacheManager.get<CachedDelegationAuth>(cacheKey);
+    if (cached) return cached;
 
     const blocksyncUri = this.configService.getOrThrow<string>(
       'BLOCKSYNC_GRAPHQL_URL',
@@ -88,18 +171,17 @@ export class AuthHeaderMiddleware implements NestMiddleware {
       oracleDid,
       blocksyncUri,
     });
-
     if (!outcome.ok) {
       this.logger.warn(`[UCAN] Delegation validation failed: ${outcome.error}`);
       return null;
     }
 
-    const { delegation } = outcome.result;
-    this.logger.log(
-      `[UCAN] Delegation validated: iss=${outcome.result.userDid} aud=${oracleDid} exp=${delegation.expiration ? new Date(delegation.expiration * 1000).toISOString() : 'none'}`,
-    );
-
-    return outcome.result;
+    const result: CachedDelegationAuth = outcome.result;
+    const ttl = result.delegation.expiration
+      ? Math.max(0, result.delegation.expiration * 1000 - Date.now())
+      : THREE_MINUTES;
+    await this.cacheManager.set(cacheKey, result, ttl);
+    return result;
   }
 
   async use(req: Request, _res: Response, next: NextFunction): Promise<void> {
@@ -107,73 +189,72 @@ export class AuthHeaderMiddleware implements NestMiddleware {
       `AuthHeaderMiddleware processing request for: ${req.originalUrl}`,
     );
     try {
-      const ucanHeader = req.headers['x-ucan-delegation'] as string | undefined;
-      if (!ucanHeader) {
-        throw new HttpException(
-          'Missing x-ucan-delegation header',
-          HttpStatus.UNAUTHORIZED,
-        );
-      }
+      const invocation = this.extractInvocation(req);
+      const delegationHeader = req.headers['x-ucan-delegation'] as
+        | string
+        | undefined;
 
-      const ucanHash = this.hashToken(ucanHeader);
-      const cachedUcan = await this.cacheManager.get<CachedUcanAuth>(
-        `ucan_auth_${ucanHash}`,
-      );
+      // Validate the delegation once (if sent). Reused below for downstream
+      // authorization and, for pre-invocation clients, as the auth fallback.
+      const delegationResult = delegationHeader
+        ? await this.validateDelegation(delegationHeader)
+        : null;
 
-      if (cachedUcan) {
-        req.authData = {
-          did: cachedUcan.userDid,
-          ucanDelegation: { ...cachedUcan.delegation, raw: ucanHeader },
-        };
-
-        // Re-cache raw delegation for downstream invocations
-        await this.ucanService.cacheDelegation(
-          cachedUcan.userDid,
-          ucanHeader,
-          cachedUcan.delegation.expiration,
-        );
-
+      // Authenticated identity: a user-signed invocation is the primary auth.
+      // A bare delegation is accepted only as a migration fallback.
+      let authedDid: string | null = null;
+      if (invocation) {
+        const inv = await this.validateInvocation(invocation);
+        if (!inv) {
+          throw new HttpException(
+            'Invalid UCAN invocation',
+            HttpStatus.UNAUTHORIZED,
+          );
+        }
+        authedDid = inv.userDid;
+      } else if (delegationResult) {
+        authedDid = delegationResult.userDid;
         this.logger.debug(
-          `[UCAN] Auth from cache for DID: ${cachedUcan.userDid}`,
+          '[UCAN] Authenticated via delegation fallback (no invocation)',
         );
-        next();
-        return;
       }
 
-      const ucanResult = await this.validateUcanDelegation(ucanHeader);
-      if (!ucanResult) {
+      if (!authedDid) {
         throw new HttpException(
-          'Invalid UCAN delegation',
+          'Missing UCAN authentication: provide Authorization: Bearer <invocation> with X-Auth-Type: ucan, or an x-ucan-delegation header',
           HttpStatus.UNAUTHORIZED,
         );
       }
 
-      req.authData = {
-        did: ucanResult.userDid,
-        ucanDelegation: { ...ucanResult.delegation, raw: ucanHeader },
-      };
+      // Downstream authorization: a delegation is public/shareable, so only
+      // trust it when it was issued BY the authenticated user. Otherwise a
+      // client could pair their own invocation with someone else's delegation
+      // and make the oracle act on that person's behalf downstream.
+      if (delegationResult && delegationResult.userDid === authedDid) {
+        req.authData = {
+          did: authedDid,
+          ucanDelegation: {
+            ...delegationResult.delegation,
+            raw: delegationHeader as string,
+          },
+        };
+        await this.ucanService.cacheDelegation(
+          authedDid,
+          delegationHeader as string,
+          delegationResult.delegation.expiration,
+        );
+      } else {
+        if (delegationResult && delegationResult.userDid !== authedDid) {
+          this.logger.warn(
+            `[UCAN] Ignoring delegation for downstream: issuer ${delegationResult.userDid} != authenticated ${authedDid}`,
+          );
+        }
+        req.authData = {
+          did: authedDid,
+          ucanDelegation: { raw: '', issuer: '', audience: '', capabilities: [] },
+        };
+      }
 
-      // Cache auth result
-      const ttl = ucanResult.delegation.expiration
-        ? Math.max(0, ucanResult.delegation.expiration * 1000 - Date.now())
-        : THREE_MINUTES;
-      await this.cacheManager.set(
-        `ucan_auth_${ucanHash}`,
-        {
-          userDid: ucanResult.userDid,
-          delegation: ucanResult.delegation,
-        } satisfies CachedUcanAuth,
-        ttl,
-      );
-
-      // Cache raw delegation for downstream service invocations
-      await this.ucanService.cacheDelegation(
-        ucanResult.userDid,
-        ucanHeader,
-        ucanResult.delegation.expiration,
-      );
-
-      this.logger.debug(`[UCAN] Auth completed for DID: ${ucanResult.userDid}`);
       next();
     } catch (error) {
       if (error instanceof HttpException) {

--- a/packages/oracle-runtime/src/modules/auth/validate-ucan-invocation.ts
+++ b/packages/oracle-runtime/src/modules/auth/validate-ucan-invocation.ts
@@ -1,0 +1,105 @@
+import {
+  createIxoDIDResolver,
+  createUCANValidator,
+  defineCapability,
+} from '@ixo/ucan';
+
+/**
+ * Default upper bound on how long an auth invocation may live. The middleware
+ * and WS gateway read `UCAN_AUTH_MAX_TTL_SECONDS` from config and fall back to
+ * this when it isn't set.
+ */
+export const DEFAULT_UCAN_AUTH_MAX_TTL_SECONDS = 900; // 15 minutes
+
+/**
+ * The capability the oracle accepts for *authentication* invocations. The
+ * client invokes `{ can: '*', with: 'ixo:oracle' }`; the
+ * server accepts any action (`can: '*'`) on the `ixo:` protocol and pins the
+ * resource to `ixo:oracle`. The invocation carries no delegation proofs — the
+ * user signs it as the root issuer, so it proves *who* is calling and nothing
+ * more. Authorization (what the oracle may do downstream) stays with the
+ * separate user→oracle delegation.
+ */
+const ORACLE_AUTH_RESOURCE = 'ixo:oracle';
+const OracleAuthCapability = defineCapability({ can: '*', protocol: 'ixo:' });
+
+/** The validated identity extracted from an auth invocation. */
+export interface ValidatedUcanInvocation {
+  userDid: string;
+  /** Effective expiry (unix seconds). Always present — auth tokens must expire. */
+  expiration: number;
+}
+
+export interface ValidateUcanInvocationOptions {
+  /** The oracle's DID — the expected invocation audience (serverDid). */
+  oracleDid: string;
+  /** Blocksync GraphQL endpoint used to resolve `did:ixo` verification keys. */
+  blocksyncUri: string;
+  /**
+   * Reject invocations whose effective expiry is further than this many seconds
+   * in the future. Bounds the replay window server-side regardless of the TTL
+   * the client declares.
+   */
+  maxTtlSeconds: number;
+}
+
+export type ValidateUcanInvocationOutcome =
+  | { ok: true; result: ValidatedUcanInvocation }
+  | { ok: false; error: string };
+
+/**
+ * Validate a user-signed UCAN auth invocation against this oracle. Shared by
+ * the HTTP `AuthHeaderMiddleware` and the WebSocket gateway so both transports
+ * authenticate identically — the returned `userDid` is the validated invoker
+ * (the invocation's signer), never a value the client claimed for itself.
+ *
+ * Unlike a delegation, an invocation is a single, short-lived assertion of
+ * "this user is calling now" — the replay window is its TTL, which we clamp.
+ */
+export async function validateUcanInvocation(
+  invocation: string,
+  opts: ValidateUcanInvocationOptions,
+): Promise<ValidateUcanInvocationOutcome> {
+  const validator = await createUCANValidator({
+    serverDid: opts.oracleDid,
+    // A user authenticates by self-signing a root invocation (no proofs), so
+    // any DID must be accepted as a root issuer. Authorization is enforced
+    // separately via the delegation chain on downstream services.
+    rootIssuers: ['*'],
+    didResolver: createIxoDIDResolver({ indexerUrl: opts.blocksyncUri }),
+  });
+
+  const result = await validator.validate(
+    invocation,
+    OracleAuthCapability,
+    ORACLE_AUTH_RESOURCE,
+  );
+
+  if (!result.ok) {
+    return {
+      ok: false,
+      error: `[${result.error?.code}] ${result.error?.message}`,
+    };
+  }
+
+  if (!result.invoker) {
+    return { ok: false, error: 'Invocation validated without an invoker DID' };
+  }
+
+  // Auth tokens must expire, and must not outlive the configured replay window.
+  if (typeof result.expiration !== 'number' || !isFinite(result.expiration)) {
+    return { ok: false, error: 'Auth invocation must declare an expiration' };
+  }
+  const nowSeconds = Math.floor(Date.now() / 1000);
+  if (result.expiration > nowSeconds + opts.maxTtlSeconds) {
+    return {
+      ok: false,
+      error: `Auth invocation TTL exceeds maximum of ${opts.maxTtlSeconds}s`,
+    };
+  }
+
+  return {
+    ok: true,
+    result: { userDid: result.invoker, expiration: result.expiration },
+  };
+}

--- a/packages/oracle-runtime/src/modules/health/health.controller.ts
+++ b/packages/oracle-runtime/src/modules/health/health.controller.ts
@@ -1,5 +1,6 @@
 import { Controller, Get } from '@nestjs/common';
 import { ApiOperation, ApiTags } from '@nestjs/swagger';
+import { Throttle } from '@nestjs/throttler';
 
 /**
  * Always-on health surface. Both routes are excluded from the auth
@@ -11,6 +12,12 @@ import { ApiOperation, ApiTags } from '@nestjs/swagger';
 @Controller()
 export class HealthController {
   @Get()
+  @Throttle({
+    default: {
+      ttl: 60000, // 1 minute
+      limit: 30, // 30 requests
+    },
+  })
   @ApiOperation({ summary: 'Root — oracle landing.' })
   root() {
     return {

--- a/packages/oracle-runtime/src/modules/messages/agent-builder.test.ts
+++ b/packages/oracle-runtime/src/modules/messages/agent-builder.test.ts
@@ -1,6 +1,9 @@
+import type { Cache } from '@nestjs/cache-manager';
+import type { ConfigService } from '@nestjs/config';
 import type { BaseCheckpointSaver } from '@langchain/langgraph';
 import { HumanMessage, fakeModel } from 'langchain';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { UcanService } from '../ucan/ucan.service.js';
 import type {
   CompiledMainAgent,
   MainAgentArgs,
@@ -36,6 +39,23 @@ const createMainAgentMock = vi.fn();
 vi.mock('../../graph/main-agent.js', () => ({
   createMainAgent: (...args: unknown[]) => createMainAgentMock(...args),
 }));
+
+// Mock MatrixManager.getInstance().sendMatrixEvent so the re-auth nudge path
+// can be asserted without a real Matrix client. Keep the rest of @ixo/matrix
+// intact (other modules import from it) by spreading the actual module.
+const { sendMatrixEventMock } = vi.hoisted(() => ({
+  sendMatrixEventMock: vi.fn(async () => 'event-id'),
+}));
+vi.mock('@ixo/matrix', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@ixo/matrix')>();
+  return {
+    ...actual,
+    MatrixManager: {
+      ...actual.MatrixManager,
+      getInstance: () => ({ sendMatrixEvent: sendMatrixEventMock }),
+    },
+  };
+});
 
 const USER_DID = 'did:ixo:user-1';
 const SESSION_ID = 'sess-1';
@@ -147,6 +167,9 @@ interface Harness {
   builder: AgentBuilder;
   bundleHolder: { get: ReturnType<typeof vi.fn> };
   fetchMock: ReturnType<typeof vi.fn>;
+  getDelegationMock: ReturnType<typeof vi.fn>;
+  cacheGetMock: ReturnType<typeof vi.fn>;
+  cacheSetMock: ReturnType<typeof vi.fn>;
   bundle: OracleRuntimeBundle;
 }
 
@@ -159,6 +182,8 @@ function buildHarness(
       userDid: string;
       sessionId: string;
     }) => Promise<Record<string, unknown> | undefined>;
+    getDelegationImpl?: (userDid: string) => Promise<string | null>;
+    configValues?: Record<string, unknown>;
   } = {},
 ): Harness {
   const bundle = overrides.bundle ?? makeBundle();
@@ -178,12 +203,45 @@ function buildHarness(
     fetch: fetchMock,
   } as unknown as UserContextFetcher;
 
+  const getDelegationMock = vi.fn(
+    overrides.getDelegationImpl ?? (async () => null),
+  );
+  const ucan = {
+    getDelegationForUser: getDelegationMock,
+  } as unknown as UcanService;
+
+  const configValues = overrides.configValues ?? {};
+  const config = {
+    get: vi.fn((key: string) => configValues[key]),
+  } as unknown as ConfigService;
+
+  const cacheStore = new Map<string, unknown>();
+  const cacheGetMock = vi.fn(async (k: string) => cacheStore.get(k));
+  const cacheSetMock = vi.fn(async (k: string, v: unknown) => {
+    cacheStore.set(k, v);
+  });
+  const cacheManager = {
+    get: cacheGetMock,
+    set: cacheSetMock,
+  } as unknown as Cache;
+
   const builder = new AgentBuilder(
     bundleHolder as unknown as OracleRuntimeBundleHolder,
     userContextFetcher,
+    ucan,
+    config,
+    cacheManager,
   );
 
-  return { builder, bundleHolder, fetchMock, bundle };
+  return {
+    builder,
+    bundleHolder,
+    fetchMock,
+    getDelegationMock,
+    cacheGetMock,
+    cacheSetMock,
+    bundle,
+  };
 }
 
 function lastMainAgentArgs(): MainAgentArgs {
@@ -198,6 +256,7 @@ describe('AgentBuilder', () => {
 
   beforeEach(() => {
     vi.resetAllMocks();
+    sendMatrixEventMock.mockResolvedValue('event-id');
     compiledAgent = {
       invoke: vi.fn(),
       streamEvents: vi.fn(),
@@ -395,6 +454,105 @@ describe('AgentBuilder', () => {
         capabilities?: ReadonlyArray<{ resource: string; action: string }>;
       };
       expect(ctxUcan).toEqual({ raw: '' });
+    });
+
+    it('does NOT read-through a delegation on the portal path (delegation absent)', async () => {
+      const { builder, getDelegationMock } = buildHarness();
+
+      await builder.build(
+        makeArgs({ payload: { ucanDelegation: undefined } }),
+      );
+
+      expect(getDelegationMock).not.toHaveBeenCalled();
+      expect(sendMatrixEventMock).not.toHaveBeenCalled();
+    });
+
+    it('reads the stored delegation through on a Matrix turn and uses it as raw', async () => {
+      const { builder, getDelegationMock } = buildHarness({
+        getDelegationImpl: async () => 'stored-raw-delegation',
+      });
+
+      await builder.build(
+        makeArgs({
+          payload: { clientType: 'matrix', ucanDelegation: undefined },
+        }),
+      );
+
+      expect(getDelegationMock).toHaveBeenCalledWith(USER_DID);
+      const ctxUcan = lastMainAgentArgs().requestCtx.user.ucanDelegation as {
+        raw: string;
+      };
+      expect(ctxUcan.raw).toBe('stored-raw-delegation');
+      // Found a delegation → no re-auth nudge.
+      expect(sendMatrixEventMock).not.toHaveBeenCalled();
+    });
+
+    it('falls back to {raw: ""} and emits a throttled delegation-required event when a Matrix turn has no stored delegation', async () => {
+      const { builder, getDelegationMock, cacheSetMock } = buildHarness({
+        getDelegationImpl: async () => null,
+        configValues: {
+          ORACLE_ENTITY_DID: 'did:ixo:entity',
+          ORACLE_DID: 'did:ixo:oracleacct',
+        },
+      });
+
+      await builder.build(
+        makeArgs({
+          payload: { clientType: 'matrix', ucanDelegation: undefined },
+        }),
+      );
+
+      expect(getDelegationMock).toHaveBeenCalledWith(USER_DID);
+      const ctxUcan = lastMainAgentArgs().requestCtx.user.ucanDelegation as {
+        raw: string;
+      };
+      expect(ctxUcan.raw).toBe('');
+      expect(sendMatrixEventMock).toHaveBeenCalledTimes(1);
+      expect(sendMatrixEventMock).toHaveBeenCalledWith(
+        ROOM_ID,
+        'ixo.oracle.delegation_required',
+        { oracleEntityDid: 'did:ixo:entity', oracleDid: 'did:ixo:oracleacct' },
+      );
+      // Throttle key written so the next miss is suppressed.
+      expect(cacheSetMock).toHaveBeenCalledWith(
+        `ucan_reauth_prompt_${USER_DID}`,
+        true,
+        expect.any(Number),
+      );
+    });
+
+    it('skips the re-auth prompt when the throttle key is already set', async () => {
+      const { builder, cacheGetMock } = buildHarness({
+        getDelegationImpl: async () => null,
+      });
+      cacheGetMock.mockResolvedValue(true);
+
+      await builder.build(
+        makeArgs({
+          payload: { clientType: 'matrix', ucanDelegation: undefined },
+        }),
+      );
+
+      expect(sendMatrixEventMock).not.toHaveBeenCalled();
+    });
+
+    it('honours UCAN_REAUTH_PROMPT_THROTTLE_SECONDS for the throttle TTL', async () => {
+      const { builder, cacheSetMock } = buildHarness({
+        getDelegationImpl: async () => null,
+        configValues: { UCAN_REAUTH_PROMPT_THROTTLE_SECONDS: 100 },
+      });
+
+      await builder.build(
+        makeArgs({
+          payload: { clientType: 'matrix', ucanDelegation: undefined },
+        }),
+      );
+
+      expect(cacheSetMock).toHaveBeenCalledWith(
+        `ucan_reauth_prompt_${USER_DID}`,
+        true,
+        100 * 1000,
+      );
     });
 
     it('produces langGraphConfig with version="v2" and forwards abortController.signal', async () => {

--- a/packages/oracle-runtime/src/modules/messages/agent-builder.test.ts
+++ b/packages/oracle-runtime/src/modules/messages/agent-builder.test.ts
@@ -459,9 +459,7 @@ describe('AgentBuilder', () => {
     it('does NOT read-through a delegation on the portal path (delegation absent)', async () => {
       const { builder, getDelegationMock } = buildHarness();
 
-      await builder.build(
-        makeArgs({ payload: { ucanDelegation: undefined } }),
-      );
+      await builder.build(makeArgs({ payload: { ucanDelegation: undefined } }));
 
       expect(getDelegationMock).not.toHaveBeenCalled();
       expect(sendMatrixEventMock).not.toHaveBeenCalled();

--- a/packages/oracle-runtime/src/modules/messages/agent-builder.ts
+++ b/packages/oracle-runtime/src/modules/messages/agent-builder.ts
@@ -1,5 +1,8 @@
+import { MatrixManager } from '@ixo/matrix';
+import { type Cache, CACHE_MANAGER } from '@nestjs/cache-manager';
 import type { BaseCheckpointSaver } from '@langchain/langgraph';
-import { Injectable, Logger } from '@nestjs/common';
+import { Inject, Injectable, Logger } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
 import { type BaseMessage } from 'langchain';
 import type {
   CompiledMainAgent,
@@ -9,6 +12,7 @@ import { createMainAgent } from '../../graph/main-agent.js';
 import type { TMainAgentGraphState } from '../../graph/state.js';
 import { didToMatrixUserId } from '../../matrix/user-id.js';
 import type { UcanDelegation } from '../../plugin-api/types.js';
+import { UcanService } from '../ucan/ucan.service.js';
 import { UserPreferencesService } from '../../plugins/user-preferences/service/user-preferences.service.js';
 import type { SendMessageRequest } from './messages.service.js';
 import { OracleRuntimeBundleHolder } from './oracle-runtime-bundle.js';
@@ -70,9 +74,18 @@ export interface BuiltAgent {
 export class AgentBuilder {
   private readonly logger = new Logger(AgentBuilder.name);
 
+  /**
+   * Default throttle window for the Matrix re-auth prompt: one prompt per
+   * user per 6 hours. Overridable via `UCAN_REAUTH_PROMPT_THROTTLE_SECONDS`.
+   */
+  private static readonly DEFAULT_REAUTH_THROTTLE_SECONDS = 6 * 60 * 60;
+
   constructor(
     private readonly bundleHolder: OracleRuntimeBundleHolder,
     private readonly userContextFetcher: UserContextFetcher,
+    private readonly ucan: UcanService,
+    private readonly config: ConfigService,
+    @Inject(CACHE_MANAGER) private readonly cacheManager: Cache,
   ) {}
 
   async build(
@@ -124,30 +137,59 @@ export class AgentBuilder {
       `[AgentBuilder] resolving prompt enrichments — roomId=${prepared.roomId}, did=${payload.did}`,
     );
 
+    const clientType: 'portal' | 'matrix' | 'slack' =
+      payload.clientType ?? 'portal';
+
+    // On the Matrix ingress path the request carries no per-user UCAN
+    // delegation header (the bot acts as the user's agent, not as the user).
+    // Read the durably-stored delegation through so Matrix turns get UCAN
+    // tooling. Folded into the same `Promise.all` so it adds no serial
+    // round-trip; best-effort (falls back to no delegation on failure).
+    const needsMatrixDelegation =
+      clientType === 'matrix' && !payload.ucanDelegation;
+
     const userPrefsService = UserPreferencesService.getInstance();
-    const [freshUserContext, freshUserPreferences] = await Promise.all([
-      this.userContextFetcher
-        .fetch({
-          roomId: prepared.roomId,
-          userDid: payload.did,
-          sessionId: prepared.sessionId,
-        })
-        .catch((err) => {
+    const [freshUserContext, freshUserPreferences, matrixDelegationRaw] =
+      await Promise.all([
+        this.userContextFetcher
+          .fetch({
+            roomId: prepared.roomId,
+            userDid: payload.did,
+            sessionId: prepared.sessionId,
+          })
+          .catch((err) => {
+            this.logger.warn(
+              `[AgentBuilder] userContext fetch failed: ${err instanceof Error ? err.message : String(err)}`,
+            );
+            return undefined;
+          }),
+        userPrefsService.get(prepared.roomId).catch((err) => {
           this.logger.warn(
-            `[AgentBuilder] userContext fetch failed: ${err instanceof Error ? err.message : String(err)}`,
+            `[AgentBuilder] userPreferences fetch failed: ${err instanceof Error ? err.message : String(err)}`,
           );
           return undefined;
         }),
-      userPrefsService.get(prepared.roomId).catch((err) => {
-        this.logger.warn(
-          `[AgentBuilder] userPreferences fetch failed: ${err instanceof Error ? err.message : String(err)}`,
-        );
-        return undefined;
-      }),
-    ]);
+        needsMatrixDelegation
+          ? this.ucan
+              .getDelegationForUser(payload.did)
+              .catch((err) => {
+                this.logger.warn(
+                  `[AgentBuilder] delegation read-through failed: ${err instanceof Error ? err.message : String(err)}`,
+                );
+                return null;
+              })
+          : Promise.resolve(null),
+      ]);
 
     const userContext = freshUserContext ?? priorState.userContext;
     const userPreferences = freshUserPreferences ?? priorState.userPreferences;
+
+    // No valid stored delegation on a Matrix turn → emit a throttled
+    // delegation-required event (the web app opens the authorize modal) and
+    // proceed without UCAN tooling.
+    if (needsMatrixDelegation && !matrixDelegationRaw) {
+      await this.maybePromptReauth(payload.did, prepared.roomId);
+    }
 
     this.logger.log(
       `[AgentBuilder] prompt enrichments resolved — userContext: ${
@@ -165,9 +207,6 @@ export class AgentBuilder {
       }`,
     );
 
-    const clientType: 'portal' | 'matrix' | 'slack' =
-      payload.clientType ?? 'portal';
-
     const ucanDelegation: UcanDelegation = payload.ucanDelegation
       ? {
           raw: payload.ucanDelegation.raw,
@@ -184,10 +223,11 @@ export class AgentBuilder {
             })),
         }
       : {
-          // Matrix listener path has no per-user UCAN — the bot acts as
-          // the oracle, not as a user. Plugins that need a delegation
-          // should branch on `raw.length === 0` and skip the mint.
-          raw: '',
+          // Matrix path has no per-request delegation header. We read the
+          // durably-stored one through above; when present the plugins get
+          // UCAN tooling, otherwise `raw: ''` and they branch on
+          // `raw.length === 0` to skip the mint.
+          raw: matrixDelegationRaw ?? '',
         };
 
     const requestCtx: MainAgentRequestContext = {
@@ -266,5 +306,55 @@ export class AgentBuilder {
     };
 
     return { agent, stateInput, langGraphConfig };
+  }
+
+  /**
+   * Emit a single throttled `ixo.oracle.delegation_required` event into the
+   * user's Matrix room when a Matrix turn finds no valid delegation. The web
+   * app listens for this event and opens the "authorize for Matrix" modal
+   * in-place; the payload is self-contained (carries the oracle entity DID the
+   * FE needs to mint + store a delegation), so the listener's location doesn't
+   * matter. Throttled per user via the cache manager (key
+   * `ucan_reauth_prompt_${userDid}`, TTL from
+   * `UCAN_REAUTH_PROMPT_THROTTLE_SECONDS`, default 6h). Best-effort — never
+   * throws, so a Matrix-send failure can't break the turn.
+   */
+  private async maybePromptReauth(
+    userDid: string,
+    roomId: string,
+  ): Promise<void> {
+    try {
+      const throttleKey = `ucan_reauth_prompt_${userDid}`;
+      const already = await this.cacheManager.get(throttleKey);
+      if (already) {
+        this.logger.debug(
+          `[AgentBuilder] delegation-required event throttled for ${userDid} (already prompted within the window)`,
+        );
+        return;
+      }
+
+      const throttleSeconds =
+        this.config.get<number>('UCAN_REAUTH_PROMPT_THROTTLE_SECONDS') ??
+        AgentBuilder.DEFAULT_REAUTH_THROTTLE_SECONDS;
+
+      await this.cacheManager.set(throttleKey, true, throttleSeconds * 1000);
+
+      await MatrixManager.getInstance().sendMatrixEvent(
+        roomId,
+        'ixo.oracle.delegation_required',
+        {
+          oracleEntityDid: this.config.get<string>('ORACLE_ENTITY_DID'),
+          oracleDid: this.config.get<string>('ORACLE_DID'),
+        },
+      );
+
+      this.logger.log(
+        `[AgentBuilder] sent ixo.oracle.delegation_required to room ${roomId} for ${userDid}`,
+      );
+    } catch (err) {
+      this.logger.warn(
+        `[AgentBuilder] delegation-required event failed: ${err instanceof Error ? err.message : String(err)}`,
+      );
+    }
   }
 }

--- a/packages/oracle-runtime/src/modules/messages/agent-builder.ts
+++ b/packages/oracle-runtime/src/modules/messages/agent-builder.ts
@@ -170,14 +170,12 @@ export class AgentBuilder {
           return undefined;
         }),
         needsMatrixDelegation
-          ? this.ucan
-              .getDelegationForUser(payload.did)
-              .catch((err) => {
-                this.logger.warn(
-                  `[AgentBuilder] delegation read-through failed: ${err instanceof Error ? err.message : String(err)}`,
-                );
-                return null;
-              })
+          ? this.ucan.getDelegationForUser(payload.did).catch((err) => {
+              this.logger.warn(
+                `[AgentBuilder] delegation read-through failed: ${err instanceof Error ? err.message : String(err)}`,
+              );
+              return null;
+            })
           : Promise.resolve(null),
       ]);
 

--- a/packages/oracle-runtime/src/modules/messages/delegation.controller.ts
+++ b/packages/oracle-runtime/src/modules/messages/delegation.controller.ts
@@ -1,0 +1,91 @@
+import {
+  Body,
+  Controller,
+  Delete,
+  Get,
+  HttpCode,
+  HttpStatus,
+  Logger,
+  NotFoundException,
+  Post,
+  Req,
+} from '@nestjs/common';
+import { ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
+import type { Request } from 'express';
+import { UcanService } from '../ucan/ucan.service.js';
+import { StoreDelegationDto } from './dto/store-delegation.dto.js';
+
+/**
+ * Accepts a freshly-signed user→oracle UCAN delegation from the client and
+ * persists it durably (Matrix room state) plus warms the in-memory cache.
+ * The FE re-auth popup POSTs here. `AuthHeaderMiddleware` runs on every route
+ * and sets `req.authData.did`, so the user is already authenticated. The
+ * canonical user↔oracle room is resolved inside `UcanService`, so the store
+ * and the Matrix read-through can never target different rooms.
+ */
+@ApiTags('delegation')
+@Controller('delegation')
+export class DelegationController {
+  private readonly logger = new Logger(DelegationController.name);
+
+  constructor(private readonly ucan: UcanService) {}
+
+  @Post()
+  @HttpCode(HttpStatus.OK)
+  @ApiOperation({
+    summary: 'Store a user→oracle UCAN delegation for the authenticated user.',
+  })
+  @ApiResponse({ status: 200, description: 'Delegation stored.' })
+  @ApiResponse({ status: 401, description: 'Missing or invalid auth token.' })
+  @ApiResponse({ status: 404, description: 'User↔oracle room not found.' })
+  async storeDelegation(
+    @Req() req: Request,
+    @Body() body: StoreDelegationDto,
+  ): Promise<{ ok: true; expiration?: number }> {
+    const { did } = req.authData;
+
+    try {
+      await this.ucan.storeDelegationForUser(did, body.raw, {
+        issuer: body.issuer,
+        audience: body.audience,
+        expiration: body.expiration,
+      });
+    } catch (error) {
+      this.logger.warn(
+        `Failed to store delegation for userDid=${did}: ${
+          error instanceof Error ? error.message : String(error)
+        }`,
+      );
+      throw new NotFoundException('User↔oracle room not found');
+    }
+
+    this.logger.log(`Stored delegation for userDid=${did}`);
+    return { ok: true, expiration: body.expiration };
+  }
+
+  @Get()
+  @ApiOperation({
+    summary:
+      'Whether the authenticated user has authorized this oracle for Matrix.',
+  })
+  @ApiResponse({ status: 200, description: 'Authorization status.' })
+  @ApiResponse({ status: 401, description: 'Missing or invalid auth token.' })
+  async getStatus(
+    @Req() req: Request,
+  ): Promise<{ authorized: boolean; expiration?: number }> {
+    return this.ucan.getDelegationStatus(req.authData.did);
+  }
+
+  @Delete()
+  @HttpCode(HttpStatus.OK)
+  @ApiOperation({
+    summary: 'Revoke the stored delegation for the authenticated user.',
+  })
+  @ApiResponse({ status: 200, description: 'Delegation revoked.' })
+  @ApiResponse({ status: 401, description: 'Missing or invalid auth token.' })
+  async revokeDelegation(@Req() req: Request): Promise<{ ok: true }> {
+    await this.ucan.revokeDelegationForUser(req.authData.did);
+    this.logger.log(`Revoked delegation for userDid=${req.authData.did}`);
+    return { ok: true };
+  }
+}

--- a/packages/oracle-runtime/src/modules/messages/dto/store-delegation.dto.ts
+++ b/packages/oracle-runtime/src/modules/messages/dto/store-delegation.dto.ts
@@ -1,0 +1,45 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsNotEmpty, IsNumber, IsOptional, IsString } from 'class-validator';
+
+/**
+ * Body for `POST /delegation`. The client posts a freshly-signed user→oracle
+ * UCAN delegation (base64 CAR) after re-authorizing in the app. The
+ * delegation is authorization-only and safe to expose.
+ */
+export class StoreDelegationDto {
+  @ApiProperty({
+    description: 'Base64-encoded UCAN delegation CAR (user → oracle).',
+    required: true,
+    type: String,
+  })
+  @IsNotEmpty()
+  @IsString()
+  raw!: string;
+
+  @ApiProperty({
+    description: 'Delegation issuer DID (the user).',
+    required: false,
+    type: String,
+  })
+  @IsOptional()
+  @IsString()
+  issuer?: string;
+
+  @ApiProperty({
+    description: 'Delegation audience DID (this oracle).',
+    required: false,
+    type: String,
+  })
+  @IsOptional()
+  @IsString()
+  audience?: string;
+
+  @ApiProperty({
+    description: 'Delegation expiration as a unix timestamp (seconds).',
+    required: false,
+    type: Number,
+  })
+  @IsOptional()
+  @IsNumber()
+  expiration?: number;
+}

--- a/packages/oracle-runtime/src/modules/messages/matrix-listener-bridge.ts
+++ b/packages/oracle-runtime/src/modules/messages/matrix-listener-bridge.ts
@@ -250,11 +250,16 @@ export class MatrixListenerBridge implements OnModuleInit, OnModuleDestroy {
     const mentions = sourceContent['m.mentions'];
     const relatesTo = sourceContent['m.relates_to'];
 
-    const message =
+    const messageRAW =
       text ??
       (attachments.length === 1
         ? `User shared a file: ${attachments[0]?.filename ?? 'file'}`
         : `User shared ${attachments.length} file(s): ${attachments.map((a) => a.filename).join(', ')}`);
+
+    const message = messageRAW.replace(
+      this.config.getOrThrow('MATRIX_ORACLE_ADMIN_USER_ID'),
+      '(USER MENTIONED YOU @AI_AGENT)',
+    );
 
     if (!this.deliverHandler) {
       this.logger.warn(
@@ -264,6 +269,9 @@ export class MatrixListenerBridge implements OnModuleInit, OnModuleDestroy {
     }
 
     try {
+      await this.matrixManager
+        .getClient()
+        ?.mxClient.setTyping(first.roomId, true);
       const aiResponse = (await this.deliverHandler({
         did,
         message,
@@ -305,6 +313,10 @@ export class MatrixListenerBridge implements OnModuleInit, OnModuleDestroy {
       });
     } catch (error) {
       this.logger.error('Failed to handle Matrix message', error);
+    } finally {
+      await this.matrixManager
+        .getClient()
+        ?.mxClient.setTyping(first.roomId, false);
     }
   }
 

--- a/packages/oracle-runtime/src/modules/messages/messages.module.ts
+++ b/packages/oracle-runtime/src/modules/messages/messages.module.ts
@@ -7,6 +7,7 @@ import { UserMatrixSqliteSyncService } from '../../matrix/checkpointer/user-matr
 import { UcanModule } from '../ucan/ucan.module.js';
 import { AgentBuilder } from './agent-builder.js';
 import { BatchInvoker } from './batch-invoker.js';
+import { DelegationController } from './delegation.controller.js';
 import { FileProcessingService } from './file-processing.service.js';
 import { HomeServerCache } from './homeserver-cache.js';
 import { MatrixListenerBridge } from './matrix-listener-bridge.js';
@@ -20,7 +21,7 @@ import { UserContextFetcher } from './user-context-fetcher.js';
 
 @Module({
   imports: [CheckpointStorageSyncModule, UcanModule],
-  controllers: [MessagesController],
+  controllers: [MessagesController, DelegationController],
   providers: [
     MessagesService,
     FileProcessingService,

--- a/packages/oracle-runtime/src/modules/ucan/delegation-store.test.ts
+++ b/packages/oracle-runtime/src/modules/ucan/delegation-store.test.ts
@@ -1,0 +1,111 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  DelegationStore,
+  UCAN_DELEGATION_STATE_KEY,
+} from './delegation-store.js';
+
+// Stub the Matrix state manager behind MatrixManager.getInstance(). MatrixError
+// is a real subclass of Error carrying an `errcode` so the store's
+// M_NOT_FOUND branch can be exercised. Defined via `vi.hoisted` so the mock
+// factory (hoisted to the top of the file) can reference them.
+const { getStateMock, setStateMock, MockMatrixError } = vi.hoisted(() => {
+  class MockMatrixError extends Error {
+    constructor(public errcode: string) {
+      super(errcode);
+      this.name = 'MatrixError';
+    }
+  }
+  return {
+    getStateMock: vi.fn(),
+    setStateMock: vi.fn(),
+    MockMatrixError,
+  };
+});
+
+vi.mock('@ixo/matrix', () => ({
+  MatrixManager: {
+    getInstance: () => ({
+      stateManager: { getState: getStateMock, setState: setStateMock },
+    }),
+  },
+  MatrixError: MockMatrixError,
+}));
+
+const ROOM_ID = '!room:home';
+
+describe('DelegationStore', () => {
+  let store: DelegationStore;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    store = new DelegationStore();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe('read', () => {
+    it('returns the validated delegation when present', async () => {
+      const payload = {
+        raw: 'raw-car',
+        issuer: 'did:ixo:user',
+        audience: 'did:ixo:oracle',
+        expiration: 1234567890,
+        updatedAt: '2026-01-01T00:00:00.000Z',
+      };
+      getStateMock.mockResolvedValue(payload);
+
+      const result = await store.read(ROOM_ID);
+
+      expect(getStateMock).toHaveBeenCalledWith(
+        ROOM_ID,
+        UCAN_DELEGATION_STATE_KEY,
+      );
+      expect(result).toEqual(payload);
+    });
+
+    it('returns null on M_NOT_FOUND (nothing stored yet)', async () => {
+      getStateMock.mockRejectedValue(new MockMatrixError('M_NOT_FOUND'));
+
+      expect(await store.read(ROOM_ID)).toBeNull();
+    });
+
+    it('returns null and swallows other read errors', async () => {
+      getStateMock.mockRejectedValue(new Error('matrix down'));
+
+      expect(await store.read(ROOM_ID)).toBeNull();
+    });
+
+    it('returns null when the stored payload fails validation', async () => {
+      getStateMock.mockResolvedValue({ raw: 123 }); // raw must be a string
+
+      expect(await store.read(ROOM_ID)).toBeNull();
+    });
+  });
+
+  describe('write', () => {
+    it('persists the delegation and stamps updatedAt', async () => {
+      setStateMock.mockResolvedValue(undefined);
+
+      await store.write(ROOM_ID, {
+        raw: 'raw-car',
+        issuer: 'did:ixo:user',
+        audience: 'did:ixo:oracle',
+        expiration: 1234567890,
+      });
+
+      expect(setStateMock).toHaveBeenCalledTimes(1);
+      const arg = setStateMock.mock.calls[0]?.[0] as {
+        roomId: string;
+        stateKey: string;
+        data: { raw: string; updatedAt: string };
+      };
+      expect(arg.roomId).toBe(ROOM_ID);
+      expect(arg.stateKey).toBe(UCAN_DELEGATION_STATE_KEY);
+      expect(arg.data.raw).toBe('raw-car');
+      expect(typeof arg.data.updatedAt).toBe('string');
+      expect(Number.isNaN(Date.parse(arg.data.updatedAt))).toBe(false);
+    });
+  });
+});

--- a/packages/oracle-runtime/src/modules/ucan/delegation-store.ts
+++ b/packages/oracle-runtime/src/modules/ucan/delegation-store.ts
@@ -1,0 +1,108 @@
+import { MatrixError, MatrixManager } from '@ixo/matrix';
+import { Injectable, Logger } from '@nestjs/common';
+import { z } from 'zod';
+
+export const UCAN_DELEGATION_STATE_KEY = 'ucan_delegation';
+
+/**
+ * Persisted shape of a user→oracle UCAN delegation stored in the user's
+ * Matrix room state. The delegation is authorization-only and safe to expose
+ * (useless without the oracle's signing key or the user's invocation
+ * signature), so it is stored in PLAINTEXT room state — same path as
+ * `UserPreferencesService`, NOT the PIN-AES secret path.
+ */
+export const StoredDelegationSchema = z.object({
+  raw: z.string(),
+  issuer: z.string().optional(),
+  audience: z.string().optional(),
+  expiration: z.number().optional(),
+  updatedAt: z.string(),
+});
+export type StoredDelegation = z.infer<typeof StoredDelegationSchema>;
+
+/**
+ * Stores a per-room user→oracle UCAN delegation in Matrix room state.
+ *
+ * Mirrors `UserPreferencesService`: same `MatrixManager.getInstance()
+ * .stateManager` read/write, same Zod validation, same plaintext storage.
+ * The event type is `ixo.room.state` and the payload is auto-deflated by the
+ * state manager — identical to preferences.
+ *
+ * Injectable so consumers (`UcanService`) get it via Nest DI; unit-testable by
+ * stubbing `MatrixManager.getInstance().stateManager`.
+ */
+@Injectable()
+export class DelegationStore {
+  private readonly logger = new Logger(DelegationStore.name);
+
+  /**
+   * Read the stored delegation for a room. Returns null when none has been
+   * stored (`M_NOT_FOUND`), when the payload fails validation, or on any
+   * other read error — a missing delegation must never break a turn.
+   */
+  async read(roomId: string): Promise<StoredDelegation | null> {
+    let raw: unknown;
+    try {
+      const stateManager = MatrixManager.getInstance().stateManager;
+      raw = await stateManager.getState<unknown>(
+        roomId,
+        UCAN_DELEGATION_STATE_KEY,
+      );
+    } catch (error) {
+      if (error instanceof MatrixError && error.errcode === 'M_NOT_FOUND') {
+        return null;
+      }
+      this.logger.warn(
+        `[DelegationStore] Failed to load delegation for room ${roomId}: ${
+          error instanceof Error ? error.message : String(error)
+        }`,
+      );
+      return null;
+    }
+
+    const parsed = StoredDelegationSchema.safeParse(raw);
+    if (!parsed.success) {
+      this.logger.warn(
+        `[DelegationStore] Invalid delegation payload for room ${roomId}: ${parsed.error.message}`,
+      );
+      return null;
+    }
+
+    return parsed.data;
+  }
+
+  /**
+   * Persist a delegation to room state. `updatedAt` is always set by this
+   * method; any caller-supplied `updatedAt` is overwritten.
+   */
+  async write(
+    roomId: string,
+    data: Omit<StoredDelegation, 'updatedAt'>,
+  ): Promise<void> {
+    const payload = StoredDelegationSchema.parse({
+      ...data,
+      updatedAt: new Date().toISOString(),
+    });
+
+    const stateManager = MatrixManager.getInstance().stateManager;
+    await stateManager.setState<StoredDelegation>({
+      roomId,
+      stateKey: UCAN_DELEGATION_STATE_KEY,
+      data: payload,
+    });
+  }
+
+  /**
+   * Revoke the stored delegation. Matrix state events can't be truly deleted,
+   * so we overwrite with empty content — a subsequent `read` then fails schema
+   * validation and returns null, i.e. "no delegation stored".
+   */
+  async delete(roomId: string): Promise<void> {
+    const stateManager = MatrixManager.getInstance().stateManager;
+    await stateManager.setState<Record<string, never>>({
+      roomId,
+      stateKey: UCAN_DELEGATION_STATE_KEY,
+      data: {},
+    });
+  }
+}

--- a/packages/oracle-runtime/src/modules/ucan/index.ts
+++ b/packages/oracle-runtime/src/modules/ucan/index.ts
@@ -5,6 +5,12 @@
 export { UcanModule } from './ucan.module.js';
 export { UcanService, type MCPValidationResult } from './ucan.service.js';
 export {
+  DelegationStore,
+  UCAN_DELEGATION_STATE_KEY,
+  StoredDelegationSchema,
+  type StoredDelegation,
+} from './delegation-store.js';
+export {
   createMCPUCANConfig,
   requiresUCANAuth,
   buildRequiredCapability,

--- a/packages/oracle-runtime/src/modules/ucan/ucan.module.ts
+++ b/packages/oracle-runtime/src/modules/ucan/ucan.module.ts
@@ -6,6 +6,7 @@
 
 import { Global, Module } from '@nestjs/common';
 import { ConfigModule } from '@nestjs/config';
+import { DelegationStore } from './delegation-store.js';
 import { UcanService } from './ucan.service.js';
 
 /**
@@ -32,7 +33,7 @@ import { UcanService } from './ucan.service.js';
 @Global()
 @Module({
   imports: [ConfigModule],
-  providers: [UcanService],
+  providers: [DelegationStore, UcanService],
   exports: [UcanService],
 })
 export class UcanModule {}

--- a/packages/oracle-runtime/src/modules/ucan/ucan.service.test.ts
+++ b/packages/oracle-runtime/src/modules/ucan/ucan.service.test.ts
@@ -1,7 +1,37 @@
 import type { Cache } from 'cache-manager';
 import type { ConfigService } from '@nestjs/config';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { DelegationStore, StoredDelegation } from './delegation-store.js';
 import { UcanService } from './ucan.service.js';
+
+const { getOracleRoomIdMock, getMatrixHomeServerMock } = vi.hoisted(() => ({
+  getOracleRoomIdMock: vi.fn(),
+  getMatrixHomeServerMock: vi.fn(),
+}));
+
+vi.mock('@ixo/matrix', () => ({
+  MatrixManager: {
+    getInstance: () => ({
+      getOracleRoomIdWithHomeServer: getOracleRoomIdMock,
+    }),
+  },
+}));
+
+vi.mock('@ixo/oracles-chain-client', () => ({
+  getMatrixHomeServerCroppedForDid: getMatrixHomeServerMock,
+}));
+
+interface DelegationStoreMock {
+  read: ReturnType<typeof vi.fn>;
+  write: ReturnType<typeof vi.fn>;
+}
+
+function makeDelegationStore(): DelegationStoreMock {
+  return {
+    read: vi.fn(async () => null as StoredDelegation | null),
+    write: vi.fn(async () => undefined),
+  };
+}
 
 interface CacheMock extends Partial<Cache> {
   store: Map<string, unknown>;
@@ -38,6 +68,7 @@ describe('UcanService', () => {
   let svc: UcanService;
   let cache: CacheMock;
   let cfg: ConfigService;
+  let delegationStore: DelegationStoreMock;
 
   beforeEach(() => {
     cache = makeCache();
@@ -45,7 +76,16 @@ describe('UcanService', () => {
       ORACLE_ENTITY_DID: ORACLE_DID,
       BLOCKSYNC_GRAPHQL_URL: 'https://blocksync.example/graphql',
     });
-    svc = new UcanService(cfg, cache as unknown as Cache);
+    delegationStore = makeDelegationStore();
+    // The canonical user↔oracle room is resolved inside UcanService now; mock
+    // the resolution so read/write still target a known room (`!room:home`).
+    getMatrixHomeServerMock.mockResolvedValue('home');
+    getOracleRoomIdMock.mockResolvedValue({ roomId: '!room:home' });
+    svc = new UcanService(
+      cfg,
+      cache as unknown as Cache,
+      delegationStore as unknown as DelegationStore,
+    );
   });
 
   afterEach(() => {
@@ -127,5 +167,83 @@ describe('UcanService', () => {
     const second = await svc.validateMCPInvocation('srv', 'tool', data);
     expect(second.valid).toBe(false);
     expect(second.error).toMatch(/replay/i);
+  });
+
+  describe('getDelegationForUser', () => {
+    const USER = 'did:ixo:user1';
+    const ROOM = '!room:home';
+
+    it('returns the cached delegation without touching the store (fast path)', async () => {
+      cache.store.set(`ucan_delegation_${USER}`, 'cached-raw');
+
+      const result = await svc.getDelegationForUser(USER);
+
+      expect(result).toBe('cached-raw');
+      expect(delegationStore.read).not.toHaveBeenCalled();
+    });
+
+    it('falls back to the store on cache miss, re-warms the cache, and returns raw', async () => {
+      const expiration = Math.floor(Date.now() / 1000) + 600;
+      delegationStore.read.mockResolvedValue({
+        raw: 'stored-raw',
+        issuer: 'did:ixo:user1',
+        audience: ORACLE_DID,
+        expiration,
+        updatedAt: new Date().toISOString(),
+      });
+
+      const result = await svc.getDelegationForUser(USER);
+
+      expect(delegationStore.read).toHaveBeenCalledWith(ROOM);
+      expect(result).toBe('stored-raw');
+      // Re-warmed so mintInvocationForServiceDid finds it downstream.
+      expect(await svc.getCachedDelegation(USER)).toBe('stored-raw');
+    });
+
+    it('returns null when the store has nothing', async () => {
+      delegationStore.read.mockResolvedValue(null);
+
+      expect(await svc.getDelegationForUser(USER)).toBeNull();
+    });
+
+    it('returns null (and does not re-warm) when the stored delegation is expired', async () => {
+      delegationStore.read.mockResolvedValue({
+        raw: 'expired-raw',
+        expiration: Math.floor(Date.now() / 1000) - 60,
+        updatedAt: new Date().toISOString(),
+      });
+
+      expect(await svc.getDelegationForUser(USER)).toBeNull();
+      expect(await svc.getCachedDelegation(USER)).toBeNull();
+    });
+
+    it('returns null when the store read throws (non-throwing contract)', async () => {
+      delegationStore.read.mockRejectedValue(new Error('matrix down'));
+
+      expect(await svc.getDelegationForUser(USER)).toBeNull();
+    });
+  });
+
+  describe('storeDelegationForUser', () => {
+    const USER = 'did:ixo:user1';
+    const ROOM = '!room:home';
+
+    it('writes to the store AND warms the in-memory cache', async () => {
+      const expiration = Math.floor(Date.now() / 1000) + 600;
+
+      await svc.storeDelegationForUser(USER, 'fresh-raw', {
+        issuer: USER,
+        audience: ORACLE_DID,
+        expiration,
+      });
+
+      expect(delegationStore.write).toHaveBeenCalledWith(ROOM, {
+        raw: 'fresh-raw',
+        issuer: USER,
+        audience: ORACLE_DID,
+        expiration,
+      });
+      expect(await svc.getCachedDelegation(USER)).toBe('fresh-raw');
+    });
   });
 });

--- a/packages/oracle-runtime/src/modules/ucan/ucan.service.ts
+++ b/packages/oracle-runtime/src/modules/ucan/ucan.service.ts
@@ -34,6 +34,9 @@ import {
   serializeInvocation,
   type SupportedDID,
 } from '@ixo/ucan';
+import { MatrixManager } from '@ixo/matrix';
+import { getMatrixHomeServerCroppedForDid } from '@ixo/oracles-chain-client';
+import { DelegationStore } from './delegation-store.js';
 
 // ============================================================================
 // Inline implementations (can be replaced with @ixo/ucan imports once built)
@@ -282,6 +285,7 @@ export class UcanService implements OnModuleDestroy {
   constructor(
     private readonly configService: ConfigService,
     @Inject(CACHE_MANAGER) private readonly cacheManager: Cache,
+    private readonly delegationStore: DelegationStore,
   ) {
     this.config = this.loadConfig();
 
@@ -407,6 +411,159 @@ export class UcanService implements OnModuleDestroy {
       `${DELEGATION_CACHE_PREFIX}${userDid}`,
     );
     return cached ?? null;
+  }
+
+  /**
+   * Read-through resolution of a user's delegation, used by ingress paths
+   * (e.g. Matrix turns) that don't carry a per-request delegation header.
+   *
+   * 1. Fast path: in-memory cache (`getCachedDelegation`).
+   * 2. On miss: durable Matrix room state (`delegationStore.read`).
+   * 3. Drop expired stored delegations (`expiration` is unix seconds).
+   * 4. Re-warm the in-memory cache so the existing
+   *    `mintInvocationForServiceDid` (which looks up by
+   *    `getCachedDelegation(userDid)`) works downstream with no further
+   *    plumbing.
+   *
+   * Non-throwing: any store error logs and returns null so the turn can
+   * proceed without UCAN tooling rather than failing.
+   */
+  async getDelegationForUser(userDid: string): Promise<string | null> {
+    const cached = await this.getCachedDelegation(userDid);
+    if (cached) {
+      return cached;
+    }
+
+    const roomId = await this.resolveUserOracleRoomId(userDid);
+    if (!roomId) {
+      return null;
+    }
+
+    let stored: Awaited<ReturnType<DelegationStore['read']>>;
+    try {
+      stored = await this.delegationStore.read(roomId);
+    } catch (error) {
+      this.logger.warn(
+        `[UCAN] Failed to read stored delegation for ${userDid} (room ${roomId}): ${
+          error instanceof Error ? error.message : String(error)
+        }`,
+      );
+      return null;
+    }
+
+    if (!stored) {
+      return null;
+    }
+
+    const nowSeconds = Math.floor(Date.now() / 1000);
+    if (
+      typeof stored.expiration === 'number' &&
+      stored.expiration <= nowSeconds
+    ) {
+      this.logger.debug(
+        `[UCAN] Stored delegation for ${userDid} expired at ${stored.expiration}`,
+      );
+      return null;
+    }
+
+    await this.cacheDelegation(userDid, stored.raw, stored.expiration);
+    return stored.raw;
+  }
+
+  /**
+   * Durably persist a user's delegation (Matrix room state) AND warm the
+   * in-memory cache. Called by the `POST /delegation` endpoint when the
+   * client posts a freshly-signed delegation. Throws if the canonical
+   * user↔oracle room can't be resolved (the controller maps that to a 404).
+   */
+  async storeDelegationForUser(
+    userDid: string,
+    raw: string,
+    meta?: { issuer?: string; audience?: string; expiration?: number },
+  ): Promise<void> {
+    const roomId = await this.resolveUserOracleRoomId(userDid);
+    if (!roomId) {
+      throw new Error(
+        `Could not resolve the user↔oracle Matrix room for ${userDid}`,
+      );
+    }
+    await this.delegationStore.write(roomId, {
+      raw,
+      issuer: meta?.issuer,
+      audience: meta?.audience,
+      expiration: meta?.expiration,
+    });
+    await this.cacheDelegation(userDid, raw, meta?.expiration);
+  }
+
+  /**
+   * Whether the user currently has a valid stored delegation for this oracle —
+   * used by the connect page to show "authorize" vs. "authorized". Reads the
+   * canonical room's durable state (authoritative + carries the expiry).
+   */
+  async getDelegationStatus(
+    userDid: string,
+  ): Promise<{ authorized: boolean; expiration?: number }> {
+    const roomId = await this.resolveUserOracleRoomId(userDid);
+    if (!roomId) {
+      return { authorized: false };
+    }
+    const stored = await this.delegationStore.read(roomId);
+    if (!stored) {
+      return { authorized: false };
+    }
+    const nowSeconds = Math.floor(Date.now() / 1000);
+    if (
+      typeof stored.expiration === 'number' &&
+      stored.expiration <= nowSeconds
+    ) {
+      return { authorized: false };
+    }
+    return { authorized: true, expiration: stored.expiration };
+  }
+
+  /**
+   * Revoke (delete) the user's stored delegation for this oracle AND clear the
+   * in-memory cache, so downstream minting stops immediately rather than after
+   * the cache TTL.
+   */
+  async revokeDelegationForUser(userDid: string): Promise<void> {
+    const roomId = await this.resolveUserOracleRoomId(userDid);
+    if (roomId) {
+      await this.delegationStore.delete(roomId);
+    }
+    await this.cacheManager.del(`${DELEGATION_CACHE_PREFIX}${userDid}`);
+  }
+
+  /**
+   * Resolve the canonical per-(user,oracle) Matrix room — the single room a
+   * user's delegation is stored in and read from, regardless of which room
+   * they happen to chat in. Both the read path (Matrix turns) and the write
+   * path (`POST /delegation`) go through here so they can never target
+   * different rooms. Non-throwing: logs + returns null on failure.
+   */
+  private async resolveUserOracleRoomId(
+    userDid: string,
+  ): Promise<string | null> {
+    try {
+      const oracleEntityDid =
+        this.configService.getOrThrow<string>('ORACLE_ENTITY_DID');
+      const userHomeServer = await getMatrixHomeServerCroppedForDid(userDid);
+      const { roomId } =
+        await MatrixManager.getInstance().getOracleRoomIdWithHomeServer({
+          userDid,
+          oracleEntityDid,
+          userHomeServer,
+        });
+      return roomId ?? null;
+    } catch (error) {
+      this.logger.warn(
+        `[UCAN] Failed to resolve user↔oracle room for ${userDid}: ${
+          error instanceof Error ? error.message : String(error)
+        }`,
+      );
+      return null;
+    }
   }
 
   // ============================================================================

--- a/packages/oracle-runtime/src/modules/ws/ws.gateway.ts
+++ b/packages/oracle-runtime/src/modules/ws/ws.gateway.ts
@@ -15,6 +15,10 @@ import {
 import { Server, Socket } from 'socket.io';
 
 import { validateUcanDelegation } from '../auth/validate-ucan-delegation.js';
+import {
+  DEFAULT_UCAN_AUTH_MAX_TTL_SECONDS,
+  validateUcanInvocation,
+} from '../auth/validate-ucan-invocation.js';
 import { UcanService } from '../ucan/ucan.service.js';
 import { WsService } from './ws.service.js';
 
@@ -54,18 +58,20 @@ export class WsGateway
       return;
     }
 
-    // Authenticate the handshake the same way HTTP requests are authenticated:
-    // a valid UCAN delegation is required, and the user identity is the
-    // *validated invoker* — never the `userDid` the client put in the query.
-    // Trusting the query (the previous behaviour) let any client impersonate
-    // another user and poison the per-DID delegation cache.
+    // Authenticate the handshake the same way HTTP requests are: a user-signed
+    // UCAN invocation is the primary auth (a bare delegation is accepted as a
+    // migration fallback), and the identity is the *validated invoker* — never
+    // the `userDid` the client put in the query. Trusting the query (the old
+    // behaviour) let any client impersonate another user and poison the per-DID
+    // delegation cache.
+    const invocation = client.handshake.auth?.invocation as string | undefined;
     const ucanDelegation = client.handshake.auth?.ucanDelegation as
       | string
       | undefined;
 
-    if (!ucanDelegation) {
+    if (!invocation && !ucanDelegation) {
       this.logger.warn(
-        `WebSocket connection rejected for session ${sessionId}: missing UCAN delegation (client: ${client.id})`,
+        `WebSocket connection rejected for session ${sessionId}: missing UCAN auth (client: ${client.id})`,
       );
       client.disconnect();
       return;
@@ -83,19 +89,50 @@ export class WsGateway
       'BLOCKSYNC_GRAPHQL_URL',
     );
 
-    const outcome = await validateUcanDelegation(ucanDelegation, {
-      oracleDid,
-      blocksyncUri,
-    });
-    if (!outcome.ok) {
+    // Validate the delegation once (if sent): used for downstream authorization
+    // and as the auth fallback for pre-invocation clients.
+    const delegationOutcome = ucanDelegation
+      ? await validateUcanDelegation(ucanDelegation, { oracleDid, blocksyncUri })
+      : null;
+    if (delegationOutcome && !delegationOutcome.ok) {
       this.logger.warn(
-        `WebSocket connection rejected for session ${sessionId}: ${outcome.error} (client: ${client.id})`,
+        `WebSocket delegation invalid for session ${sessionId}: ${delegationOutcome.error} (client: ${client.id})`,
+      );
+    }
+    const validDelegation =
+      delegationOutcome && delegationOutcome.ok ? delegationOutcome.result : null;
+
+    // Authenticated identity: invocation (primary) → delegation (fallback).
+    let userDid: string | null = null;
+    if (invocation) {
+      const maxTtlSeconds =
+        Number(this.configService.get('UCAN_AUTH_MAX_TTL_SECONDS')) ||
+        DEFAULT_UCAN_AUTH_MAX_TTL_SECONDS;
+      const invOutcome = await validateUcanInvocation(invocation, {
+        oracleDid,
+        blocksyncUri,
+        maxTtlSeconds,
+      });
+      if (!invOutcome.ok) {
+        this.logger.warn(
+          `WebSocket connection rejected for session ${sessionId}: ${invOutcome.error} (client: ${client.id})`,
+        );
+        client.disconnect();
+        return;
+      }
+      userDid = invOutcome.result.userDid;
+    } else if (validDelegation) {
+      userDid = validDelegation.userDid;
+    }
+
+    if (!userDid) {
+      this.logger.warn(
+        `WebSocket connection rejected for session ${sessionId}: no valid UCAN auth (client: ${client.id})`,
       );
       client.disconnect();
       return;
     }
 
-    const userDid = outcome.result.userDid;
     // Stash the validated identity on the socket so disconnect-time history
     // processing reads the authenticated DID rather than the untrusted query.
     client.data.userDid = userDid;
@@ -104,13 +141,22 @@ export class WsGateway
       `WebSocket connection established for session: ${sessionId}, did: ${userDid}, client: ${client.id}`,
     );
 
-    // Cache the (now-validated) delegation for downstream invocations, keyed
-    // by the validated invoker DID and bounded by the delegation's lifetime.
-    if (this.ucanService) {
+    // Cache the delegation for downstream invocations — but only when it was
+    // issued by the authenticated user (delegations are public; never act on
+    // someone else's just because a client presented it).
+    if (
+      this.ucanService &&
+      validDelegation &&
+      validDelegation.userDid === userDid
+    ) {
       await this.ucanService.cacheDelegation(
         userDid,
-        ucanDelegation,
-        outcome.result.delegation.expiration,
+        ucanDelegation as string,
+        validDelegation.delegation.expiration,
+      );
+    } else if (validDelegation && validDelegation.userDid !== userDid) {
+      this.logger.warn(
+        `WebSocket ignoring delegation for downstream: issuer ${validDelegation.userDid} != authenticated ${userDid}`,
       );
     }
 

--- a/packages/oracle-runtime/src/modules/ws/ws.gateway.ts
+++ b/packages/oracle-runtime/src/modules/ws/ws.gateway.ts
@@ -92,7 +92,10 @@ export class WsGateway
     // Validate the delegation once (if sent): used for downstream authorization
     // and as the auth fallback for pre-invocation clients.
     const delegationOutcome = ucanDelegation
-      ? await validateUcanDelegation(ucanDelegation, { oracleDid, blocksyncUri })
+      ? await validateUcanDelegation(ucanDelegation, {
+          oracleDid,
+          blocksyncUri,
+        })
       : null;
     if (delegationOutcome && !delegationOutcome.ok) {
       this.logger.warn(
@@ -100,7 +103,9 @@ export class WsGateway
       );
     }
     const validDelegation =
-      delegationOutcome && delegationOutcome.ok ? delegationOutcome.result : null;
+      delegationOutcome && delegationOutcome.ok
+        ? delegationOutcome.result
+        : null;
 
     // Authenticated identity: invocation (primary) → delegation (fallback).
     let userDid: string | null = null;

--- a/packages/oracle-runtime/src/plugin-api/ucan-errors.ts
+++ b/packages/oracle-runtime/src/plugin-api/ucan-errors.ts
@@ -1,0 +1,15 @@
+/**
+ * Thrown by the runtime's UCAN adapter (`bootstrap/ambient-factory.ts`) when an
+ * invocation cannot be minted for an EXPECTED reason — the oracle has no signing
+ * key loaded, or the user has no cached delegation. It is deliberately distinct
+ * from a plain `Error` (which signals an UNEXPECTED mint/sign failure) so plugin
+ * auth helpers can classify the two without matching error-message substrings:
+ * an `instanceof UcanMintUnavailableError` check demotes the expected case to a
+ * non-error log and degrades silently, while any other throw is a real failure.
+ */
+export class UcanMintUnavailableError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'UcanMintUnavailableError';
+  }
+}

--- a/packages/oracle-runtime/src/plugins/composio/composio-ucan.ts
+++ b/packages/oracle-runtime/src/plugins/composio/composio-ucan.ts
@@ -1,4 +1,8 @@
 import type { RuntimeContext } from '../../plugin-api/types.js';
+import {
+  mintInvocationSafely,
+  resolveServiceDidSafely,
+} from '../ucan-failure.js';
 
 /**
  * Mint a UCAN invocation token addressed to the composio-worker.
@@ -8,33 +12,32 @@ import type { RuntimeContext } from '../../plugin-api/types.js';
  *   2. Mints an `ixo:sandbox` invocation using the user's signing key.
  *
  * Returns `null` when DID resolution fails, when minting throws, or when no
- * signing material is available. Callers degrade silently — the composio
- * client is simply not constructed and the plugin contributes no tools.
+ * signing material is available. Every failure is contained inside the shared
+ * UCAN helpers — nothing throws past this boundary. Callers degrade silently:
+ * the composio client is simply not constructed and the plugin contributes no
+ * tools. The "no delegation present" case logs at `debug`; a genuine
+ * resolve/mint failure logs at `warn`.
  */
 export async function mintComposioInvocation(
   runCtx: RuntimeContext,
   composioBaseUrl: string,
 ): Promise<string | null> {
-  const composioDid = await runCtx.ucan.resolveServiceDid(composioBaseUrl);
+  const composioDid = await resolveServiceDidSafely(
+    runCtx,
+    composioBaseUrl,
+    'composio',
+  );
   if (!composioDid) return null;
 
-  try {
-    // skipCache: the composio-worker enforces single-use replay protection
-    // per invocation CID (see composio-worker `lib/validation.ts`
-    // `createInvocationStore`, KV-backed, 120s default TTL). A cached
-    // invocation would be replayed on the second request and rejected with
-    // `401 REPLAY: Invocation has already been used`. Mint fresh every call.
-    const invocation = await runCtx.ucan.mintInvocation(
-      { did: composioDid, capability: 'ixo:sandbox' },
-      { skipCache: true },
-    );
-    return invocation && invocation.length > 0 ? invocation : null;
-  } catch (error) {
-    const detail =
-      error instanceof Error
-        ? `${error.name}: ${error.message}`
-        : String(error);
-    runCtx.logger.warn(`[composio] failed to mint UCAN invocation: ${detail}`);
-    return null;
-  }
+  // skipCache: the composio-worker enforces single-use replay protection
+  // per invocation CID (see composio-worker `lib/validation.ts`
+  // `createInvocationStore`, KV-backed, 120s default TTL). A cached
+  // invocation would be replayed on the second request and rejected with
+  // `401 REPLAY: Invocation has already been used`. Mint fresh every call.
+  return mintInvocationSafely(
+    runCtx,
+    { did: composioDid, capability: 'ixo:sandbox' },
+    'composio',
+    { skipCache: true },
+  );
 }

--- a/packages/oracle-runtime/src/plugins/memory/memory-ucan.ts
+++ b/packages/oracle-runtime/src/plugins/memory/memory-ucan.ts
@@ -1,4 +1,8 @@
 import type { RuntimeContext } from '../../plugin-api/types.js';
+import {
+  mintInvocationSafely,
+  resolveServiceDidSafely,
+} from '../ucan-failure.js';
 
 /**
  * Build the headers needed to call the Memory Engine MCP server on behalf of
@@ -9,40 +13,39 @@ import type { RuntimeContext } from '../../plugin-api/types.js';
  *   2. Mint an `ixo:memory` invocation using the user's signing key.
  *   3. Layer the resulting Bearer token plus the active `x-room-id`.
  *
- * UCAN-only — no Matrix-OpenID fallback. If minting fails for any reason
- * (no signing key, no cached delegation, did:web unresolved) the function
- * returns `null` so callers can degrade silently rather than leak a
- * half-built request to the upstream service.
+ * UCAN-only — no Matrix-OpenID fallback. If resolution or minting fails for
+ * any reason (no signing key, no cached delegation, did:web unresolved,
+ * network error) the function returns `null` so callers degrade silently
+ * rather than leak a half-built request to the upstream service. All failures
+ * are contained by the shared UCAN helpers — nothing throws past this
+ * boundary. The "no delegation present" case logs at `debug`; a genuine
+ * resolve/mint failure logs at `warn`.
  */
 export async function buildMemoryHeaders(
   runCtx: RuntimeContext,
   memoryMcpUrl: string,
 ): Promise<Record<string, string> | null> {
-  const memoryDid = await runCtx.ucan.resolveServiceDid(memoryMcpUrl);
+  const memoryDid = await resolveServiceDidSafely(
+    runCtx,
+    memoryMcpUrl,
+    'memory',
+  );
   if (!memoryDid) return null;
 
-  try {
-    const invocation = await runCtx.ucan.mintInvocation({
-      did: memoryDid,
-      capability: 'ixo:memory',
-    });
-    if (!invocation || invocation.length === 0) return null;
+  const invocation = await mintInvocationSafely(
+    runCtx,
+    { did: memoryDid, capability: 'ixo:memory' },
+    'memory',
+  );
+  if (!invocation) return null;
 
-    const headers: Record<string, string> = {
-      Authorization: `Bearer ${invocation}`,
-      'X-Auth-Type': 'ucan',
-      'User-Agent': 'LangChain-MCP-Client/1.0',
-    };
-    if (runCtx.session.roomId) {
-      headers['x-room-id'] = runCtx.session.roomId;
-    }
-    return headers;
-  } catch (error) {
-    const detail =
-      error instanceof Error
-        ? `${error.name}: ${error.message}`
-        : String(error);
-    runCtx.logger.warn(`[memory] failed to mint UCAN invocation: ${detail}`);
-    return null;
+  const headers: Record<string, string> = {
+    Authorization: `Bearer ${invocation}`,
+    'X-Auth-Type': 'ucan',
+    'User-Agent': 'LangChain-MCP-Client/1.0',
+  };
+  if (runCtx.session.roomId) {
+    headers['x-room-id'] = runCtx.session.roomId;
   }
+  return headers;
 }

--- a/packages/oracle-runtime/src/plugins/sandbox/sandbox.plugin.ts
+++ b/packages/oracle-runtime/src/plugins/sandbox/sandbox.plugin.ts
@@ -250,6 +250,17 @@ export class SandboxPlugin extends OraclePlugin {
       rtCtx,
     );
 
+    // No UCAN invocation could be minted (the user hasn't authorized) → the
+    // sandbox MCP server would reject us with 401. Skip connecting entirely
+    // and contribute no tools, rather than letting the auth error crash the
+    // turn. Mirrors composio/memory's graceful degradation.
+    if (!headers.Authorization) {
+      rtCtx.logger.log(
+        '[sandbox] skipping — no UCAN invocation (user not authorized); not connecting to the sandbox MCP server.',
+      );
+      return [];
+    }
+
     const client = this.mcpClientFactory({
       mcpServers: {
         sandbox: {

--- a/packages/oracle-runtime/src/plugins/skills/skills-ucan.ts
+++ b/packages/oracle-runtime/src/plugins/skills/skills-ucan.ts
@@ -1,4 +1,8 @@
 import type { RuntimeContext } from '../../plugin-api/types.js';
+import {
+  mintInvocationSafely,
+  resolveServiceDidSafely,
+} from '../ucan-failure.js';
 
 /**
  * Mints an `ixo:skills` UCAN invocation for outbound calls to the skills
@@ -22,30 +26,26 @@ export type SkillsUcanBuilder = (
 /**
  * Default {@link SkillsUcanBuilder}. Uses the same primitives as the sandbox
  * plugin: `runCtx.ucan.resolveServiceDid` for did:web resolution +
- * `runCtx.ucan.mintInvocation` to obtain the bearer token. Failures are
- * logged at `warn` and swallowed — the caller falls back to public-only.
+ * `runCtx.ucan.mintInvocation` to obtain the bearer token. All failures are
+ * contained by the shared UCAN helpers — nothing throws past this boundary,
+ * and the caller falls back to public-only. The "no delegation present" case
+ * logs at `debug`; a genuine resolve/mint failure logs at `warn`.
  */
 export function createDefaultSkillsUcanBuilder(): SkillsUcanBuilder {
   return async (skillsServiceUrl, runCtx) => {
-    const skillsDid = await runCtx.ucan.resolveServiceDid(skillsServiceUrl);
+    const skillsDid = await resolveServiceDidSafely(
+      runCtx,
+      skillsServiceUrl,
+      'skills',
+    );
     if (!skillsDid) {
       return undefined;
     }
-    try {
-      const invocation = await runCtx.ucan.mintInvocation({
-        did: skillsDid,
-        capability: 'ixo:skills',
-      });
-      return invocation || undefined;
-    } catch (error) {
-      const detail =
-        error instanceof Error
-          ? `${error.name}: ${error.message}`
-          : String(error);
-      runCtx.logger.warn(
-        `[skills] failed to mint skills UCAN invocation: ${detail}`,
-      );
-      return undefined;
-    }
+    const invocation = await mintInvocationSafely(
+      runCtx,
+      { did: skillsDid, capability: 'ixo:skills' },
+      'skills',
+    );
+    return invocation ?? undefined;
   };
 }

--- a/packages/oracle-runtime/src/plugins/ucan-failure.ts
+++ b/packages/oracle-runtime/src/plugins/ucan-failure.ts
@@ -1,0 +1,132 @@
+import type { RuntimeContext } from '../plugin-api/types.js';
+import { UcanMintUnavailableError } from '../plugin-api/ucan-errors.js';
+
+/**
+ * Shared, non-throwing UCAN failure handling for plugin auth helpers
+ * (composio / memory / skills, and any future minting plugin).
+ *
+ * Every plugin that mints a service-targeted invocation runs the same two
+ * risky steps:
+ *
+ *   1. `runCtx.ucan.resolveServiceDid(url)` — a did:web lookup that can throw
+ *      on network/DNS failure or return `null` when the document is missing.
+ *   2. `runCtx.ucan.mintInvocation(...)` — which the runtime adapter throws
+ *      from when the underlying service returns `null` (no signing key, no
+ *      cached delegation, or an internal mint/sign failure).
+ *
+ * The plugin contract is safe degradation: the capability is simply absent for
+ * the turn and the agent keeps running. These helpers make sure a failure
+ * never escapes the plugin boundary, and that the log line distinguishes the
+ * EXPECTED "this user just hasn't delegated to us" case (info/debug) from a
+ * genuine ERROR ("a delegation exists but mint/resolve blew up", warn).
+ */
+
+/** Why `mintInvocation` failed to produce a usable invocation. */
+type MintFailureKind =
+  | 'no-signing-key' // oracle has no Ed25519 key — UCAN minting is disabled
+  | 'no-delegation' // expected: this user has not delegated to the oracle
+  | 'error'; // unexpected throw — delegation likely present but minting failed
+
+/**
+ * Classify a thrown value from `mintInvocation` into expected vs. error. The
+ * adapter (`bootstrap/ambient-factory.ts`) throws a typed
+ * `UcanMintUnavailableError` for the EXPECTED cases (no signing key / no cached
+ * delegation); anything else is an unexpected failure. We refine the expected
+ * case into `no-signing-key` vs `no-delegation` purely for the log message.
+ */
+function classifyMintError(
+  runCtx: RuntimeContext,
+  error: unknown,
+): MintFailureKind {
+  if (!(error instanceof UcanMintUnavailableError)) return 'error';
+  return runCtx.ucan.hasSigningKey() ? 'no-delegation' : 'no-signing-key';
+}
+
+/** Human-readable detail string for an unknown thrown value. */
+function describe(error: unknown): string {
+  return error instanceof Error
+    ? `${error.name}: ${error.message}`
+    : String(error);
+}
+
+/**
+ * Log an expected (non-error) UCAN degradation. Prefers the optional `debug`
+ * channel; falls back to `log` when the logger doesn't expose `debug`, so the
+ * line never lands on the `warn`/`error` channels reserved for real failures.
+ */
+function logExpected(runCtx: RuntimeContext, message: string): void {
+  if (runCtx.logger.debug) {
+    runCtx.logger.debug(message);
+  } else {
+    runCtx.logger.log(message);
+  }
+}
+
+/**
+ * Resolve a service DID without throwing. Returns `null` on a missing document
+ * (expected) or on a resolution error (logged at `warn`). The boolean-less
+ * `null` return keeps the existing caller contract intact.
+ */
+export async function resolveServiceDidSafely(
+  runCtx: RuntimeContext,
+  serviceUrl: string,
+  plugin: string,
+): Promise<string | null> {
+  try {
+    const did = await runCtx.ucan.resolveServiceDid(serviceUrl);
+    if (!did) {
+      logExpected(
+        runCtx,
+        `[${plugin}] UCAN unavailable: service DID could not be resolved for ${serviceUrl} (no document / no id). Degrading without auth.`,
+      );
+      return null;
+    }
+    return did;
+  } catch (error) {
+    runCtx.logger.warn(
+      `[${plugin}] UCAN error: resolving service DID for ${serviceUrl} threw — ${describe(error)}. Degrading without auth.`,
+    );
+    return null;
+  }
+}
+
+/**
+ * Mint an invocation without throwing. Returns the token on success, or `null`
+ * on any failure — logging the EXPECTED cases (no signing key / no delegation)
+ * at `debug` and genuine errors (delegation present, mint/sign failed) at
+ * `warn` with the underlying message.
+ */
+export async function mintInvocationSafely(
+  runCtx: RuntimeContext,
+  target: { did: string; capability: string },
+  plugin: string,
+  opts?: { skipCache?: boolean },
+): Promise<string | null> {
+  try {
+    // Forward `opts` only when supplied so the no-opts call signature stays
+    // `mintInvocation(target)` — passing an explicit `undefined` second arg
+    // would be a needless behavioural change for callers that don't opt out
+    // of caching (memory / skills).
+    const invocation = opts
+      ? await runCtx.ucan.mintInvocation(target, opts)
+      : await runCtx.ucan.mintInvocation(target);
+    return invocation && invocation.length > 0 ? invocation : null;
+  } catch (error) {
+    const kind = classifyMintError(runCtx, error);
+    if (kind === 'error') {
+      runCtx.logger.warn(
+        `[${plugin}] UCAN error: minting '${target.capability}' invocation failed — ${describe(error)}. Degrading without auth.`,
+      );
+    } else {
+      const reason =
+        kind === 'no-signing-key'
+          ? 'oracle has no signing key'
+          : 'no delegation present for this user';
+      logExpected(
+        runCtx,
+        `[${plugin}] UCAN unavailable: ${reason} — skipping '${target.capability}' invocation. Degrading without auth.`,
+      );
+    }
+    return null;
+  }
+}

--- a/packages/oracle-runtime/src/testing/integration/chat-client.ts
+++ b/packages/oracle-runtime/src/testing/integration/chat-client.ts
@@ -22,6 +22,13 @@ export type { SendMessageResponse } from '../../modules/messages/dto/send-messag
 export interface ChatClientOptions {
   /** Base64 UCAN delegation, forwarded as `x-ucan-delegation`. */
   delegation?: string;
+  /**
+   * Base64 UCAN auth invocation — the primary auth artifact. Forwarded as
+   * `Authorization: Bearer <invocation>` + `X-Auth-Type: ucan`. Sent in
+   * addition to the delegation, which remains required for downstream
+   * authorization.
+   */
+  invocation?: string;
   /** IANA timezone string — sent in the request BODY (matches SDK). */
   timezone?: string;
   /** Per-request timeout (ms). Default 60_000. */
@@ -38,6 +45,8 @@ export interface SendOptions {
   timezone?: string;
   /** Per-call override of the constructor's `delegation`. */
   delegation?: string;
+  /** Per-call override of the constructor's auth `invocation`. */
+  invocation?: string;
   /** Optional metadata forwarded to the server (matches SDK). */
   metadata?: Record<string, unknown>;
   /** Optional attachments — same shape the SDK sends. */
@@ -102,6 +111,7 @@ export interface StreamFinal {
 export class ChatClient {
   private readonly baseUrl: string;
   private readonly delegation: string | undefined;
+  private readonly invocation: string | undefined;
   private readonly timezone: string;
   private readonly timeoutMs: number;
   private readonly fetchImpl: typeof globalThis.fetch;
@@ -109,21 +119,33 @@ export class ChatClient {
   constructor(baseUrl: string, opts: ChatClientOptions = {}) {
     this.baseUrl = baseUrl.replace(/\/+$/, '');
     this.delegation = opts.delegation;
+    this.invocation = opts.invocation;
     this.timezone = opts.timezone ?? 'UTC';
     this.timeoutMs = opts.timeoutMs ?? 60_000;
     this.fetchImpl = opts.fetch ?? globalThis.fetch.bind(globalThis);
   }
 
-  /** Headers shared by every request. `timezone` is NOT here — it's in the body. */
+  /**
+   * Headers shared by every request. `timezone` is NOT here — it's in the body.
+   *
+   * The auth invocation (primary) goes out as `Authorization: Bearer` +
+   * `X-Auth-Type: ucan`; the delegation (fallback + downstream authorization)
+   * goes out as `x-ucan-delegation`. Both are sent when available so the
+   * harness exercises the real production auth path.
+   */
   private authHeaders(extra: Record<string, string> = {}): HeadersInit {
     const out: Record<string, string> = {
       'content-type': 'application/json',
-      ...extra,
     };
     if (this.delegation && this.delegation.length > 0) {
       out['x-ucan-delegation'] = this.delegation;
     }
-    return out;
+    if (this.invocation && this.invocation.length > 0) {
+      out.authorization = `Bearer ${this.invocation}`;
+      out['x-auth-type'] = 'ucan';
+    }
+    // `extra` last so per-call overrides win over the instance defaults above.
+    return { ...out, ...extra };
   }
 
   /**
@@ -178,9 +200,7 @@ export class ChatClient {
     opts: SendOptions = {},
   ): Promise<SendResult<SendMessageWithTranscriptResponse>> {
     const start = Date.now();
-    const headers = this.authHeaders(
-      opts.delegation ? { 'x-ucan-delegation': opts.delegation } : {},
-    );
+    const headers = this.authHeaders(perCallAuthHeaders(opts));
 
     const controller = new AbortController();
     const timeoutId = setTimeout(() => controller.abort(), this.timeoutMs);
@@ -224,7 +244,7 @@ export class ChatClient {
   ): AsyncIterable<SSEEvent> & { final(): Promise<StreamFinal> } {
     const headers = this.authHeaders({
       accept: 'text/event-stream',
-      ...(opts.delegation ? { 'x-ucan-delegation': opts.delegation } : {}),
+      ...perCallAuthHeaders(opts),
     });
 
     const start = Date.now();
@@ -369,6 +389,24 @@ export class ChatClient {
       requestId: res.headers.get('x-request-id') ?? undefined,
     };
   }
+}
+
+/**
+ * Build per-call auth header overrides from a `SendOptions`/`StreamOptions`.
+ * Mirrors the instance defaults in `authHeaders`: a delegation override sets
+ * `x-ucan-delegation`; an invocation override sets `Authorization: Bearer` +
+ * `X-Auth-Type: ucan`. Returns only the keys the caller actually overrode.
+ */
+function perCallAuthHeaders(opts: SendOptions): Record<string, string> {
+  const out: Record<string, string> = {};
+  if (opts.delegation) {
+    out['x-ucan-delegation'] = opts.delegation;
+  }
+  if (opts.invocation) {
+    out.authorization = `Bearer ${opts.invocation}`;
+    out['x-auth-type'] = 'ucan';
+  }
+  return out;
 }
 
 /** Merge a timeout signal with a caller-supplied one. */

--- a/packages/oracle-runtime/src/testing/integration/index.ts
+++ b/packages/oracle-runtime/src/testing/integration/index.ts
@@ -27,12 +27,14 @@ export {
 
 export {
   mintUserDelegation,
+  mintAuthInvocation,
   memoryCap,
   sandboxCap,
   skillsCap,
   subscriptionsReadCap,
   allCaps,
   type MintUserDelegationOptions,
+  type MintAuthInvocationOptions,
 } from './ucan.js';
 
 export { waitForMatrixLoaded } from './wait-for-matrix-loaded.js';

--- a/packages/oracle-runtime/src/testing/integration/ucan.ts
+++ b/packages/oracle-runtime/src/testing/integration/ucan.ts
@@ -13,7 +13,9 @@
  */
 import {
   createDelegation,
+  createInvocation,
   serializeDelegation,
+  serializeInvocation,
   signerFromMnemonic,
   type Capability,
 } from '@ixo/ucan';
@@ -150,4 +152,81 @@ export async function mintUserDelegation(
   });
 
   return serializeDelegation(delegation);
+}
+
+/**
+ * The auth capability a root invocation carries. The ability is `*` (top) to
+ * match the runtime's server-side capability parser (`defineCapability({ can:
+ * '*' })`) — `@ixo/ucan` matches the `can` string literally, and the specific
+ * action is irrelevant for auth since identity comes from the signature.
+ */
+const AUTH_CAPABILITY: Capability = {
+  can: '*',
+  with: 'ixo:oracle',
+};
+
+/** Default TTL (seconds) for a test auth invocation — short-lived, like prod. */
+const AUTH_INVOCATION_TTL_SECONDS = 300;
+
+/** Options accepted by `mintAuthInvocation`. */
+export interface MintAuthInvocationOptions {
+  /**
+   * BIP39 mnemonic for the test user — the SAME signer used by
+   * `mintUserDelegation`. Stored in `.env.integration` as
+   * `TEST_USER_MNEMONIC`.
+   */
+  userMnemonic: string;
+  /**
+   * The oracle's DID — the invocation's audience. Matches the `serverDid`
+   * the runtime's UCAN validator boots with.
+   */
+  oracleDid: string;
+  /**
+   * The test user's DID. Defaults to the DID derived from the mnemonic by
+   * `signerFromMnemonic`. Pass `process.env.TEST_USER_DID!` when the user has
+   * an on-chain Ed25519 verification method.
+   */
+  userDid?: string;
+  /**
+   * Time-to-live, in **seconds** (Unix seconds, not ms). Defaults to 300 —
+   * a short-lived auth invocation, mirroring the production frontend.
+   */
+  ttlSec?: number;
+}
+
+/**
+ * Mint a real Ed25519-signed UCAN **invocation** for the test user — the
+ * primary auth artifact the runtime now expects.
+ *
+ * A root auth invocation: issuer = the test user's signer (the SAME identity
+ * as the delegation), audience = the oracle DID, capability
+ * `{ can: '*', with: 'ixo:oracle' }`, no proofs, short TTL.
+ * Sent as `Authorization: Bearer <invocation>` + `X-Auth-Type: ucan`.
+ *
+ * Pipeline: `signerFromMnemonic(userMnemonic, userDid?)` →
+ * `createInvocation({ issuer, audience: oracleDid, capability, proofs: [],
+ *  expiration: now+ttl })` → `serializeInvocation()`.
+ *
+ * `expiration` is Unix **seconds**, not milliseconds.
+ */
+export async function mintAuthInvocation(
+  opts: MintAuthInvocationOptions,
+): Promise<string> {
+  const ttlSec = opts.ttlSec ?? AUTH_INVOCATION_TTL_SECONDS;
+  const expiration = Math.floor(Date.now() / 1000) + ttlSec;
+
+  const { signer } = await signerFromMnemonic(
+    opts.userMnemonic,
+    toSupportedDid(opts.userDid),
+  );
+
+  const invocation = await createInvocation({
+    issuer: signer,
+    audience: opts.oracleDid,
+    capability: AUTH_CAPABILITY,
+    proofs: [],
+    expiration,
+  });
+
+  return serializeInvocation(invocation);
 }

--- a/packages/oracles-client-sdk/package.json
+++ b/packages/oracles-client-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ixo/oracles-client-sdk",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "type": "module",
   "private": false,
   "description": "Client SDK for interacting with QiForge oracles, designed for React applications",

--- a/packages/oracles-client-sdk/src/hooks/use-chat/v2/use-send-message.ts
+++ b/packages/oracles-client-sdk/src/hooks/use-chat/v2/use-send-message.ts
@@ -49,7 +49,7 @@ export function useSendMessage({
     overrides,
   );
   const apiUrl = overrides?.baseUrl ?? config.apiUrl;
-  const { wallet, authedRequest, agActions, getDelegation } =
+  const { wallet, authedRequest, agActions, getDelegation, getInvocation } =
     useOraclesContext();
 
   // Abort controller for canceling requests
@@ -141,6 +141,11 @@ export function useSendMessage({
           );
         }
 
+        // Get UCAN invocation (treated like a bearer token). Migration-safe:
+        // if no createInvocation callback is provided this is null and we
+        // proceed with delegation only.
+        const invocation = oracleDid ? await getInvocation(oracleDid) : null;
+
         // Create abort controller for this request
         abortControllerRef.current = new AbortController();
 
@@ -148,6 +153,7 @@ export function useSendMessage({
           apiURL: apiUrl,
           message,
           delegation,
+          invocation,
           sessionId,
           metadata,
           attachments,
@@ -269,6 +275,7 @@ const askOracleStream = async (props: {
   message: string;
   sessionId: string;
   delegation: string;
+  invocation?: string | null;
   metadata?: Record<string, unknown>;
   attachments?: Attachment[];
   browserTools?: {
@@ -311,6 +318,10 @@ const askOracleStream = async (props: {
     headers: {
       'Content-Type': 'application/json',
       'x-ucan-delegation': props.delegation,
+      ...(props.invocation && {
+        Authorization: `Bearer ${props.invocation}`,
+        'X-Auth-Type': 'ucan',
+      }),
     },
     body: JSON.stringify({
       message: props.message,

--- a/packages/oracles-client-sdk/src/hooks/use-websocket-events/use-websocket-events.tsx
+++ b/packages/oracles-client-sdk/src/hooks/use-websocket-events/use-websocket-events.tsx
@@ -19,7 +19,7 @@ export function useWebSocketEvents(
     props.oracleDid,
     props.overrides,
   );
-  const { wallet, getDelegation } = useOraclesContext();
+  const { wallet, getDelegation, getInvocation } = useOraclesContext();
 
   const [isConnected, setIsConnected] = useState(false);
   const [error, setError] = useState<Error | null>(null);
@@ -78,10 +78,19 @@ export function useWebSocketEvents(
         return;
       }
 
+      // Resolve the UCAN invocation (treated like a bearer token) alongside
+      // the delegation. Migration-safe: if no createInvocation callback is
+      // provided this is null and the handshake behaves as before.
+      const invocation = await getInvocation(props.oracleDid);
+      if (cancelled) return;
+
       // Create WebSocket connection
       const newSocket = io(apiUrl, {
         query: { sessionId, userDid: wallet.did },
-        auth: { ucanDelegation: delegation },
+        auth: {
+          ucanDelegation: delegation,
+          ...(invocation && { invocation }),
+        },
         transports: ['websocket'],
       });
 

--- a/packages/oracles-client-sdk/src/providers/oracles-provider/index.ts
+++ b/packages/oracles-client-sdk/src/providers/oracles-provider/index.ts
@@ -1,2 +1,2 @@
-export { OraclesProvider } from './oracles-context.js';
+export { OraclesProvider, useOraclesContext } from './oracles-context.js';
 export * from './types.js';

--- a/packages/oracles-client-sdk/src/providers/oracles-provider/oracles-context.tsx
+++ b/packages/oracles-client-sdk/src/providers/oracles-provider/oracles-context.tsx
@@ -15,6 +15,10 @@ import {
   getCachedDelegation,
   setCachedDelegation,
 } from '../../utils/delegation-cache.js';
+import {
+  getCachedInvocation,
+  setCachedInvocation,
+} from '../../utils/invocation-cache.js';
 import type { AgAction } from '../../hooks/use-ag-action.js';
 import {
   type IOraclesContextProps,
@@ -38,6 +42,7 @@ export const OraclesProvider = ({
   initialWallet,
   transactSignX,
   createDelegation,
+  createInvocation,
 }: PropsWithChildren<IOraclesProviderProps>) => {
   if ((!initialWallet as unknown) || !transactSignX) {
     throw new Error('initialWallet and transactSignX are required');
@@ -78,6 +83,32 @@ export const OraclesProvider = ({
     [initialWallet.did, createDelegation],
   );
 
+  const getInvocation = useCallback(
+    async (oracleDid: string): Promise<string | null> => {
+      // Check cache first
+      const cached = getCachedInvocation(initialWallet.did, oracleDid);
+      if (cached) return cached;
+
+      // No callback provided — skip invocation (migration-safe)
+      if (!createInvocation) return null;
+
+      try {
+        const result = await createInvocation(oracleDid);
+        setCachedInvocation(
+          initialWallet.did,
+          oracleDid,
+          result.serialized,
+          result.expiresAt,
+        );
+        return result.serialized;
+      } catch (error) {
+        console.warn('Failed to create UCAN invocation:', error);
+        return null;
+      }
+    },
+    [initialWallet.did, createInvocation],
+  );
+
   const authedRequest = useCallback(
     async (
       url: string,
@@ -94,6 +125,12 @@ export const OraclesProvider = ({
         if (delegation) {
           headers['x-ucan-delegation'] = delegation;
         }
+
+        const invocation = await getInvocation(oracleDid);
+        if (invocation) {
+          headers['Authorization'] = `Bearer ${invocation}`;
+          headers['X-Auth-Type'] = 'ucan';
+        }
       }
 
       return request(url, method, {
@@ -101,7 +138,7 @@ export const OraclesProvider = ({
         headers,
       });
     },
-    [getDelegation],
+    [getDelegation, getInvocation],
   );
 
   // AG-UI action management functions
@@ -159,6 +196,7 @@ export const OraclesProvider = ({
         oracleDid?: string,
       ) => Promise<T>,
       getDelegation,
+      getInvocation,
       agActions,
       registerAgAction,
       unregisterAgAction,
@@ -170,6 +208,7 @@ export const OraclesProvider = ({
       transactSignX,
       authedRequest,
       getDelegation,
+      getInvocation,
       agActions,
       registerAgAction,
       unregisterAgAction,

--- a/packages/oracles-client-sdk/src/providers/oracles-provider/types.ts
+++ b/packages/oracles-client-sdk/src/providers/oracles-provider/types.ts
@@ -21,6 +21,15 @@ export type CreateDelegationFn = (
   oracleDid: string,
 ) => Promise<DelegationResult>;
 
+export interface InvocationResult {
+  serialized: string;
+  expiresAt: number;
+}
+
+export type CreateInvocationFn = (
+  oracleDid: string,
+) => Promise<InvocationResult>;
+
 export interface IOraclesContextProps {
   wallet: IWalletProps | null;
   transactSignX: TransactionFn;
@@ -31,6 +40,7 @@ export interface IOraclesContextProps {
     oracleDid?: string,
   ) => Promise<T>;
   getDelegation: (oracleDid: string) => Promise<string | null>;
+  getInvocation: (oracleDid: string) => Promise<string | null>;
   // AG-UI action management
   agActions: AgAction[];
   registerAgAction: (
@@ -51,4 +61,5 @@ export interface IOraclesProviderProps {
   initialWallet: IWalletProps;
   transactSignX: TransactionFn;
   createDelegation: CreateDelegationFn;
+  createInvocation?: CreateInvocationFn;
 }

--- a/packages/oracles-client-sdk/src/utils/invocation-cache.ts
+++ b/packages/oracles-client-sdk/src/utils/invocation-cache.ts
@@ -1,0 +1,77 @@
+/* eslint-disable no-console */
+
+interface CachedInvocation {
+  serialized: string;
+  expiresAt: number;
+}
+
+type InvocationMap = Record<string, CachedInvocation>;
+
+const STORAGE_KEY = 'oracles_ucan_invocations';
+const EXPIRY_BUFFER_MS = 30 * 1000; // 30 seconds — invocations are short-lived (~5 min)
+
+function loadMap(): InvocationMap {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    if (!raw) return {};
+    return JSON.parse(raw) as InvocationMap;
+  } catch {
+    return {};
+  }
+}
+
+function saveMap(map: InvocationMap): void {
+  try {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(map));
+  } catch (error) {
+    console.error('Failed to save invocation cache:', error);
+  }
+}
+
+function cacheKey(userDid: string, oracleDid: string): string {
+  return `${userDid}::${oracleDid}`;
+}
+
+export function getCachedInvocation(
+  userDid: string,
+  oracleDid: string,
+): string | null {
+  const map = loadMap();
+  const key = cacheKey(userDid, oracleDid);
+  const entry = map[key];
+
+  if (!entry) return null;
+
+  if (entry.expiresAt < Date.now() + EXPIRY_BUFFER_MS) {
+    delete map[key];
+    saveMap(map);
+    return null;
+  }
+
+  return entry.serialized;
+}
+
+export function setCachedInvocation(
+  userDid: string,
+  oracleDid: string,
+  serialized: string,
+  expiresAt: number,
+): void {
+  const map = loadMap();
+  const key = cacheKey(userDid, oracleDid);
+  map[key] = { serialized, expiresAt };
+
+  // Prune expired entries
+  const now = Date.now();
+  for (const k of Object.keys(map)) {
+    if (map[k]!.expiresAt < now) {
+      delete map[k];
+    }
+  }
+
+  saveMap(map);
+}
+
+export function clearInvocationCache(): void {
+  localStorage.removeItem(STORAGE_KEY);
+}


### PR DESCRIPTION
## What

Moves oracle **authentication** to user-signed UCAN **invocations** (the delegation becomes **authorization-only**), and lets **Matrix** clients use the oracle's full capabilities by storing the user's delegation durably in their Matrix room.

## Why

A delegation is long-lived and replayable, so using it as the auth credential is weak; an invocation is short-lived, freshly user-signed, and replay-bounded — the correct UCAN auth primitive. Separately, Matrix-originated turns carried no delegation and got no UCAN-gated tooling; now they do.

## Changes

**Auth (HTTP + WS)**
- `validate-ucan-invocation.ts`: validates a user-signed invocation (root, capability `ixo:oracle`), requires an expiry, rejects TTL beyond `UCAN_AUTH_MAX_TTL_SECONDS`.
- `auth-header.middleware.ts` + `ws.gateway.ts`: invocation = primary auth, delegation = migration fallback; **issuer-binding** (only trust a delegation issued by the authenticated user); validation-result cache keyed by token hash with TTL = the token's own expiry.

**Matrix delegation storage**
- `DelegationStore`: stores the delegation in the **canonical per-(user,oracle)** Matrix room state (plaintext — authorization-only, safe to expose).
- `UcanService`: `getDelegationForUser` (read-through that re-warms the cache so downstream minting works), `storeDelegationForUser`, `getDelegationStatus`, `revokeDelegationForUser`.
- `POST/GET/DELETE /delegation`.
- Throttled `ixo.oracle.delegation_required` Matrix event when a Matrix turn has no valid delegation.

**Graceful failures**
- Typed `UcanMintUnavailableError` + `ucan-failure.ts` helpers; composio/memory/skills/sandbox skip cleanly (no throw, no MCP connect) when there's no UCAN.

**SDK**
- Optional `createInvocation` provider prop + invocation cache; sends `Authorization: Bearer <inv>` + `X-Auth-Type: ucan` alongside `x-ucan-delegation` (HTTP + WS); exposes `useOraclesContext`.

**Misc**
- New env: `UCAN_AUTH_MAX_TTL_SECONDS` (900), `UCAN_REAUTH_PROMPT_THROTTLE_SECONDS` (21600).
- Example app `.env.example` + integration harness auth-invocation minting.

## Migration

Delegation-as-auth is still accepted as a **fallback**; removing it (cutover) is tracked in **ORA-266** and is out of scope here until all clients send invocations.

## Testing

`pnpm --filter @ixo/oracle-runtime test` → 647/647 unit pass; `tsc --noEmit` clean.

## Frontend

The impacts-x-web side (the `createInvocation` callback, the connect-page authorize/revoke UI, and the `delegation_required` listener) lands in a **separate PR** in that repo.

Linear: ORA-261 — ORA-262, ORA-263, ORA-264, ORA-265, ORA-269.