### PR TITLE
feat: dedupe entity fetches, gate empty-DID queries, staleTime + queryClient injection

### DIFF
--- a/packages/oracles-chain-client/package.json
+++ b/packages/oracles-chain-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ixo/oracles-chain-client",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "private": false,
   "publishConfig": {
     "access": "public"

--- a/packages/oracles-chain-client/src/utils/get-settings-resouce.ts
+++ b/packages/oracles-chain-client/src/utils/get-settings-resouce.ts
@@ -2,6 +2,38 @@ import { type LinkedResource } from '@ixo/impactxclient-sdk/codegen/ixo/iid/v1be
 import { gqlClient } from 'src/gql/index.js';
 import { type TGetSettingsResourceSchema } from '../client/entities/types.js';
 
+type ProtocolEntity = Awaited<
+  ReturnType<typeof gqlClient.GetEntityById>
+>['entity'];
+
+// Every settings resource on the same protocol (authz `#orz`, pricing `#fee`,
+// …) resolves the identical entity document, and callers fetch them side by
+// side — so entity lookups are deduped in-flight and briefly cached instead of
+// hitting blocksync once per resource. Failures are evicted immediately.
+const ENTITY_CACHE_TTL_MS = 60_000;
+const entityFetchCache = new Map<
+  string,
+  { promise: Promise<ProtocolEntity>; at: number }
+>();
+
+function getEntityByIdCached(protocolDid: string): Promise<ProtocolEntity> {
+  const cached = entityFetchCache.get(protocolDid);
+  if (cached && Date.now() - cached.at < ENTITY_CACHE_TTL_MS) {
+    return cached.promise;
+  }
+
+  const promise = gqlClient
+    .GetEntityById({ id: protocolDid })
+    .then((result) => result?.entity);
+  entityFetchCache.set(protocolDid, { promise, at: Date.now() });
+  promise.catch(() => {
+    if (entityFetchCache.get(protocolDid)?.promise === promise) {
+      entityFetchCache.delete(protocolDid);
+    }
+  });
+  return promise;
+}
+
 function rewriteMatrixMediaUrl(url: string, matrixHomeServer: string): string {
   const mediaMatch = url.match(
     /https?:\/\/[^/]+\/_matrix\/media\/[^/]+\/download\/([^/]+)\/(.+)/,
@@ -17,9 +49,9 @@ export async function getSettingsResource<T>(
   matrixAccessToken?: string,
   matrixHomeServer?: string,
 ): Promise<T> {
-  const protocol = (
-    await gqlClient.GetEntityById({ id: settingsResourceParams.protocolDid })
-  )?.entity;
+  const protocol = await getEntityByIdCached(
+    settingsResourceParams.protocolDid,
+  );
   if (!protocol) {
     throw new Error(
       'Protocol not found with did: ' + settingsResourceParams.protocolDid,

--- a/packages/oracles-client-sdk/package.json
+++ b/packages/oracles-client-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ixo/oracles-client-sdk",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "type": "module",
   "private": false,
   "description": "Client SDK for interacting with QiForge oracles, designed for React applications",

--- a/packages/oracles-client-sdk/src/hooks/use-contract-oracle/use-contract-oracle.ts
+++ b/packages/oracles-client-sdk/src/hooks/use-contract-oracle/use-contract-oracle.ts
@@ -24,6 +24,11 @@ interface IUseContractOracleProps {
   };
 }
 
+// Oracle entity settings (authz config, pricing list, room ids) change rarely;
+// keep them fresh for a while so remounting hosts (lists render one hook per
+// oracle card) don't refetch the same documents.
+const ORACLE_CONFIG_STALE_TIME_MS = 5 * 60 * 1000;
+
 const useContractOracle = ({ params }: IUseContractOracleProps) => {
   const { wallet, transactSignX } = useOraclesContext();
   const matrixClientRef = useMemo(
@@ -45,7 +50,8 @@ const useContractOracle = ({ params }: IUseContractOracleProps) => {
       });
       return config;
     },
-    enabled: Boolean(wallet?.address),
+    enabled: Boolean(wallet?.address && params.oracleDid),
+    staleTime: ORACLE_CONFIG_STALE_TIME_MS,
   });
 
   const { data: oracleRoomId, isLoading: _isLoadingOracleRoomId } = useQuery({
@@ -59,6 +65,7 @@ const useContractOracle = ({ params }: IUseContractOracleProps) => {
       return roomId;
     },
     enabled: Boolean(wallet?.did && params.oracleDid),
+    staleTime: ORACLE_CONFIG_STALE_TIME_MS,
   });
 
   // Get pricing list
@@ -72,6 +79,8 @@ const useContractOracle = ({ params }: IUseContractOracleProps) => {
       );
       return list;
     },
+    enabled: Boolean(params.oracleDid),
+    staleTime: ORACLE_CONFIG_STALE_TIME_MS,
   });
 
   const { mutateAsync: contractOracle, isPending: isContractingOracle } =

--- a/packages/oracles-client-sdk/src/hooks/use-oracles-config.ts
+++ b/packages/oracles-client-sdk/src/hooks/use-oracles-config.ts
@@ -11,6 +11,10 @@ type Service = {
   id: string;
 };
 
+// Oracle entity documents change rarely; a generous staleTime keeps remounting
+// consumers from refetching the same config.
+const ORACLES_CONFIG_STALE_TIME_MS = 5 * 60 * 1000;
+
 export const useOraclesConfig = (
   oracleId: string,
   overrides?: {
@@ -25,6 +29,8 @@ export const useOraclesConfig = (
       const res = await gqlClient.GetEntityById({ id: oracleId });
       return res.entity;
     },
+    enabled: Boolean(oracleId),
+    staleTime: ORACLES_CONFIG_STALE_TIME_MS,
   });
 
   const { data: authConfig, isLoading: isLoadingAuthConfig } = useQuery({
@@ -36,7 +42,8 @@ export const useOraclesConfig = (
         matrixAccessToken: wallet?.matrix.accessToken,
         matrixHomeServer: wallet?.matrix.homeServer,
       }),
-    enabled: Boolean(wallet?.address),
+    enabled: Boolean(wallet?.address && oracleId),
+    staleTime: ORACLES_CONFIG_STALE_TIME_MS,
   });
 
   const apiUrl = useMemo(() => {

--- a/packages/oracles-client-sdk/src/providers/oracles-provider/oracles-context.tsx
+++ b/packages/oracles-client-sdk/src/providers/oracles-provider/oracles-context.tsx
@@ -43,6 +43,7 @@ export const OraclesProvider = ({
   transactSignX,
   createDelegation,
   createInvocation,
+  queryClient: externalQueryClient,
 }: PropsWithChildren<IOraclesProviderProps>) => {
   if ((!initialWallet as unknown) || !transactSignX) {
     throw new Error('initialWallet and transactSignX are required');
@@ -217,7 +218,20 @@ export const OraclesProvider = ({
     ],
   );
 
-  const [queryClient] = useState(() => new QueryClient());
+  // Config-style queries barely change; without defaults every remount and
+  // window focus refetches them all.
+  const [ownQueryClient] = useState(
+    () =>
+      new QueryClient({
+        defaultOptions: {
+          queries: {
+            staleTime: 60_000,
+            refetchOnWindowFocus: false,
+          },
+        },
+      }),
+  );
+  const queryClient = externalQueryClient ?? ownQueryClient;
   return (
     <OraclesContext.Provider value={value}>
       <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>

--- a/packages/oracles-client-sdk/src/providers/oracles-provider/types.ts
+++ b/packages/oracles-client-sdk/src/providers/oracles-provider/types.ts
@@ -1,4 +1,5 @@
 import type { TransactionFn } from '@ixo/oracles-chain-client/react';
+import type { QueryClient } from '@tanstack/react-query';
 import type { AgAction } from '../../hooks/use-ag-action.js';
 
 export interface IMatrixLoginProps {
@@ -62,4 +63,10 @@ export interface IOraclesProviderProps {
   transactSignX: TransactionFn;
   createDelegation: CreateDelegationFn;
   createInvocation?: CreateInvocationFn;
+  /**
+   * Share the host app's react-query client instead of the SDK creating its
+   * own. Without this, hosts that already mount a QueryClientProvider get a
+   * second client (and second cache) shadowing theirs for the SDK subtree.
+   */
+  queryClient?: QueryClient;
 }


### PR DESCRIPTION
Cuts redundant blocksync GraphQL traffic from the client SDK. On the portal marketplace this was ~20 `GetEntityById` POSTs per navigation.

**@ixo/oracles-chain-client 2.0.1**
- `getSettingsResource` dedupes the protocol entity fetch (in-flight + 60s TTL) — the `#orz` authz and `#fee` pricing resources previously fetched the identical entity document side by side, twice per oracle.

**@ixo/oracles-client-sdk 1.3.2**
- `useContractOracle` / `useOraclesConfig`: config queries are now gated on a non-empty `oracleDid` (an empty DID fired a guaranteed-to-fail `GetEntityById({id:""})` plus 3 react-query retries) and got 5-minute `staleTime`s — these documents change rarely, and list hosts mount one hook per oracle card.
- `OraclesProvider`: its own QueryClient now has sane defaults (60s staleTime, no refetch-on-window-focus), and a new optional `queryClient` prop lets host apps share their existing react-query client instead of getting a second cache shadowing theirs for the SDK subtree.

No breaking changes — the new prop is optional and existing behavior only changes in request volume.

Verified: `pnpm build` for both packages, eslint + prettier clean on changed files.

Authored by: Michael Pretorius <michael@ixo.world>