### PR TITLE
fix(ucan): derive mnemonic signer in pure JS so minting works on Cloudflare Workers (IXO-3650)

### DIFF
--- a/packages/ucan/package.json
+++ b/packages/ucan/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@ixo/ucan",
   "description": "UCAN authorization for any service - built on ucanto",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "private": false,
   "publishConfig": {
     "access": "public"
@@ -56,8 +56,6 @@
     }
   },
   "devDependencies": {
-    "@cosmjs/crypto": "0.39.0",
-    "@cosmjs/encoding": "0.39.0",
     "@ixo/eslint-config": "workspace:*",
     "@ixo/typescript-config": "workspace:*",
     "@ixo/vitest-config": "workspace:*",
@@ -76,17 +74,7 @@
     "@ucanto/validator": "10.0.1"
   },
   "peerDependencies": {
-    "@cosmjs/crypto": ">=0.39.0",
-    "@cosmjs/encoding": ">=0.39.0",
     "typescript": ">=5.0.0"
-  },
-  "peerDependenciesMeta": {
-    "@cosmjs/crypto": {
-      "optional": true
-    },
-    "@cosmjs/encoding": {
-      "optional": true
-    }
   },
   "sideEffects": false
 }

--- a/packages/ucan/src/client/create-client.test.ts
+++ b/packages/ucan/src/client/create-client.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from 'vitest';
+import { ed25519 } from '@ucanto/principal';
+import { parseSigner, signerFromMnemonic } from './create-client.js';
+
+/**
+ * GOLDEN VECTORS — generated with the ORIGINAL @cosmjs/crypto (libsodium) implementation of
+ * `signerFromMnemonic` before it was replaced with the pure-JS derivation (WebCrypto SHA-256 +
+ * ucanto `ed25519.derive`). These pin the derivation contract byte-for-byte:
+ *
+ *   seed = SHA256(utf8(mnemonic.trim()))[0..32) → Ed25519 keypair
+ *   privateKey = 'M' + base64pad([0x80,0x26] + seed(32) + [0xed,0x01] + pubkey(32))
+ *
+ * If these ever fail, the derived keys no longer match the verification methods registered
+ * on-chain — that is a breaking change, not a test to update.
+ */
+const GOLDEN_VECTORS = [
+  {
+    mnemonic:
+      'test walk nut penalty hip pave soap entry language right filter choice',
+    did: 'did:key:z6Mkewi4Ko5asBsD3ihaHLAMYZJLx7DWJuRgkgPsme4yect7',
+    privateKey:
+      'MgCbkMwR9mL9STR39eTw2NNIOxsuPaF/w2cwo2mFQvp/bpO0BB0ms3SLsNb7m0aquWmOcC6Xx8EQiDH6LraZ3897K4ug=',
+  },
+  {
+    mnemonic:
+      'abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about',
+    did: 'did:key:z6MkpPcjwo4wP49VnvG7isXnqvFJyEqZ5JxSjohHxTT9Zr1c',
+    privateKey:
+      'MgCbFV+7IeN/YUro/iAh8TzUPCcVVN6teVJw80UMg7DzvOO0Bk6XyYZhJMeDfXHQ0sW1GjvsZUwmNPK1PoVBrngUuf8c=',
+  },
+] as const;
+
+describe('signerFromMnemonic', () => {
+  it.each(GOLDEN_VECTORS)(
+    'derives the same key as the original cosmjs implementation ($did)',
+    async ({ mnemonic, did, privateKey }) => {
+      const result = await signerFromMnemonic(mnemonic);
+      expect(result.did).toBe(did);
+      expect(result.privateKey).toBe(privateKey);
+      expect(result.signer.did()).toBe(did);
+    },
+  );
+
+  it('trims surrounding whitespace before hashing (same key either way)', async () => {
+    const clean = await signerFromMnemonic(GOLDEN_VECTORS[0].mnemonic);
+    const padded = await signerFromMnemonic(`  ${GOLDEN_VECTORS[0].mnemonic}\n`);
+    expect(padded.did).toBe(clean.did);
+    expect(padded.privateKey).toBe(clean.privateKey);
+  });
+
+  it('returns a privateKey that parseSigner round-trips to the same signer', async () => {
+    const { did, privateKey } = await signerFromMnemonic(GOLDEN_VECTORS[0].mnemonic);
+    const reparsed = parseSigner(privateKey);
+    expect(reparsed.did()).toBe(did);
+  });
+
+  it('produces signatures that verify against the derived public key', async () => {
+    const { signer, did } = await signerFromMnemonic(GOLDEN_VECTORS[0].mnemonic);
+    const payload = new TextEncoder().encode('ucan-signer-round-trip');
+    const signature = await signer.sign(payload);
+    const verifier = ed25519.Verifier.parse(did as `did:key:${string}`);
+    expect(await verifier.verify(payload, signature)).toBe(true);
+  });
+
+  it('withDID override keeps the same key but reports the supplied DID', async () => {
+    const oracleDid = 'did:ixo:ixo1fyc0tfakzvup0p7q76apt9kky255h5vejajqkl' as const;
+    const { signer, did, privateKey } = await signerFromMnemonic(
+      GOLDEN_VECTORS[0].mnemonic,
+      oracleDid,
+    );
+    expect(did).toBe(oracleDid);
+    expect(signer.did()).toBe(oracleDid);
+    // The underlying key is unchanged — the privateKey still parses to the base did:key.
+    expect(privateKey).toBe(GOLDEN_VECTORS[0].privateKey);
+  });
+});

--- a/packages/ucan/src/client/create-client.ts
+++ b/packages/ucan/src/client/create-client.ts
@@ -106,53 +106,23 @@ export async function signerFromMnemonic(
   did: string;
   privateKey: string;
 }> {
-  // Use @cosmjs/crypto - same as IXO frontend for verification methods
-  // This ensures the derived key matches what's registered on-chain
-  const { Ed25519, sha256 } = await import('@cosmjs/crypto');
-  const { toUtf8 } = await import('@cosmjs/encoding');
-
-  // Derive Ed25519 keypair using same method as IXO verification methods:
-  // SHA256(mnemonic UTF-8 bytes) → first 32 bytes as seed → Ed25519 keypair
-  const seed = sha256(toUtf8(mnemonic.trim())).slice(0, 32);
-  const keypair = await Ed25519.makeKeypair(seed);
-
-  // Note: cosmjs returns keypair.privkey as 64 bytes (seed + pubkey concatenated)
-  // but ucanto expects just the 32-byte seed, so we use `seed` directly
-
-  // Build ucanto's private key format (68 bytes total):
-  // M + base64( [0x80, 0x26] + seed(32) + [0xed, 0x01] + pubkey(32) )
-  // where:
-  //   [0x80, 0x26] = varint for 0x1300 (ed25519-priv multicodec)
-  //   [0xed, 0x01] = varint for 0xed (ed25519-pub multicodec, 237 decimal)
-  const ED25519_PRIV_MULTICODEC = new Uint8Array([0x80, 0x26]); // 2 bytes
-  const ED25519_PUB_MULTICODEC = new Uint8Array([0xed, 0x01]); // 2 bytes (varint of 237)
-
-  // Total: 2 + 32 + 2 + 32 = 68 bytes (matches ucanto expectation)
-  const keyMaterial = new Uint8Array(
-    ED25519_PRIV_MULTICODEC.length + // 2
-      seed.length + // 32
-      ED25519_PUB_MULTICODEC.length + // 2
-      keypair.pubkey.length, // 32
+  // Derive the Ed25519 keypair the same way as IXO verification methods:
+  // SHA256(mnemonic UTF-8 bytes) → first 32 bytes as seed → Ed25519 keypair.
+  //
+  // Pure JS (WebCrypto + ucanto) so it runs everywhere ucanto runs — Node,
+  // browsers, and Cloudflare Workers. (The previous implementation derived the
+  // keypair via @cosmjs/crypto, whose libsodium WASM loader crashes on workerd.
+  // The output is byte-identical — see the golden vectors in create-client.test.ts.)
+  const digest = await crypto.subtle.digest(
+    'SHA-256',
+    new TextEncoder().encode(mnemonic.trim()),
   );
-  keyMaterial.set(ED25519_PRIV_MULTICODEC, 0);
-  keyMaterial.set(seed, ED25519_PRIV_MULTICODEC.length);
-  keyMaterial.set(
-    ED25519_PUB_MULTICODEC,
-    ED25519_PRIV_MULTICODEC.length + seed.length,
-  );
-  keyMaterial.set(
-    keypair.pubkey,
-    ED25519_PRIV_MULTICODEC.length +
-      seed.length +
-      ED25519_PUB_MULTICODEC.length,
-  );
+  const seed = new Uint8Array(digest).slice(0, 32);
 
-  // Encode as base64pad multibase (prefix 'M')
-  const base64 = Buffer.from(keyMaterial).toString('base64');
-  const multibasePrivateKey = 'M' + base64;
-
-  // Parse using ucanto's parser to get a proper Signer
-  const signer = ed25519.Signer.parse(multibasePrivateKey);
+  const signer = await ed25519.derive(seed);
+  // ed25519.format → 'M' + base64pad([0x80,0x26] + seed(32) + [0xed,0x01] + pubkey(32)),
+  // i.e. exactly the 68-byte ucanto private key the old code assembled by hand.
+  const multibasePrivateKey = ed25519.format(signer);
   const finalSigner = did ? signer.withDID(did) : signer;
 
   return {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1109,12 +1109,6 @@ importers:
         specifier: 10.0.1
         version: 10.0.1
     devDependencies:
-      '@cosmjs/crypto':
-        specifier: 0.39.0
-        version: 0.39.0
-      '@cosmjs/encoding':
-        specifier: 0.39.0
-        version: 0.39.0
       '@ixo/eslint-config':
         specifier: workspace:*
         version: link:../eslint-config


### PR DESCRIPTION
Linear: [IXO-3650](https://linear.app/ixo-world/issue/IXO-3650/fix-ixoucan-on-cloudflare-workers-mnemonic-signer-crashed-on) (sub-issue of [IXO-3628](https://linear.app/ixo-world/issue/IXO-3628/eval-engine-prod-version-re-write))

## The problem

`signerFromMnemonic()` derived its Ed25519 keypair via `@cosmjs/crypto`'s `Ed25519.makeKeypair(seed)`, which is backed by **libsodium (WASM)**. libsodium's module loader locates its `.wasm` by sniffing its environment — browser globals (`document` / `location.href`) or Node globals. **workerd is neither**, so it dereferences `undefined.href` and throws:

```
TypeError: Cannot read properties of undefined (reading 'href')
  at libsodium-sumo.js → Module2.useBackupModule
```

This made `@ixo/ucan` unusable on Cloudflare Workers for **any service that MINTS (signs) UCANs** — a load-time crash, not a wrong result.

## Why it was invisible until now

Only the signing path imports cosmjs; the validation path is pure JS. Every existing consumer sat on the safe side of that line:

| Consumer | Runtime | Uses | Affected |
| --- | --- | --- | --- |
| `subscriptions-api` | Workers | validate only | No |
| `ixo-ucan-store-worker` | Workers | validate only | No |
| `ixo-matrix-claims-bot` | Node | mints | No (libsodium loads on Node) |
| portal | browser | mints | No (libsodium loads in browsers) |

**`eval-engine` is the first UCAN *client* running inside a Worker** — the first to mint on workerd, and so the first to hit it.

## The fix

Derive the same key without WASM:

- **seed** — WebCrypto `crypto.subtle.digest('SHA-256', …)` instead of cosmjs `sha256`/`toUtf8`.
- **keypair + encoding** — `ed25519.derive(seed)` and `ed25519.format(signer)` from **`@ucanto/principal`**, already this package's own dependency and already the source of the final Signer via `ed25519.Signer.parse()`.

cosmjs was only ever a calculator for two intermediate values (the seed and the public key); `ed25519.format` emits exactly the 68-byte private key the old code hand-assembled. **The derivation contract is unchanged:**

```
seed       = SHA256(utf8(mnemonic.trim()))[0..32)  → Ed25519 keypair
privateKey = 'M' + base64pad([0x80,0x26] + seed(32) + [0xed,0x01] + pubkey(32))
```

Also drops `@cosmjs/crypto` / `@cosmjs/encoding` from `devDependencies`, `peerDependencies` and `peerDependenciesMeta` — nothing imports them now. That also closes the optional-peer trap where minting failed with `Cannot find module '@cosmjs/crypto'` unless a consumer happened to install it.

## Evidence: keys are byte-identical

These keys are registered on-chain, so the bar was not "does it work" but "is it the same key, byte for byte".

- **Golden vectors** — generated from the **original cosmjs implementation** and pinned in the new `packages/ucan/src/client/create-client.test.ts`. Both `did:key` **and** the `privateKey` string match **byte-for-byte**.
- **Real devnet oracle mnemonic** — old vs new → identical `did` + identical `privateKey`. Cross-check: a signature produced by the **new** signer verifies under the **old** implementation's public key.
- **Package tests: 33/33 pass.** Built `dist/` contains zero cosmjs/libsodium references.

## Evidence: proven end-to-end on real workerd

`eval-engine` (Cloudflare Worker) pulled a real devnet claim: minted a `store/get` invocation → fetched the owner delegation from the UCAN Store → minted a delegation-backed bot invocation → retrieved the decrypted claim body plus two 320 KB PNG attachments. Same on-chain Ed25519 verification method, zero signature changes.

## Impact on consumers

**Consumers that only validate are unaffected** — that path never touched the broken code. Patch release (2.0.0 → 2.0.1). Publishing to npm is deliberately left as a separate call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
