### PR TITLE
[codex] Evict expired Composio tool definitions

### DIFF
--- a/packages/oracle-runtime/src/plugins/composio/composio-tools.ts
+++ b/packages/oracle-runtime/src/plugins/composio/composio-tools.ts
@@ -104,9 +104,9 @@ function defsCacheKey(baseUrl: string, userId: string): string {
 
 /**
  * Drop expired entries (and, if still over the cap, the soonest-to-expire
- * ones). Runs on every cache write, so in a long-running multi-tenant
- * process one-off users' schemas are reclaimed instead of accumulating for
- * the process lifetime.
+ * ones). Runs on cache reads and writes, so in a long-running multi-tenant
+ * process one-off users' schemas are reclaimed even when opening a replacement
+ * session fails.
  */
 function pruneDefsCache(cache: ComposioDefsCache, now: number): void {
   for (const [key, entry] of cache) {
@@ -298,8 +298,11 @@ export async function createComposioTools(
   };
 
   const cacheKey = defsCacheKey(opts.baseUrl, opts.userId);
+  const now = Date.now();
+  if (opts.defsCache) pruneDefsCache(opts.defsCache, now);
+
   const cached = opts.defsCache?.get(cacheKey);
-  if (cached && cached.expiresAt > Date.now()) {
+  if (cached && cached.expiresAt > now) {
     return buildLazySessionTools(cached.defs, sessionArgs, sessionFactory);
   }
 

--- a/packages/oracle-runtime/src/plugins/composio/composio.plugin.test.ts
+++ b/packages/oracle-runtime/src/plugins/composio/composio.plugin.test.ts
@@ -384,6 +384,34 @@ describe('ComposioPlugin.getRequestTools — session tool-definition cache', () 
     expect(defsCache.has(`${COMPOSIO_URL}::did:ixo:fresh-user`)).toBe(true);
   });
 
+  it('evicts an expired entry before opening its replacement session', async () => {
+    const cacheKey = `${COMPOSIO_URL}::did:ixo:offline-user`;
+    const defsCache: ComposioDefsCache = new Map([
+      [
+        cacheKey,
+        {
+          defs: [{ name: 'STALE', description: 'stale', schema: undefined }],
+          expiresAt: Date.now() - 1,
+        },
+      ],
+    ]);
+
+    await expect(
+      createComposioTools({
+        apiKey: COMPOSIO_API_KEY,
+        baseUrl: COMPOSIO_URL,
+        ucanInvocation: 'ucan-token-offline',
+        userId: 'did:ixo:offline-user',
+        sessionFactory: async () => {
+          throw new Error('composio unavailable');
+        },
+        defsCache,
+      }),
+    ).rejects.toThrow('composio unavailable');
+
+    expect(defsCache.has(cacheKey)).toBe(false);
+  });
+
   it('caps the cache size, evicting the soonest-to-expire entries first', async () => {
     const defsCache: ComposioDefsCache = new Map();
     const base = Date.now() + COMPOSIO_TOOL_DEFS_TTL_MS;


### PR DESCRIPTION
## Summary

This fixes unbounded retention of per-user Composio tool-definition schemas in a long-running oracle process.

The cache previously treated expired entries as misses but did not remove them until a later successful write. One-off tenants could therefore leave stale schemas resident for the life of the process, particularly if replacement session creation failed.

The request path now prunes expired entries before cache lookup, and retains the existing post-write prune and 1,000-entry cap. This reclaims stale user entries on both reads and writes while preserving warm-cache behavior for live sessions.

## Validation

- `pnpm --filter @ixo/oracle-runtime exec vitest run src/plugins/composio/composio.plugin.test.ts` — 15 tests passed
- `pnpm --filter @ixo/oracle-runtime exec eslint src/plugins/composio/composio-tools.ts src/plugins/composio/composio.plugin.test.ts`
- `git diff --check`

A regression test proves an expired entry is removed before a replacement session attempt, including when that attempt fails.