### PR TITLE
feat(matrix): bot-sdk 0.8.0-ixo.14 + cross-signing bootstrap for MSC4268 history sharing

### DIFF
--- a/.changeset/matrix-cross-signing-msc4268.md
+++ b/.changeset/matrix-cross-signing-msc4268.md
@@ -1,0 +1,5 @@
+---
+'@ixo/matrix': minor
+---
+
+Bump matrix-bot-sdk to ^0.8.0-ixo.14 and bootstrap cross-signing after the Matrix client starts. Brings MSC4268 encrypted history sharing (send and accept), the non-blocking room tracker (instant startup with a deferred background room scan), and a fail-closed encryption check on send. Cross-signing is required for key bundles in both directions; the identity is restored from Secret Storage when available.

--- a/packages/matrix/package.json
+++ b/packages/matrix/package.json
@@ -52,7 +52,7 @@
     "@langchain/langgraph-checkpoint": "1.0.2",
     "dotenv": "^17.2.0",
     "marked": "^16.4.0",
-    "matrix-bot-sdk": "npm:@ixo/matrix-bot-sdk@^0.8.0-ixo.12",
+    "matrix-bot-sdk": "npm:@ixo/matrix-bot-sdk@^0.8.0-ixo.14",
     "matrix-js-sdk": "^37.11.0",
     "superjson": "1.13.3"
   }

--- a/packages/matrix/src/matrix-manager.ts
+++ b/packages/matrix/src/matrix-manager.ts
@@ -170,6 +170,23 @@ export class MatrixManager {
       this.mxClient = createSimpleMatrixClient(config);
       await this.mxClient.start();
 
+      // Publish (or restore from Secret Storage) the client's cross-signing
+      // identity. Required for MSC4268 history sharing in both directions:
+      // key bundles this client sends are only trusted from a cross-signed
+      // device, and bundles it receives are only delivered to cross-signed
+      // devices.
+      const crypto = this.mxClient.mxClient.crypto;
+      if (crypto?.isReady) {
+        try {
+          await crypto.ensureCrossSigningBootstrapped();
+        } catch (e) {
+          Logger.warn(
+            'Failed to bootstrap cross-signing; history sharing on invite will not work:',
+            e,
+          );
+        }
+      }
+
       this.stateManager = MatrixStateManager.getInstance();
 
       // Mark as initialized only after everything succeeds

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -594,8 +594,8 @@ importers:
         specifier: ^16.4.0
         version: 16.4.2
       matrix-bot-sdk:
-        specifier: npm:@ixo/matrix-bot-sdk@^0.8.0-ixo.12
-        version: '@ixo/matrix-bot-sdk@0.8.0-ixo.12'
+        specifier: npm:@ixo/matrix-bot-sdk@^0.8.0-ixo.14
+        version: '@ixo/matrix-bot-sdk@0.8.0-ixo.14'
       matrix-js-sdk:
         specifier: ^37.11.0
         version: 37.13.0
@@ -3429,6 +3429,10 @@ packages:
     resolution: {integrity: sha512-T3gQb2MwytN+A+hzLrOmrIsROOOU9S4mHEJ68O/U86s+3R3vqTtQTwum4tetGXqg2pwJHXCVn8F449Xh/ybc4g==}
     engines: {node: '>=22.0.0'}
 
+  '@ixo/matrix-bot-sdk@0.8.0-ixo.14':
+    resolution: {integrity: sha512-Uf4HflULYYrWudPEdzzFBTpXhMd0Flo0IbNdcMt3T+YGQBQl5xzzv8RCN8FWWz02YrWBzPO73ZsaSgn6cUFMBA==}
+    engines: {node: '>=22.0.0'}
+
   '@ixo/matrix-crdt@1.2.5':
     resolution: {integrity: sha512-/l59DAsD1A9QPLyj+najCTm/s0A6DEHjAtR0d5r0EMSlD5/OmumaH4hlGqAmK1rCIkRC86WjJ1owHmgRxBOomQ==}
     peerDependencies:
@@ -3440,6 +3444,10 @@ packages:
   '@ixo/matrix-sdk-crypto-nodejs@0.4.2':
     resolution: {integrity: sha512-kzDNrsr9CojYX+8JfrND+/KbNRDcliwkaY9FTxo8OCM3ye7a4n2RmV6qo4jfRA4V9IqYA0G++s2Sr7XLMEhdng==}
     engines: {node: '>= 22'}
+
+  '@ixo/matrix-sdk-crypto-nodejs@0.6.1-ixo.1':
+    resolution: {integrity: sha512-YQJ1wbnDgcJ32aCiIgypXXcyqUdciNhIPKCHTfmklUuI0JDgWIoXr7QwSpNMhIVx1O+fIBGQWZIJd2AePj5eXQ==}
+    engines: {node: '>= 24'}
 
   '@ixo/matrix@1.2.33':
     resolution: {integrity: sha512-ZIUqpCTHycxMDj1YKoi9zHWB3uStrtJJ+TFmQzdWKP8sF22PzBcXxmij6GYHBKpIJGoRNOdxB+7kGtV30vtSAw==}
@@ -16738,6 +16746,30 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@ixo/matrix-bot-sdk@0.8.0-ixo.14':
+    dependencies:
+      '@ixo/matrix-sdk-crypto-nodejs': 0.6.1-ixo.1
+      '@types/express': 4.17.25
+      another-json: 0.2.0
+      async-lock: 1.4.1
+      bs58: 6.0.0
+      chalk: 4.1.2
+      express: 4.22.2
+      glob-to-regexp: 0.4.1
+      hash.js: 1.1.7
+      html-to-text: 9.0.5
+      htmlencode: 0.0.4
+      lowdb: 1.0.0
+      lru-cache: 10.4.3
+      mkdirp: 3.0.1
+      morgan: 1.11.0
+      postgres: 3.4.9
+      request: 2.88.2
+      request-promise: 4.2.6(request@2.88.2)
+      sanitize-html: 2.17.5
+    transitivePeerDependencies:
+      - supports-color
+
   '@ixo/matrix-crdt@1.2.5(lib0@0.2.117)(matrix-js-sdk@37.13.0)(y-protocols@1.0.7(yjs@13.6.31))(yjs@13.6.31)':
     dependencies:
       another-json: 0.2.0
@@ -16752,6 +16784,13 @@ snapshots:
       - supports-color
 
   '@ixo/matrix-sdk-crypto-nodejs@0.4.2':
+    dependencies:
+      https-proxy-agent: 7.0.6
+      node-downloader-helper: 2.1.11
+    transitivePeerDependencies:
+      - supports-color
+
+  '@ixo/matrix-sdk-crypto-nodejs@0.6.1-ixo.1':
     dependencies:
       https-proxy-agent: 7.0.6
       node-downloader-helper: 2.1.11


### PR DESCRIPTION
Brings `@ixo/matrix` in line with the matrix bot fleet (already live on devnet/testnet/mainnet):

- **matrix-bot-sdk `^0.8.0-ixo.12` → `^0.8.0-ixo.14`**: MSC4268 encrypted history sharing (send + accept), non-blocking room tracker (instant startup, deferred 10-min background room scan), fail-closed encryption check on send.
- **Cross-signing bootstrapped after `mxClient.start()`** in `MatrixManager.performInitialization` (restore-from-Secret-Storage first, fresh bootstrap otherwise). Required for key bundles in both directions: bundles this client sends are only trusted from a cross-signed device, and bundles it receives are only delivered to cross-signed devices. Non-fatal on failure — logged as a warning.
- Changeset included (`@ixo/matrix` minor).

Notes for deploys consuming this package: the rust crypto store schema migration is one-way — back up the store directory before first boot on the new version.