### PR TITLE
feat(runtime): allow forks to override plugin manifest settings

### DIFF
--- a/docs/architecture/boot-sequence.md
+++ b/docs/architecture/boot-sequence.md
@@ -28,12 +28,14 @@ Order plugins by `dependsOn`. Cycles or missing hard deps surface as resolver er
 
 ### 4. Manifest validation
 
-For each loaded plugin, `validateManifest(plugin.manifest, plugin.name)` in `manifest/validator.ts`:
+First, fork-supplied `opts.manifestOverrides` are merged onto each plugin's own manifest via `mergeManifestOverride(plugin.manifest, override)` (`manifest/merge-override.ts`). The merge is shallow — keys the override sets win, omitted keys keep the plugin default, and `undefined` values are ignored so a sparse override never blanks a field. Override keys that don't match a loaded plugin are logged (`boot.plugin.manifest_override_unknown`) and ignored. This is how a fork retunes a bundled plugin's discovery — most commonly flipping a noisy `always` plugin to `on-demand`, hiding one behind `silent`, or relabelling `summary`/`tags`/`whenToUse` — without forking the plugin source.
+
+Validation then runs against the **merged** manifest, so an override is held to the same rules as an authored manifest. For each loaded plugin, `validateManifest(effectiveManifest, plugin.name)` in `manifest/validator.ts`:
 
 - Hard: `summary` non-empty; `whenToUse` ≥ 1 entry when `visibility !== 'silent'`; every `example.tool` references a registered tool.
 - Soft: `summary` ≤ 120 chars; `whenToUse` entries ≤ 100 chars and ≤ 8 entries; `tags` all lowercase.
 
-Hard violations are collected; if non-empty, boot throws `Plugin manifest validation failed (N issues)`.
+Hard violations are collected; if non-empty, boot throws `Plugin manifest validation failed (N issues)`. The same merged manifest is what gets handed to the `ManifestRegistry` in step 8, so every downstream reader (the Tier-1 prompt, the capability meta-tools, the agent's visibility index) sees the override too.
 
 ### 5. Schema merge + env validation
 

--- a/packages/oracle-runtime/package.json
+++ b/packages/oracle-runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ixo/oracle-runtime",
-  "version": "1.1.1",
+  "version": "1.2.0",
   "description": "Plugin-based runtime for QiForge oracles",
   "private": false,
   "publishConfig": {

--- a/packages/oracle-runtime/src/bootstrap/create-oracle-app.test.ts
+++ b/packages/oracle-runtime/src/bootstrap/create-oracle-app.test.ts
@@ -302,6 +302,70 @@ describe('createOracleApp — credits + subscription middleware', () => {
   });
 });
 
+describe('createOracleApp — manifest overrides', () => {
+  class OverridablePlugin extends OraclePlugin {
+    readonly name = 'overridable';
+    readonly version = '1.0.0';
+    readonly manifest: PluginManifest = {
+      title: 'Overridable',
+      summary: 'A plugin whose manifest a fork can retune.',
+      whenToUse: ['user asks the overridable thing'],
+      visibility: 'always',
+    };
+  }
+
+  it('boots cleanly when an override only retunes display fields', async () => {
+    await expect(
+      createOracleApp({
+        ...defaultOpts,
+        plugins: [new OverridablePlugin()],
+        manifestOverrides: {
+          overridable: { visibility: 'on-demand', summary: 'Tuned summary.' },
+        },
+      }),
+    ).resolves.toBeDefined();
+  });
+
+  it('validates the merged manifest — a bad override fails boot', async () => {
+    // Base is `always` with a populated whenToUse (valid). Emptying whenToUse
+    // while leaving visibility non-silent must fail, proving the validator
+    // runs against the merged manifest rather than the plugin's own.
+    await expect(
+      createOracleApp({
+        ...defaultOpts,
+        plugins: [new OverridablePlugin()],
+        manifestOverrides: {
+          overridable: { whenToUse: [] },
+        },
+      }),
+    ).rejects.toThrow(/manifest validation failed/i);
+  });
+
+  it('warns and ignores overrides that reference an unloaded plugin', async () => {
+    const warnings: string[] = [];
+    const logger = {
+      log: () => undefined,
+      warn: (msg: unknown) =>
+        warnings.push(typeof msg === 'string' ? msg : JSON.stringify(msg)),
+      error: () => undefined,
+    };
+
+    await expect(
+      createOracleApp({
+        ...defaultOpts,
+        plugins: [new OverridablePlugin()],
+        manifestOverrides: {
+          'does-not-exist': { visibility: 'silent' },
+        },
+        logger,
+      }),
+    ).resolves.toBeDefined();
+
+    expect(warnings.join('\n')).toMatch(/does-not-exist/);
+    expect(warnings.join('\n')).toMatch(/not a loaded plugin/);
+  });
+});
+
 describe('createOracleApp — plugin-contributed NestJS modules', () => {
   it('flows getNestModules() output into RuntimeAppModule.imports', async () => {
     class FakeSlackModule {}

--- a/packages/oracle-runtime/src/bootstrap/create-oracle-app.ts
+++ b/packages/oracle-runtime/src/bootstrap/create-oracle-app.ts
@@ -21,6 +21,10 @@ import {
 } from '../config/base-env-schema.js';
 import type { MainAgentHooks } from '../graph/main-agent-types.js';
 import { getModelForRole, getProviderConfig } from '../llm/llm-provider.js';
+import {
+  mergeManifestOverride,
+  type PluginManifestOverride,
+} from '../manifest/merge-override.js';
 import { validateManifest } from '../manifest/validator.js';
 import { UserMatrixSqliteSyncService } from '../matrix/checkpointer/user-matrix-sqlite-sync-service.service.js';
 import { setFileProcessingProvider } from '../modules/messages/file-processing.service.js';
@@ -70,6 +74,20 @@ export interface CreateOracleAppOptions {
    */
   config: OracleConfig;
   features?: Partial<Record<BundledFeatureName | (string & {}), FeatureToggle>>;
+  /**
+   * Per-plugin manifest overrides. Each entry is merged shallowly over the
+   * plugin's own `manifest` at boot — keys you set win, keys you omit keep the
+   * plugin's default. Use to retune a bundled plugin's discovery without
+   * forking its source: flip a noisy `always` plugin to `on-demand`, hide one
+   * behind `silent`, or relabel its `summary`/`tags`/`whenToUse`. The merged
+   * manifest is validated exactly like an authored one, so an override that
+   * (say) empties `whenToUse` on a non-silent plugin fails the boot with a
+   * clear message. Keys that don't match a loaded plugin are logged and
+   * ignored.
+   */
+  manifestOverrides?: Partial<
+    Record<BundledFeatureName | (string & {}), PluginManifestOverride>
+  >;
   plugins?: OraclePlugin[];
   /** Developer's own NestJS modules. Spread into `RuntimeAppModule.imports`. */
   nestModules?: Array<Type | DynamicModule>;
@@ -189,10 +207,32 @@ export async function createOracleApp(
     throw err;
   }
 
-  // 4. Manifest validation
+  // 4. Manifest validation — against the effective (override-merged) manifest
+  // so a fork override is held to the same rules as an authored manifest.
+  const manifestOverrides = opts.manifestOverrides ?? {};
+  const loadedNames = new Set(resolved.loaded.map((p) => p.name));
+  for (const key of Object.keys(manifestOverrides)) {
+    if (!loadedNames.has(key)) {
+      logger.warn?.(
+        `[boot] manifestOverrides references '${key}', which is not a loaded plugin — ignored ` +
+          `(event: boot.plugin.manifest_override_unknown)`,
+      );
+    }
+  }
+
+  const effectiveManifests = new Map(
+    resolved.loaded.map((plugin) => [
+      plugin.name,
+      mergeManifestOverride(plugin.manifest, manifestOverrides[plugin.name]),
+    ]),
+  );
+
   const manifestErrors: string[] = [];
   for (const plugin of resolved.loaded) {
-    const result = validateManifest(plugin.manifest, plugin.name);
+    const result = validateManifest(
+      effectiveManifests.get(plugin.name),
+      plugin.name,
+    );
     if (!result.valid) manifestErrors.push(...result.errors);
   }
   if (manifestErrors.length > 0) {
@@ -264,7 +304,7 @@ export async function createOracleApp(
     registries.tools.register(plugin);
     registries.subAgents.register(plugin);
     registries.middlewares.register(plugin);
-    registries.manifests.register(plugin);
+    registries.manifests.register(plugin, manifestOverrides[plugin.name]);
     registries.configSchema.register(plugin);
     registries.sharedState.register(plugin);
   }

--- a/packages/oracle-runtime/src/index.ts
+++ b/packages/oracle-runtime/src/index.ts
@@ -96,12 +96,14 @@ export {
   validateManifest,
   validateExamplesAgainstTools,
   renderTier1,
+  mergeManifestOverride,
 } from './manifest/index.js';
 export type {
   ManifestValidationResult,
   Tier1Entry,
   Tier1Input,
   Tier1Output,
+  PluginManifestOverride,
 } from './manifest/index.js';
 
 export {

--- a/packages/oracle-runtime/src/manifest/index.ts
+++ b/packages/oracle-runtime/src/manifest/index.ts
@@ -12,3 +12,6 @@ export type { ManifestValidationResult } from './validator.js';
 
 export { renderTier1 } from './tier1-renderer.js';
 export type { Tier1Entry, Tier1Input, Tier1Output } from './tier1-renderer.js';
+
+export { mergeManifestOverride } from './merge-override.js';
+export type { PluginManifestOverride } from './merge-override.js';

--- a/packages/oracle-runtime/src/manifest/merge-override.test.ts
+++ b/packages/oracle-runtime/src/manifest/merge-override.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from 'vitest';
+import type { PluginManifest } from '../plugin-api/types.js';
+import { mergeManifestOverride } from './merge-override.js';
+
+const base: PluginManifest = {
+  title: 'Weather',
+  summary: 'Current conditions and forecasts.',
+  whenToUse: ['user asks about weather'],
+  visibility: 'always',
+  tags: ['data'],
+};
+
+describe('mergeManifestOverride', () => {
+  it('returns the same reference when no override is given', () => {
+    expect(mergeManifestOverride(base)).toBe(base);
+  });
+
+  it('returns the same reference when the override is empty', () => {
+    expect(mergeManifestOverride(base, {})).toBe(base);
+  });
+
+  it('overrides visibility while leaving other fields intact', () => {
+    const merged = mergeManifestOverride(base, { visibility: 'on-demand' });
+    expect(merged.visibility).toBe('on-demand');
+    expect(merged.title).toBe('Weather');
+    expect(merged.whenToUse).toEqual(['user asks about weather']);
+  });
+
+  it('replaces array fields wholesale rather than concatenating', () => {
+    const merged = mergeManifestOverride(base, { tags: ['ui', 'beta'] });
+    expect(merged.tags).toEqual(['ui', 'beta']);
+  });
+
+  it('ignores undefined override values so a sparse override never blanks a field', () => {
+    const merged = mergeManifestOverride(base, {
+      visibility: undefined,
+      summary: 'New summary.',
+    });
+    expect(merged.visibility).toBe('always');
+    expect(merged.summary).toBe('New summary.');
+  });
+
+  it('does not mutate the base manifest', () => {
+    mergeManifestOverride(base, { visibility: 'silent' });
+    expect(base.visibility).toBe('always');
+  });
+});

--- a/packages/oracle-runtime/src/manifest/merge-override.ts
+++ b/packages/oracle-runtime/src/manifest/merge-override.ts
@@ -1,0 +1,32 @@
+import type { PluginManifest } from '../plugin-api/types.js';
+
+/**
+ * Fork-supplied overrides for a plugin's manifest. Merged shallowly over the
+ * plugin's own `manifest` at boot — keys present in the override win, absent
+ * keys keep the plugin default. Lets a fork retune a bundled plugin's
+ * discovery without forking its source (e.g. flip a noisy `always` plugin to
+ * `on-demand`, hide one with `silent`, or relabel its `summary`/`tags`).
+ */
+export type PluginManifestOverride = Partial<PluginManifest>;
+
+/**
+ * Shallow-merge a manifest override onto a base manifest. Only keys the
+ * override actually sets take effect — an `undefined` value is treated as
+ * "leave the base alone" so a sparse override never blanks out a field.
+ *
+ * Returns the base manifest unchanged (same reference) when there is no
+ * override or the override is empty, so callers can cheaply skip work.
+ */
+export function mergeManifestOverride(
+  base: PluginManifest,
+  override?: PluginManifestOverride,
+): PluginManifest {
+  if (!override) return base;
+
+  const defined = Object.fromEntries(
+    Object.entries(override).filter(([, value]) => value !== undefined),
+  );
+  if (Object.keys(defined).length === 0) return base;
+
+  return { ...base, ...defined };
+}

--- a/packages/oracle-runtime/src/registries/manifest-registry.test.ts
+++ b/packages/oracle-runtime/src/registries/manifest-registry.test.ts
@@ -130,6 +130,34 @@ describe('ManifestRegistry', () => {
     expect(result.errors[0]).toContain('open_url');
   });
 
+  it('applies a fork override over the plugin manifest at registration', () => {
+    const reg = new ManifestRegistry();
+    reg.register(
+      makePlugin({
+        name: 'weather',
+        manifest: makeManifest({ title: 'Weather', visibility: 'always' }),
+      }),
+      { visibility: 'on-demand', summary: 'Tuned by the fork.' },
+    );
+
+    const [entry] = reg.collect();
+    expect(entry.manifest.visibility).toBe('on-demand');
+    expect(entry.manifest.summary).toBe('Tuned by the fork.');
+    // Untouched fields keep the plugin default.
+    expect(entry.manifest.title).toBe('Weather');
+  });
+
+  it('leaves the manifest unchanged when no override is supplied', () => {
+    const reg = new ManifestRegistry();
+    reg.register(
+      makePlugin({
+        name: 'weather',
+        manifest: makeManifest({ visibility: 'always' }),
+      }),
+    );
+    expect(reg.collect()[0].manifest.visibility).toBe('always');
+  });
+
   it('assertNoCollisions is a no-op (manifest titles can collide)', () => {
     const reg = new ManifestRegistry();
     reg.register(

--- a/packages/oracle-runtime/src/registries/manifest-registry.ts
+++ b/packages/oracle-runtime/src/registries/manifest-registry.ts
@@ -1,3 +1,7 @@
+import {
+  mergeManifestOverride,
+  type PluginManifestOverride,
+} from '../manifest/merge-override.js';
 import { validateExamplesAgainstTools } from '../manifest/validator.js';
 import type { OraclePlugin } from '../plugin-api/oracle-plugin.js';
 import type { PluginManifest } from '../plugin-api/types.js';
@@ -25,9 +29,18 @@ export interface ManifestCrossCheckResult {
 export class ManifestRegistry {
   private readonly entries: RegisteredManifest[] = [];
 
-  /** Record a plugin's manifest. */
-  register(plugin: OraclePlugin): void {
-    this.entries.push({ pluginName: plugin.name, manifest: plugin.manifest });
+  /**
+   * Record a plugin's manifest. A fork-supplied `override` is merged shallowly
+   * over the plugin's own manifest, so every downstream reader (`collect()`,
+   * the Tier-1 renderer, the capability meta-tools, the agent's visibility
+   * index) sees the effective manifest — the override is the single source of
+   * truth from here on.
+   */
+  register(plugin: OraclePlugin, override?: PluginManifestOverride): void {
+    this.entries.push({
+      pluginName: plugin.name,
+      manifest: mergeManifestOverride(plugin.manifest, override),
+    });
   }
 
   /**

--- a/packages/oracle-runtime/src/testing/create-test-runtime.ts
+++ b/packages/oracle-runtime/src/testing/create-test-runtime.ts
@@ -3,6 +3,7 @@ import {
   resolvePlugins,
   type FeatureToggle,
 } from '../bootstrap/plugin-loader.js';
+import type { PluginManifestOverride } from '../manifest/merge-override.js';
 import { validateManifest } from '../manifest/validator.js';
 import type { OraclePlugin } from '../plugin-api/oracle-plugin.js';
 import type {
@@ -49,6 +50,14 @@ export interface CreateTestRuntimeOptions {
    * for plugins that have an `autoDetect`, otherwise on.
    */
   features?: Partial<Record<string, FeatureToggle>>;
+  /**
+   * Per-plugin manifest overrides, same shape and semantics as
+   * `createOracleApp`. Merged shallowly over each plugin's own manifest, so
+   * `getManifest`/`listCapabilities` and the visibility-driven helpers reflect
+   * the override. Lets a test exercise a plugin under a retuned visibility
+   * (e.g. forcing `silent`) without a bespoke fixture.
+   */
+  manifestOverrides?: Partial<Record<string, PluginManifestOverride>>;
   /** Merged config (env vars). Plugins read this through `ctx.config`. */
   config?: Record<string, unknown>;
   /** Override fields on the synthesized RuntimeContext.user. */
@@ -159,11 +168,12 @@ export async function createTestRuntime(
   const configSchemas = new ConfigSchemaRegistry();
   const sharedState = new SharedStateRegistry();
 
+  const manifestOverrides = opts.manifestOverrides ?? {};
   for (const plugin of resolved.loaded) {
     tools.register(plugin);
     subAgents.register(plugin);
     middlewares.register(plugin);
-    manifests.register(plugin);
+    manifests.register(plugin, manifestOverrides[plugin.name]);
     configSchemas.register(plugin);
     sharedState.register(plugin);
   }


### PR DESCRIPTION
Adds a manifestOverrides option to createOracleApp (and createTestRuntime)
so a fork can retune a bundled plugin's manifest — most usefully its
visibility (always/on-demand/silent) — without forking the plugin source.

Overrides are merged shallowly onto each plugin's own manifest via
mergeManifestOverride: keys set win, omitted keys keep the default,
undefined values are ignored. The merged manifest is what gets validated
and registered, so every downstream reader (Tier-1 prompt, capability
meta-tools, the agent's visibility index) sees the override. Keys that
don't match a loaded plugin are logged and ignored.