### PR TITLE
Credits: configurable claim threshold + end-to-end pricing/cost logging (ORA-327)

### DIFF
--- a/packages/oracle-runtime/package.json
+++ b/packages/oracle-runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ixo/oracle-runtime",
-  "version": "1.3.3",
+  "version": "1.3.4",
   "description": "Plugin-based runtime for QiForge oracles",
   "private": false,
   "publishConfig": {

--- a/packages/oracle-runtime/src/plugins/credits/claim-processing.service.ts
+++ b/packages/oracle-runtime/src/plugins/credits/claim-processing.service.ts
@@ -55,6 +55,10 @@ interface ClaimProcessingConfig {
   // Raw env string — ConfigService reads process.env before the validated
   // (coerced) config, so this is never a boolean here.
   DISABLE_CREDITS?: string;
+  // Minimum held credits before a claim is settled on-chain. Arrives as a
+  // raw string when set in process.env, or the zod-coerced number (from the
+  // loaded validated config) when unset. Parsed defensively at boot.
+  MINIMUM_CLAIM_THRESHOLD?: string | number;
 }
 
 interface ProcessClaimParams {
@@ -78,8 +82,14 @@ interface SplitContext {
   originalAmount: number;
 }
 
-/** Minimum held credits before submitting a claim (prevents spam of tiny txns). */
-const MINIMUM_CLAIM_THRESHOLD = 5000;
+/**
+ * Default minimum held credits before submitting a claim (prevents spam of
+ * tiny txns). Overridable per-oracle via the `MINIMUM_CLAIM_THRESHOLD` env var.
+ */
+const DEFAULT_MINIMUM_CLAIM_THRESHOLD = 1000;
+
+/** Log prefix for the whole claim-settlement flow — grep this to trace it end-to-end. */
+const LOG_TAG = '[Credits/Claims]';
 
 /**
  * Submits held-credit claims to the chain on a fixed cron. Pulls users with
@@ -102,6 +112,7 @@ export class ClaimProcessingService {
   private readonly claimProcessingCheckpointer: BaseCheckpointSaver;
   private readonly claimProcessingDbPath: string;
   private readonly tokenLimiter: TokenLimiter;
+  private readonly minimumClaimThreshold: number;
 
   private readonly retryPolicy = {
     maxAttempts: 3,
@@ -128,6 +139,16 @@ export class ClaimProcessingService {
         ? MAINNET_IBC_DENOM
         : 'uixo';
 
+    this.minimumClaimThreshold = this.resolveMinimumClaimThreshold();
+
+    this.logger.log(
+      `${LOG_TAG} Claim processing initialized: network=${this.configService.get(
+        'NETWORK',
+      )} denom=${this.denom} minimumClaimThreshold=${this.minimumClaimThreshold} disableCredits=${
+        this.configService.get('DISABLE_CREDITS') ?? 'false'
+      } matrixAccountRoomId=${this.configService.get('MATRIX_ACCOUNT_ROOM_ID') ? 'set' : 'MISSING'}`,
+    );
+
     const sqlitePath = this.configService.getOrThrow('SQLITE_DATABASE_PATH');
     const claimProcessingFolder = path.join(sqlitePath, 'claim_processing');
     this.claimProcessingDbPath = path.join(
@@ -149,6 +170,29 @@ export class ClaimProcessingService {
     const sqliteSaver = SqliteSaver.fromConnString(this.claimProcessingDbPath);
     this.claimProcessingCheckpointer =
       sqliteSaver as unknown as BaseCheckpointSaver;
+  }
+
+  /**
+   * Resolve the minimum held-credits threshold from config. Accepts a raw env
+   * string (process.env precedence) or the zod-coerced number (from the loaded
+   * validated config); falls back to {@link DEFAULT_MINIMUM_CLAIM_THRESHOLD}
+   * when unset or invalid.
+   */
+  private resolveMinimumClaimThreshold(): number {
+    const raw = this.configService.get('MINIMUM_CLAIM_THRESHOLD');
+    if (raw === undefined || raw === null || raw === '') {
+      return DEFAULT_MINIMUM_CLAIM_THRESHOLD;
+    }
+
+    const parsed = typeof raw === 'number' ? raw : Number(raw);
+    if (!Number.isFinite(parsed) || parsed <= 0) {
+      this.logger.warn(
+        `${LOG_TAG} Invalid MINIMUM_CLAIM_THRESHOLD="${String(raw)}"; falling back to default ${DEFAULT_MINIMUM_CLAIM_THRESHOLD}`,
+      );
+      return DEFAULT_MINIMUM_CLAIM_THRESHOLD;
+    }
+
+    return Math.round(parsed);
   }
 
   /**
@@ -177,6 +221,10 @@ export class ClaimProcessingService {
       retry: this.retryPolicy,
     },
     async (params: ProcessClaimParams) => {
+      this.logger.log(
+        `${LOG_TAG} [step 1/4 submitIntent] user=${params.userDid} amount=${params.heldAmount} denom=${params.denom} — sending payment to escrow`,
+      );
+
       const collectionId =
         params.subscription.claimCollections.oracleClaimsCollectionId;
       if (!collectionId) {
@@ -194,7 +242,7 @@ export class ClaimProcessingService {
 
       if (hasActiveIntent) {
         this.logger.log(
-          `User ${params.userDid} already has an active intent, skipping`,
+          `${LOG_TAG} [step 1/4 submitIntent] user=${params.userDid} already has an active intent — reusing it, skipping escrow payment`,
         );
         return { success: true, transactionHash: null };
       }
@@ -208,13 +256,16 @@ export class ClaimProcessingService {
       });
 
       if (intent.code !== 0) {
+        this.logger.error(
+          `${LOG_TAG} [step 1/4 submitIntent] FAILED user=${params.userDid} code=${intent.code}: ${intent.rawLog || 'Unknown error'}`,
+        );
         throw new Error(
           `Failed to send payment to escrow: ${intent.rawLog || 'Unknown error'}`,
         );
       }
 
       this.logger.log(
-        `Successfully sent payment to escrow for user: ${params.userDid} with intent tx hash: ${intent.transactionHash}`,
+        `${LOG_TAG} [step 1/4 submitIntent] OK user=${params.userDid} intentTxHash=${intent.transactionHash}`,
       );
 
       return { success: true, transactionHash: intent.transactionHash };
@@ -228,6 +279,10 @@ export class ClaimProcessingService {
       retry: this.retryPolicy,
     },
     async (params: ProcessClaimParams) => {
+      this.logger.log(
+        `${LOG_TAG} [step 2/4 saveToMatrix] user=${params.userDid} amount=${params.heldAmount} — signing claim and saving to Matrix`,
+      );
+
       const collectionId =
         params.subscription.claimCollections.oracleClaimsCollectionId;
       if (!collectionId) {
@@ -280,7 +335,7 @@ export class ClaimProcessingService {
       });
 
       this.logger.log(
-        `Successfully submitted and saved signed claim ${cid} for user: ${params.userDid}`,
+        `${LOG_TAG} [step 2/4 saveToMatrix] OK user=${params.userDid} claimCid=${cid}`,
       );
 
       return { cid };
@@ -294,6 +349,10 @@ export class ClaimProcessingService {
       retry: this.retryPolicy,
     },
     async (params: ProcessClaimParams & { cid: string }) => {
+      this.logger.log(
+        `${LOG_TAG} [step 3/4 submitToChain] user=${params.userDid} claimCid=${params.cid} amount=${params.heldAmount} — submitting on-chain`,
+      );
+
       const collectionId =
         params.subscription.claimCollections.oracleClaimsCollectionId;
       if (!collectionId) {
@@ -317,13 +376,16 @@ export class ClaimProcessingService {
       });
 
       if (result.code !== 0) {
+        this.logger.error(
+          `${LOG_TAG} [step 3/4 submitToChain] FAILED user=${params.userDid} claimCid=${params.cid} code=${result.code}: ${result.rawLog || 'Unknown error'}`,
+        );
         throw new Error(
           `Failed to submit claim to chain: ${result.rawLog || 'Unknown error'}`,
         );
       }
 
       this.logger.log(
-        `Successfully submitted claim ${params.cid} to chain for user: ${params.userDid}`,
+        `${LOG_TAG} [step 3/4 submitToChain] OK user=${params.userDid} claimCid=${params.cid} chainTxHash=${result.transactionHash}`,
       );
 
       return { success: true, transactionHash: result.transactionHash };
@@ -341,10 +403,14 @@ export class ClaimProcessingService {
         this.configService.get('SUBSCRIPTION_URL') ??
         getSubscriptionUrlByNetwork(params.configService.getOrThrow('NETWORK'));
 
+      this.logger.log(
+        `${LOG_TAG} [step 4/4 sendToSubsApi] user=${params.userDid} claimCid=${params.cid} — notifying subscription API at ${subscriptionUrl}`,
+      );
+
       await submitClaimToSubscriptionApi(subscriptionUrl, params.cid);
 
       this.logger.log(
-        `Successfully sent claim ${params.cid} to subscription API for user: ${params.userDid}`,
+        `${LOG_TAG} [step 4/4 sendToSubsApi] OK user=${params.userDid} claimCid=${params.cid}`,
       );
 
       return { success: true };
@@ -390,51 +456,72 @@ export class ClaimProcessingService {
     if (disableCredits) {
       this.logger.debug(
         matrixAccountRoomId
-          ? 'Claims task submission skipped (DISABLE_CREDITS=true)'
-          : 'Claims task submission skipped (MATRIX_ACCOUNT_ROOM_ID not set)',
+          ? `${LOG_TAG} Cron tick skipped (DISABLE_CREDITS=true)`
+          : `${LOG_TAG} Cron tick skipped (MATRIX_ACCOUNT_ROOM_ID not set)`,
       );
       return;
     }
 
     const users = await this.tokenLimiter.listUsersWithHeldAmount(
-      MINIMUM_CLAIM_THRESHOLD,
+      this.minimumClaimThreshold,
     );
-    this.logger.log(`Processing held amount for ${users.length} users`);
+    this.logger.log(
+      `${LOG_TAG} Cron tick: ${users.length} user(s) at/above threshold ${this.minimumClaimThreshold} — starting settlement`,
+    );
+
+    let submitted = 0;
+    let skipped = 0;
+    let failed = 0;
 
     for (const [userDid, rawHeldAmount] of users) {
       try {
         const heldAmount = Math.round(rawHeldAmount);
-        if (heldAmount < MINIMUM_CLAIM_THRESHOLD) {
+        this.logger.log(
+          `${LOG_TAG} user=${userDid} heldAmount=${heldAmount} — evaluating`,
+        );
+        if (heldAmount < this.minimumClaimThreshold) {
           this.logger.debug(
-            `Held amount ${heldAmount} for user ${userDid} below threshold ${MINIMUM_CLAIM_THRESHOLD}, skipping`,
+            `${LOG_TAG} SKIP user=${userDid} heldAmount=${heldAmount} below threshold ${this.minimumClaimThreshold}`,
           );
+          skipped++;
           continue;
         }
 
         const subscription =
           await this.tokenLimiter.getSubscriptionPayload(userDid);
         if (!subscription) {
-          this.logger.warn(`No subscription found for user: ${userDid}`);
+          this.logger.warn(
+            `${LOG_TAG} SKIP user=${userDid} — no subscription payload found in Redis`,
+          );
+          skipped++;
           continue;
         }
 
         if (!subscription.claimCollections.oracleClaimsCollectionId) {
           this.logger.warn(
-            `No oracle claims collection ID found for user: ${userDid}`,
+            `${LOG_TAG} SKIP user=${userDid} — subscription has no oracleClaimsCollectionId`,
           );
+          skipped++;
           continue;
         }
 
         const availableCredits = subscription.totalCredits;
         if (availableCredits < heldAmount) {
           this.logger.warn(
-            `Insufficient available credits found for user: ${userDid}`,
+            `${LOG_TAG} SKIP user=${userDid} — insufficient available credits (available=${availableCredits} < held=${heldAmount})`,
           );
+          skipped++;
           continue;
         }
 
-        const oraclePricingList = await Payments.getOraclePricingList(
-          this.configService.getOrThrow('ORACLE_ENTITY_DID'),
+        const oracleEntityDid =
+          this.configService.getOrThrow('ORACLE_ENTITY_DID');
+        const oraclePricingList =
+          await Payments.getOraclePricingList(oracleEntityDid);
+        this.logger.log(
+          `${LOG_TAG} user=${userDid} pricing: fetched on-chain oracle pricing list for entity=${oracleEntityDid} → ${JSON.stringify(
+            oraclePricingList,
+          )}`,
         );
         const maxAllowedClaimAmount = oraclePricingList.find(
           (item) => item.denom === this.denom,
@@ -448,6 +535,9 @@ export class ClaimProcessingService {
 
         const maxAmount = parseInt(maxAllowedClaimAmount, 10);
         const splits = this.calculateSplits(heldAmount, maxAmount);
+        this.logger.log(
+          `${LOG_TAG} user=${userDid} cost: claiming heldAmount=${heldAmount} ${this.denom} | per-claim ceiling maxAmount=${maxAmount} ${this.denom} (from oracle pricing list) | ${splits.length} claim(s)`,
+        );
 
         const collectionId =
           subscription.claimCollections.oracleClaimsCollectionId;
@@ -461,7 +551,7 @@ export class ClaimProcessingService {
 
         if (splits.length > 1) {
           this.logger.log(
-            `Held amount ${heldAmount} for user ${userDid} exceeds max allowed ${maxAmount}. Splitting into ${splits.length} chunks: ${splits.join(', ')}`,
+            `${LOG_TAG} user=${userDid} heldAmount=${heldAmount} exceeds per-claim max ${maxAmount} — splitting into ${splits.length} chunks: ${splits.join(', ')}`,
           );
 
           for (let i = 0; i < splits.length; i++) {
@@ -492,11 +582,11 @@ export class ClaimProcessingService {
           }
 
           this.logger.log(
-            `Successfully processed all ${splits.length} splits for user: ${userDid}`,
+            `${LOG_TAG} DONE user=${userDid} — all ${splits.length} split claim(s) submitted successfully`,
           );
         } else {
           this.logger.log(
-            `Processing held amount ${heldAmount} for user ${userDid} (no splitting needed)`,
+            `${LOG_TAG} user=${userDid} heldAmount=${heldAmount} within per-claim max ${maxAmount} — no splitting needed`,
           );
 
           await this.processAmount(
@@ -505,15 +595,23 @@ export class ClaimProcessingService {
             subscriptionForProcessing,
           );
         }
+
+        submitted++;
       } catch (error) {
+        failed++;
         this.logger.error(
-          `Error processing held amount for user ${userDid}:`,
-          error instanceof Error ? error.message : String(error),
+          `${LOG_TAG} FAILED user=${userDid} — ${
+            error instanceof Error ? error.message : String(error)
+          } (held amount + pending claim kept, will retry next tick)`,
           error instanceof Error ? error.stack : undefined,
         );
         // Don't clear held amount or pending claim - will retry next run.
       }
     }
+
+    this.logger.log(
+      `${LOG_TAG} Cron tick complete: submitted=${submitted} skipped=${skipped} failed=${failed} (of ${users.length} candidate user(s))`,
+    );
   }
 
   /**
@@ -536,11 +634,13 @@ export class ClaimProcessingService {
       );
     }
 
-    if (splitContext) {
-      this.logger.log(
-        `Processing split ${splitContext.index}/${splitContext.total} (amount: ${heldAmount}, original: ${splitContext.originalAmount}) for user: ${userDid}`,
-      );
-    }
+    const claimLabel = splitContext
+      ? `split ${splitContext.index}/${splitContext.total} (amount=${heldAmount}, original=${splitContext.originalAmount})`
+      : `full claim (amount=${heldAmount})`;
+
+    this.logger.log(
+      `${LOG_TAG} user=${userDid} — starting 4-step workflow for ${claimLabel}`,
+    );
 
     const internalClaimId = await this.tokenLimiter.getOrCreatePendingClaim(
       userDid,
@@ -575,21 +675,21 @@ export class ClaimProcessingService {
       if (splitContext) {
         await this.tokenLimiter.incrementUserHeldAmount(userDid, -heldAmount);
         this.logger.log(
-          `Successfully processed split ${splitContext.index}/${splitContext.total} (claim ${result.cid}) and decremented held amount by ${heldAmount} for user: ${userDid}`,
+          `${LOG_TAG} ✔ SUBMITTED user=${userDid} claimCid=${result.cid} — split ${splitContext.index}/${splitContext.total} done, held amount decremented by ${heldAmount}`,
         );
       } else {
         await this.tokenLimiter.deleteUserHeldAmount(userDid);
         this.logger.log(
-          `Successfully processed claim ${result.cid} and cleared held amount and pending claim for user: ${userDid}`,
+          `${LOG_TAG} ✔ SUBMITTED user=${userDid} claimCid=${result.cid} — full claim done, held amount + pending claim cleared`,
         );
       }
     } else {
       this.logger.warn(
-        `Workflow completed but result indicates failure for user: ${userDid}${
+        `${LOG_TAG} workflow completed but result indicates failure for user=${userDid}${
           splitContext
             ? ` (split ${splitContext.index}/${splitContext.total})`
             : ''
-        }`,
+        } — held amount kept, will retry next tick`,
       );
     }
   }

--- a/packages/oracle-runtime/src/plugins/credits/credits.plugin.ts
+++ b/packages/oracle-runtime/src/plugins/credits/credits.plugin.ts
@@ -44,6 +44,10 @@ const CreditsConfigSchema = z.object({
     .enum(['true', 'false'])
     .optional()
     .transform((v) => v === 'true'),
+  // Minimum held credits before the claim-processing cron settles a claim
+  // on-chain. Validated when set; when unset, the claim-processing service
+  // applies its own default (prevents spamming the chain with tiny txns).
+  MINIMUM_CLAIM_THRESHOLD: z.coerce.number().int().positive().optional(),
 });
 
 type CreditsConfig = z.infer<typeof CreditsConfigSchema>;

--- a/packages/oracle-runtime/src/plugins/credits/token-limiter.ts
+++ b/packages/oracle-runtime/src/plugins/credits/token-limiter.ts
@@ -221,10 +221,14 @@ export class TokenLimiter {
     totalTokens: number;
     model?: string;
   }): number {
+    // Post-markup USD cost via the same 3-priority fallback — logged alongside
+    // credits in every branch so the source and dollar cost are both visible.
+    const usdCost = this.calculateCostUsdWithMarkup(params);
+
     if (params.providerCost != null && params.providerCost > 0) {
       const credits = this.usdCostToCredits(params.providerCost);
       this.logger.log(
-        `[TokenLimiter] Using provider cost: $${params.providerCost} → ${credits} credits`,
+        `[TokenLimiter] source=provider-cost providerCost=$${params.providerCost} costUsd=$${usdCost.toFixed(6)} → ${credits} credits (network=${this.network})`,
       );
       return credits;
     }
@@ -236,13 +240,13 @@ export class TokenLimiter {
         pricing,
       );
       this.logger.log(
-        `[TokenLimiter] Using cached pricing for model=${params.model ?? 'unknown'} → ${credits} credits`,
+        `[TokenLimiter] source=model-pricing model=${params.model ?? 'unknown'} in=${params.inputTokens} out=${params.outputTokens} costUsd=$${usdCost.toFixed(6)} → ${credits} credits (network=${this.network})`,
       );
       return credits;
     }
     const credits = this.llmTokenToCredits(params.totalTokens);
     this.logger.log(
-      `[TokenLimiter] Using flat-rate fallback (model=${params.model ?? 'unknown'}) → ${credits} credits`,
+      `[TokenLimiter] source=flat-rate model=${params.model ?? 'unknown'} totalTokens=${params.totalTokens} costUsd=$${usdCost.toFixed(6)} → ${credits} credits (network=${this.network})`,
     );
     return credits;
   }


### PR DESCRIPTION
## Summary

Makes credit metering and on-chain claim settlement observable, and makes the claim threshold configurable — diagnostics for **ORA-325** (PA doesn't seem to use credits on testnet). Documented in **ORA-327**.

All changes are in `packages/oracle-runtime/src/plugins/credits/`.

### 1. Configurable claim threshold (default lowered 5000 → 1000)
- New env var `MINIMUM_CLAIM_THRESHOLD` on the credits plugin `configSchema` (`z.coerce.number().int().positive().optional()` — validated loudly when set).
- Replaced the hardcoded `const MINIMUM_CLAIM_THRESHOLD = 5000` with `DEFAULT_MINIMUM_CLAIM_THRESHOLD = 1000` + a `resolveMinimumClaimThreshold()` helper that parses config defensively (raw `process.env` string *or* zod-coerced number) and falls back to the default when unset/invalid. Default lives in one place.
- Override: set `MINIMUM_CLAIM_THRESHOLD=<n>`; unset ⇒ 1000.

### 2. End-to-end claim-flow logging (`[Credits/Claims]` prefix)
- Boot: `Claim processing initialized: network=… denom=… minimumClaimThreshold=… disableCredits=… matrixAccountRoomId=set|MISSING`
- Per cron tick: `Cron tick: N user(s) at/above threshold T` → per-user `evaluating` → explicit `SKIP user=… — <reason>` → `Cron tick complete: submitted=X skipped=Y failed=Z`
- Per claim, each of the 4 workflow steps logs start + `OK`/`FAILED` with tx hashes (`intentTxHash`, `claimCid`, `chainTxHash`), ending in `✔ SUBMITTED user=… claimCid=…`.

### 3. Pricing source + cost visibility
- Claim cron logs where the per-claim ceiling comes from: `pricing: fetched on-chain oracle pricing list for entity=<did> → [...]` and `cost: claiming heldAmount=N <denom> | per-claim ceiling maxAmount=M <denom> | K claim(s)`.
- `TokenLimiter.creditsForUsage` now logs the pricing source and post-markup USD cost in **all three** fallback branches (previously only provider-cost showed a dollar figure): `source=provider-cost|model-pricing|flat-rate … costUsd=$… → N credits (network=…)`.

## Files
- `credits/credits.plugin.ts` — new `MINIMUM_CLAIM_THRESHOLD` config field.
- `credits/claim-processing.service.ts` — env-driven threshold + `[Credits/Claims]` logging + pricing/cost logs + per-tick counters.
- `credits/token-limiter.ts` — `source=…`/`costUsd=…` on all `creditsForUsage` branches.
- `oracle-runtime/package.json` — version bump to 1.3.4.

## Likely root cause for ORA-325
The flat-rate fallback (`llmTokenToCredits`, `$0.75 / 1M tokens × markup`) runs `Math.round`, so on testnet/devnet a small reply (~300 tokens → `costUsd≈$0.001125`) rounds to **0 credits** — the balance genuinely doesn't move, matching "balance stays the same". The new logs confirm which pricing source the PA hits on testnet and whether provider/per-model pricing is populated at all.

## Follow-up (not in this PR)
- Decide whether the flat-rate rate + `Math.round` should floor sub-1-credit testnet costs to 0, or accumulate fractionally.
- Stale unit test `credits.plugin.test.ts` (flat-rate `300 tokens → 1 credit`): its comment assumes `tokensPerMillion=1000` while `token-limiter.ts` uses `1_000_000` (actual `0`). Pre-existing; not touched.

## Verification
`pnpm typecheck`, `eslint`, `prettier --check` pass on all changed files. Credits unit suite: 8 pass, 1 pre-existing failure (the stale test above — unrelated to this change).
