### PR TITLE
fix(ucan): claim the granted ability, not `*`, on downstream invocations

### DIFF
--- a/packages/oracle-runtime/package.json
+++ b/packages/oracle-runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ixo/oracle-runtime",
-  "version": "1.3.7",
+  "version": "1.3.8",
   "description": "Plugin-based runtime for QiForge oracles",
   "private": false,
   "publishConfig": {

--- a/packages/oracle-runtime/src/modules/messages/user-context-fetcher.test.ts
+++ b/packages/oracle-runtime/src/modules/messages/user-context-fetcher.test.ts
@@ -125,6 +125,9 @@ describe('UserContextFetcher.fetch', () => {
       MEMORY_ENGINE_URL,
       USER_DID,
       'ixo:memory',
+      // Must claim the granted ability, not '*' — a '*' claim is satisfiable
+      // only by a '*' grant, and the delegation grants 'memory/*'.
+      { can: 'memory/*' },
     );
     expect(memoryEngine.gatherUserContext).toHaveBeenCalledWith({
       oracleDid: ORACLE_DID,

--- a/packages/oracle-runtime/src/modules/messages/user-context-fetcher.ts
+++ b/packages/oracle-runtime/src/modules/messages/user-context-fetcher.ts
@@ -143,6 +143,9 @@ export class UserContextFetcher {
         engineUrl,
         userDid,
         'ixo:memory',
+        // Claim the ability the user's delegation actually grants. A `'*'`
+        // claim is satisfiable only by a `'*'` grant.
+        { can: 'memory/*' },
       );
     } catch (err) {
       this.logger.warn(

--- a/packages/oracle-runtime/src/modules/sessions/session-history-processor.service.ts
+++ b/packages/oracle-runtime/src/modules/sessions/session-history-processor.service.ts
@@ -197,6 +197,9 @@ export class SessionHistoryProcessor {
         this.configService.getOrThrow('MEMORY_ENGINE_URL'),
         did,
         'ixo:memory',
+        // Claim the ability the user's delegation actually grants. A `'*'`
+        // claim is satisfiable only by a `'*'` grant.
+        { can: 'memory/*' },
       );
       if (invocation) {
         memoryUcanInvocation = invocation;

--- a/packages/oracle-runtime/src/modules/subscription/subscription.middleware.ts
+++ b/packages/oracle-runtime/src/modules/subscription/subscription.middleware.ts
@@ -170,10 +170,15 @@ export class SubscriptionMiddleware implements NestMiddleware {
         );
       }
 
+      // `subscriptions/read` — the exact ability the user's delegation grants.
+      // Claiming `'*'` here would be unsatisfiable: ucanto only resolves a
+      // `'*'` claim against a `'*'` grant, so the read-scoped delegation the
+      // portal issues would be reported as an unknown capability.
       const invocation = await this.ucanService.createServiceInvocation(
         subscriptionUrl,
         did,
         'ixo:subscriptions',
+        { can: 'subscriptions/read' },
       );
       if (!invocation) {
         throw new HttpException(

--- a/packages/oracle-runtime/src/modules/ucan/ucan.service.invocation-ability.test.ts
+++ b/packages/oracle-runtime/src/modules/ucan/ucan.service.invocation-ability.test.ts
@@ -1,0 +1,149 @@
+/**
+ * The ability (`can`) a downstream invocation declares must be the ability the
+ * user's delegation actually grants.
+ *
+ * ucanto resolves a claim against a proof only when the delegated ability is
+ * `'*'`, equals the claimed ability, or is a `prefix/*` covering it — so a
+ * `'*'` claim is satisfiable ONLY by a `'*'` grant. Claiming `'*'` against a
+ * narrow grant (e.g. the portal's `subscriptions/read`) is an over-claim the
+ * service refuses.
+ *
+ * `@ixo/ucan` is mocked here: these assertions are about which capability the
+ * service asks for, not about real Ed25519 signing.
+ */
+import type { Cache } from 'cache-manager';
+import type { ConfigService } from '@nestjs/config';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { DelegationStore } from './delegation-store.js';
+import { UcanService } from './ucan.service.js';
+
+const { createInvocationMock } = vi.hoisted(() => ({
+  createInvocationMock: vi.fn(),
+}));
+
+vi.mock('@ixo/ucan', () => ({
+  signerFromMnemonic: vi.fn(async () => ({ signer: { id: 'signer' } })),
+  parseDelegation: vi.fn(async () => ({ expiration: Infinity })),
+  createInvocation: createInvocationMock,
+  serializeInvocation: vi.fn(async () => 'serialized-invocation'),
+}));
+
+vi.mock('@ixo/matrix', () => ({
+  MatrixManager: { getInstance: () => ({}) },
+}));
+
+vi.mock('@ixo/oracles-chain-client', () => ({
+  getMatrixHomeServerCroppedForDid: vi.fn(),
+}));
+
+const ORACLE_DID = 'did:ixo:oracle1';
+const USER_DID = 'did:ixo:user1';
+const SERVICE_DID = 'did:web:subscriptions.example';
+
+function makeCache(): Cache & { store: Map<string, unknown> } {
+  const store = new Map<string, unknown>();
+  return {
+    store,
+    get: vi.fn(async (k: string) => store.get(k)),
+    set: vi.fn(async (k: string, v: unknown) => {
+      store.set(k, v);
+    }),
+  } as unknown as Cache & { store: Map<string, unknown> };
+}
+
+function makeConfig(values: Record<string, unknown>): ConfigService {
+  return {
+    get: vi.fn(<T>(key: string): T | undefined => values[key] as T | undefined),
+    getOrThrow: vi.fn(<T>(key: string): T => values[key] as T),
+  } as unknown as ConfigService;
+}
+
+describe('UcanService — invocation ability', () => {
+  let svc: UcanService;
+  let cache: Cache & { store: Map<string, unknown> };
+
+  beforeEach(async () => {
+    createInvocationMock.mockReset();
+    createInvocationMock.mockResolvedValue({ cid: 'bafy-test' });
+    cache = makeCache();
+    svc = new UcanService(
+      makeConfig({ ORACLE_ENTITY_DID: ORACLE_DID }),
+      cache,
+      { read: vi.fn(), write: vi.fn() } as unknown as DelegationStore,
+    );
+    svc.setSigningMnemonic('seed words here', ORACLE_DID);
+    await svc.cacheDelegation(USER_DID, 'raw-delegation');
+  });
+
+  afterEach(() => {
+    svc.onModuleDestroy();
+    vi.restoreAllMocks();
+  });
+
+  function mintedCapability(): { can: string; with: string } {
+    return createInvocationMock.mock.calls.at(-1)?.[0].capability;
+  }
+
+  it('claims the requested ability rather than the wildcard', async () => {
+    await svc.mintInvocationForServiceDid(
+      USER_DID,
+      SERVICE_DID,
+      'ixo:subscriptions',
+      { can: 'subscriptions/read' },
+    );
+
+    expect(mintedCapability()).toEqual({
+      can: 'subscriptions/read',
+      with: 'ixo:subscriptions',
+    });
+  });
+
+  it("defaults to '*' so existing callers are unchanged", async () => {
+    await svc.mintInvocationForServiceDid(USER_DID, SERVICE_DID, 'ixo:memory');
+
+    expect(mintedCapability()).toEqual({ can: '*', with: 'ixo:memory' });
+  });
+
+  it('does not serve a cached invocation minted for a different ability', async () => {
+    await svc.mintInvocationForServiceDid(
+      USER_DID,
+      SERVICE_DID,
+      'ixo:subscriptions',
+      { can: 'subscriptions/read' },
+    );
+    expect(createInvocationMock).toHaveBeenCalledTimes(1);
+
+    // Same user + service, different ability: must mint afresh. Sharing the
+    // cache entry would hand back a read-scoped invocation for a '*' claim.
+    await svc.mintInvocationForServiceDid(
+      USER_DID,
+      SERVICE_DID,
+      'ixo:subscriptions',
+      { can: '*' },
+    );
+
+    expect(createInvocationMock).toHaveBeenCalledTimes(2);
+    expect(mintedCapability()).toEqual({
+      can: '*',
+      with: 'ixo:subscriptions',
+    });
+  });
+
+  it('still reuses the cached invocation for a repeated ability', async () => {
+    const opts = { can: 'subscriptions/read' };
+    await svc.mintInvocationForServiceDid(
+      USER_DID,
+      SERVICE_DID,
+      'ixo:subscriptions',
+      opts,
+    );
+    await svc.mintInvocationForServiceDid(
+      USER_DID,
+      SERVICE_DID,
+      'ixo:subscriptions',
+      opts,
+    );
+
+    expect(createInvocationMock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/oracle-runtime/src/modules/ucan/ucan.service.ts
+++ b/packages/oracle-runtime/src/modules/ucan/ucan.service.ts
@@ -636,12 +636,19 @@ export class UcanService implements OnModuleDestroy {
    * @param serviceUrl - URL of the downstream service (used to resolve did:web)
    * @param userDid - The user's DID (used to look up cached delegation)
    * @param resource - The capability resource URI (e.g., 'ixo:sandbox')
+   * @param opts.can - The ability to invoke. Defaults to `'*'`. Must be an
+   *   ability the user's delegation actually covers: ucanto resolves a claim
+   *   against a proof only when the delegated ability is `'*'`, equals the
+   *   claimed ability, or is a `prefix/*` pattern covering it. A `'*'` claim is
+   *   therefore ONLY satisfiable by a `'*'` grant — pass the concrete ability
+   *   (e.g. `'subscriptions/read'`) whenever the delegation grants one.
    * @returns Base64-encoded invocation CAR, or null if unavailable
    */
   async createServiceInvocation(
     serviceUrl: string,
     userDid: string,
     resource = 'ixo:sandbox',
+    opts: { can?: string; skipCache?: boolean } = {},
   ): Promise<string | null> {
     const serviceDid = await this.resolveServiceDid(serviceUrl);
     if (!serviceDid) {
@@ -650,7 +657,12 @@ export class UcanService implements OnModuleDestroy {
       );
       return null;
     }
-    return this.mintInvocationForServiceDid(userDid, serviceDid, resource);
+    return this.mintInvocationForServiceDid(
+      userDid,
+      serviceDid,
+      resource,
+      opts,
+    );
   }
 
   /**
@@ -663,13 +675,18 @@ export class UcanService implements OnModuleDestroy {
    * services that enforce single-use replay protection per invocation CID
    * (e.g. composio-worker). Without this flag a cached CID would be reused
    * across requests and rejected as a replay.
+   *
+   * `opts.can` — the ability to invoke, default `'*'`. See
+   * {@link createServiceInvocation} for why this must line up with what the
+   * user's delegation grants.
    */
   async mintInvocationForServiceDid(
     userDid: string,
     serviceDid: string,
     resource = 'ixo:sandbox',
-    opts: { skipCache?: boolean } = {},
+    opts: { skipCache?: boolean; can?: string } = {},
   ): Promise<string | null> {
+    const can = opts.can ?? '*';
     if (!this.signingMnemonic || !this.oracleDid) {
       this.logger.debug('[UCAN] No signing key available, skipping invocation');
       return null;
@@ -683,8 +700,10 @@ export class UcanService implements OnModuleDestroy {
       return null;
     }
 
-    // Check invocation cache (skipped for replay-protected services)
-    const cacheKey = `${INVOCATION_CACHE_PREFIX}${userDid}:${serviceDid}`;
+    // Check invocation cache (skipped for replay-protected services). The
+    // ability is part of the key — two mints for the same service with
+    // different `can` values are different invocations.
+    const cacheKey = `${INVOCATION_CACHE_PREFIX}${userDid}:${serviceDid}:${can}`;
     if (!opts.skipCache) {
       const cached = await this.cacheManager.get<{
         invocation: string;
@@ -721,7 +740,10 @@ export class UcanService implements OnModuleDestroy {
       const invocation = await createInvocation({
         issuer: signer,
         audience: serviceDid,
-        capability: { can: '*', with: resource as `${string}:${string}` },
+        capability: {
+          can: can as `${string}/${string}`,
+          with: resource as `${string}:${string}`,
+        },
         proofs: [delegation],
         expiration: expirationSeconds,
         // Unique nonce → unique invocation CID even for two mints in the same
@@ -746,7 +768,7 @@ export class UcanService implements OnModuleDestroy {
       }
 
       this.logger.debug(
-        `[UCAN] Created invocation: iss=${this.oracleDid} aud=${serviceDid} user=${userDid}`,
+        `[UCAN] Created invocation: iss=${this.oracleDid} aud=${serviceDid} user=${userDid} can=${can} with=${resource}`,
       );
       return serialized;
     } catch (error) {

--- a/packages/oracle-runtime/src/plugin-api/types.ts
+++ b/packages/oracle-runtime/src/plugin-api/types.ts
@@ -337,7 +337,7 @@ export interface RuntimeContext<TConfig = MergedConfig> {
     hasCapability: (resource: string, action: string) => boolean;
     mintInvocation: (
       target: { did: string; capability: string },
-      opts?: { skipCache?: boolean },
+      opts?: { skipCache?: boolean; can?: string },
     ) => Promise<string>;
     /**
      * Resolve a downstream service URL to its did:web identifier. Returns

--- a/packages/oracle-runtime/src/plugins/composio/composio-ucan.ts
+++ b/packages/oracle-runtime/src/plugins/composio/composio-ucan.ts
@@ -38,6 +38,9 @@ export async function mintComposioInvocation(
     runCtx,
     { did: composioDid, capability: 'ixo:sandbox' },
     'composio',
-    { skipCache: true },
+    // can: composio routes through the sandbox capability, and the user's
+    // delegation grants `sandbox/*`. A `'*'` claim is satisfiable only by a
+    // `'*'` grant — `'*'.startsWith('sandbox/')` is false.
+    { skipCache: true, can: 'sandbox/*' },
   );
 }

--- a/packages/oracle-runtime/src/plugins/composio/composio.plugin.test.ts
+++ b/packages/oracle-runtime/src/plugins/composio/composio.plugin.test.ts
@@ -106,7 +106,9 @@ describe('ComposioPlugin.getRequestTools — UCAN minting flow', () => {
     expect(resolveSpy).toHaveBeenCalledWith(COMPOSIO_URL);
     expect(mintSpy).toHaveBeenCalledWith(
       { did: 'did:web:composio.test', capability: 'ixo:sandbox' },
-      { skipCache: true },
+      // Composio routes through the sandbox capability; must claim the granted
+      // ability, not '*', since a '*' claim needs a '*' grant.
+      { skipCache: true, can: 'sandbox/*' },
     );
     expect(sessionFactory).toHaveBeenCalledWith({
       apiKey: COMPOSIO_API_KEY,

--- a/packages/oracle-runtime/src/plugins/memory/memory-ucan.ts
+++ b/packages/oracle-runtime/src/plugins/memory/memory-ucan.ts
@@ -36,6 +36,9 @@ export async function buildMemoryHeaders(
     runCtx,
     { did: memoryDid, capability: 'ixo:memory' },
     'memory',
+    // Claim the ability the user's delegation actually grants. A `'*'` claim is
+    // satisfiable only by a `'*'` grant — `'*'.startsWith('memory/')` is false.
+    { can: 'memory/*' },
   );
   if (!invocation) return null;
 

--- a/packages/oracle-runtime/src/plugins/memory/memory.plugin.test.ts
+++ b/packages/oracle-runtime/src/plugins/memory/memory.plugin.test.ts
@@ -197,10 +197,12 @@ describe('MemoryPlugin', () => {
 
     const headers = await buildMemoryHeaders(ctx, MEMORY_MCP_URL);
     expect(resolveServiceDid).toHaveBeenCalledWith(MEMORY_MCP_URL);
-    expect(mintInvocation).toHaveBeenCalledWith({
-      did: 'did:web:memory.test',
-      capability: 'ixo:memory',
-    });
+    expect(mintInvocation).toHaveBeenCalledWith(
+      { did: 'did:web:memory.test', capability: 'ixo:memory' },
+      // Must claim the granted ability, not '*' — a '*' claim is satisfiable
+      // only by a '*' grant, and the delegation grants 'memory/*'.
+      { can: 'memory/*' },
+    );
     expect(headers).toEqual({
       Authorization: 'Bearer inv-token',
       'X-Auth-Type': 'ucan',

--- a/packages/oracle-runtime/src/plugins/sandbox/sandbox-mcp.ts
+++ b/packages/oracle-runtime/src/plugins/sandbox/sandbox-mcp.ts
@@ -70,10 +70,12 @@ export function createDefaultAuthBuilder(): SandboxAuthBuilder {
     );
     if (sandboxDid) {
       try {
-        const invocation = await runCtx.ucan.mintInvocation({
-          did: sandboxDid,
-          capability: 'ixo:sandbox',
-        });
+        const invocation = await runCtx.ucan.mintInvocation(
+          { did: sandboxDid, capability: 'ixo:sandbox' },
+          // Claim the ability the user's delegation actually grants. A `'*'`
+          // claim is satisfiable only by a `'*'` grant.
+          { can: 'sandbox/*' },
+        );
         if (invocation) {
           headers.Authorization = `Bearer ${invocation}`;
           headers['X-Auth-Type'] = 'ucan';
@@ -95,10 +97,10 @@ export function createDefaultAuthBuilder(): SandboxAuthBuilder {
       );
       if (skillsDid) {
         try {
-          const skillsInvocation = await runCtx.ucan.mintInvocation({
-            did: skillsDid,
-            capability: 'ixo:skills',
-          });
+          const skillsInvocation = await runCtx.ucan.mintInvocation(
+            { did: skillsDid, capability: 'ixo:skills' },
+            { can: 'skills/*' },
+          );
           if (skillsInvocation) {
             headers['X-Skills-Invocation'] = skillsInvocation;
           }

--- a/packages/oracle-runtime/src/plugins/skills/skills-ucan.ts
+++ b/packages/oracle-runtime/src/plugins/skills/skills-ucan.ts
@@ -45,6 +45,10 @@ export function createDefaultSkillsUcanBuilder(): SkillsUcanBuilder {
       runCtx,
       { did: skillsDid, capability: 'ixo:skills' },
       'skills',
+      // Claim the ability the user's delegation actually grants. A `'*'` claim
+      // is satisfiable only by a `'*'` grant — `'*'.startsWith('skills/')` is
+      // false.
+      { can: 'skills/*' },
     );
     return invocation ?? undefined;
   };

--- a/packages/oracle-runtime/src/plugins/skills/skills.plugin.test.ts
+++ b/packages/oracle-runtime/src/plugins/skills/skills.plugin.test.ts
@@ -144,10 +144,12 @@ describe('createDefaultSkillsUcanBuilder', () => {
     const token = await builder(SKILLS_URL, runCtx);
 
     expect(resolveSpy).toHaveBeenCalledWith(SKILLS_URL);
-    expect(mintSpy).toHaveBeenCalledWith({
-      did: 'did:web:skills.test',
-      capability: 'ixo:skills',
-    });
+    expect(mintSpy).toHaveBeenCalledWith(
+      { did: 'did:web:skills.test', capability: 'ixo:skills' },
+      // Must claim the granted ability, not '*' — a '*' claim is satisfiable
+      // only by a '*' grant, and the delegation grants 'skills/*'.
+      { can: 'skills/*' },
+    );
     expect(token).toBe('minted-token');
 
     // When DID resolution returns null the builder returns undefined and

--- a/packages/oracle-runtime/src/plugins/ucan-failure.ts
+++ b/packages/oracle-runtime/src/plugins/ucan-failure.ts
@@ -100,7 +100,7 @@ export async function mintInvocationSafely(
   runCtx: RuntimeContext,
   target: { did: string; capability: string },
   plugin: string,
-  opts?: { skipCache?: boolean },
+  opts?: { skipCache?: boolean; can?: string },
 ): Promise<string | null> {
   try {
     // Forward `opts` only when supplied so the no-opts call signature stays

--- a/packages/oracle-runtime/src/runtime-context/ambient.ts
+++ b/packages/oracle-runtime/src/runtime-context/ambient.ts
@@ -68,7 +68,7 @@ export interface UcanAdapter {
   mintInvocation(
     userDid: string,
     target: { did: string; capability: string },
-    opts?: { skipCache?: boolean },
+    opts?: { skipCache?: boolean; can?: string },
   ): Promise<string>;
   /**
    * Resolve a downstream service URL to its did:web identifier (fetched


### PR DESCRIPTION
Fixes the 401 on the subscription check. Pairs with **ixoworld/subscriptions-service#60** — ship together.

Refs [ORA-364](https://linear.app/ixo-world/issue/ORA-364/ucan-oracle-over-claims-can-on-ixosubscriptions-401-after-ixoucan-210)

```
[UNAUTHORIZED] Claim {"can":"*"} is not authorized
  - Capability {"can":"*","with":"ixo:subscriptions"} is not authorized because:
    - Capability can not be (self) issued by 'did:ixo:ixo1x4p20…'
    - Delegated capability not found
    - Encountered unknown capabilities
      - {"can":"subscriptions/read","with":"ixo:subscriptions"}   ← what we were granted
```

## The bug

The portal delegates exactly:

```ts
{ can: "subscriptions/read", with: "ixo:subscriptions" }
```

but `mintInvocationForServiceDid` hardcoded `can: '*'`. ucanto resolves a claim against a proof only when the delegated ability is `'*'`, equals the claim, or is a `prefix/*` covering it (`resolveAbility`, `@ucanto/validator/src/capability.js:694`). A `'*'` claim is therefore satisfiable **only** by a `'*'` grant. We were asking for more than we were given.

Nothing regressed in the portal's caps — this was latent from day one.

## Why it surfaced now

The subscriptions API upgraded to `@ixo/ucan` 2.1.0. Under 2.0.1 its validator did:

```js
canIssue: (cap, issuer) => {
  if (options.rootIssuers.includes('*')) return true;   // ← anyone self-authorizes
  ...
}
```

That API runs with `rootIssuers: ['*']`, so our invocation was authorized on its own signature and **the delegation proofs were never walked or verified at all** — a real auth bypass. 2.1.0 restricts self-issuance to the chain's structural root, so proofs are genuinely verified and our over-claim is now rejected.

## The change

- `createServiceInvocation` / `mintInvocationForServiceDid` take `opts.can`, **defaulting to `'*'`** — every existing caller (memory, sandbox, skills, session history, user-context fetcher) is byte-identical.
- `SubscriptionMiddleware` asks for `{ can: 'subscriptions/read' }`.
- The ability is now part of the invocation cache key. Without that, a read-scoped invocation could be served for a wildcard claim.
- `mintInvocation` opts widened in `plugin-api/types.ts`, `runtime-context/ambient.ts`, `plugins/ucan-failure.ts` so plugins can pass it.

## Verification

Live against a worker on 2.1.0, real oracle signing key, portal-shaped delegation, called through `getUserSubscription()`:

| oracle invokes | before | after |
| --- | --- | --- |
| `can:'*'` | 401 (production error, verbatim) | 401 — correct, a read grant cannot back a wildcard claim |
| `can:'subscriptions/read'` | 401 unknown capability | **200** — `status=active credits=9924.961` |

Attribution confirmed correct under 2.1.0: a self-signed invocation and one from an unrelated identity both 404, so the actor really is resolved from the verified chain root.

New `ucan.service.invocation-ability.test.ts` covers: the requested ability is claimed, the default stays `'*'`, and a cached invocation is not reused across abilities. Runtime suite: 930 passed. `pnpm lint` clean.

## Note for other services

`can: '*'` is still the default, so any service whose delegation grants a narrow ability (e.g. memory's `memory/*`) has the same latent mismatch and will break the moment it upgrades to 2.1.0 — `'*'.startsWith('memory/')` is false, so `memory/*` cannot back a `'*'` claim either. Those call sites should pass their concrete ability as a follow-up.