### PR TITLE
fix(schemas): resolve JSON-pointer $refs in client-declared tool schemas

### DIFF
--- a/packages/oracle-runtime/package.json
+++ b/packages/oracle-runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ixo/oracle-runtime",
-  "version": "1.3.8",
+  "version": "1.3.9",
   "description": "Plugin-based runtime for QiForge oracles",
   "private": false,
   "publishConfig": {

--- a/packages/oracle-runtime/src/plugins/agui/agui.plugin.test.ts
+++ b/packages/oracle-runtime/src/plugins/agui/agui.plugin.test.ts
@@ -25,6 +25,36 @@ const CHART_ACTION: AgAction = {
   schema: { type: 'object', properties: {}, required: [] },
 };
 
+/** What `zod-to-json-schema`'s default `$refStrategy: 'root'` emits for a
+ * subschema used twice — a JSON pointer `z.fromJSONSchema` cannot resolve. */
+const POINTER_REF_ACTION: AgAction = {
+  name: 'render_survey_ops',
+  description: 'Render a batch of survey operations.',
+  schema: {
+    type: 'object',
+    properties: {
+      ops: {
+        type: 'array',
+        items: {
+          type: 'object',
+          properties: { questionId: { type: 'string' } },
+        },
+      },
+      focus: { $ref: '#/properties/ops/items/properties/questionId' },
+    },
+    required: ['ops'],
+  },
+};
+
+const UNCONVERTIBLE_ACTION: AgAction = {
+  name: 'broken_action',
+  description: 'Declares a schema the runtime cannot convert.',
+  schema: {
+    type: 'object',
+    properties: { x: { $ref: 'https://example.com/remote.json' } },
+  },
+};
+
 vi.mock('@ixo/common', () => ({
   callAgAction: vi.fn(async () => ({ ok: true })),
   logActionToMatrix: vi.fn(),
@@ -102,6 +132,61 @@ describe('AGUIPlugin', () => {
     expect(prompt).toContain('AG-UI Agent');
     expect(prompt).toContain(TABLE_ACTION.name);
     expect(prompt).toContain(CHART_ACTION.name);
+  });
+
+  it('builds an action tool from a schema carrying JSON-pointer $refs', async () => {
+    const plugin = new AGUIPlugin();
+    const rtCtx = makeRuntimeContext({
+      history: {
+        messages: [],
+        recent: () => [],
+        userContext: {},
+        state: { messages: [], agActions: [POINTER_REF_ACTION] },
+      },
+    });
+
+    const [sub] = await plugin.getRequestSubAgents(rtCtx);
+    if (!sub) throw new Error('expected one sub-agent');
+    const tools = Array.isArray(sub.tools) ? sub.tools : [];
+    expect(tools.map((t) => t.name)).toEqual([POINTER_REF_ACTION.name]);
+    expect(
+      tools[0]?.schema.safeParse({ ops: [{ questionId: 'q1' }], focus: 'q1' })
+        .success,
+    ).toBe(true);
+  });
+
+  it('drops an action whose schema cannot be converted, keeping the others', async () => {
+    const plugin = new AGUIPlugin();
+    const rtCtx = makeRuntimeContext({
+      history: {
+        messages: [],
+        recent: () => [],
+        userContext: {},
+        state: {
+          messages: [],
+          agActions: [UNCONVERTIBLE_ACTION, TABLE_ACTION],
+        },
+      },
+    });
+
+    const [sub] = await plugin.getRequestSubAgents(rtCtx);
+    if (!sub) throw new Error('expected one sub-agent');
+    const tools = Array.isArray(sub.tools) ? sub.tools : [];
+    expect(tools.map((t) => t.name)).toEqual([TABLE_ACTION.name]);
+  });
+
+  it('returns no sub-agent when every declared action has an unconvertible schema', async () => {
+    const plugin = new AGUIPlugin();
+    const rtCtx = makeRuntimeContext({
+      history: {
+        messages: [],
+        recent: () => [],
+        userContext: {},
+        state: { messages: [], agActions: [UNCONVERTIBLE_ACTION] },
+      },
+    });
+
+    await expect(plugin.getRequestSubAgents(rtCtx)).resolves.toEqual([]);
   });
 
   it('action tool handler dispatches via callAgAction with the session id and tags args + roomId logging', async () => {

--- a/packages/oracle-runtime/src/plugins/agui/agui.plugin.ts
+++ b/packages/oracle-runtime/src/plugins/agui/agui.plugin.ts
@@ -10,6 +10,7 @@ import type {
   PluginTool,
   RuntimeContext,
 } from '../../plugin-api/types.js';
+import { clientSchemaToZod } from '../../utils/client-tool-schema.js';
 import { createAguiSubAgent } from './agui-agent.js';
 
 const manifest: PluginManifest = {
@@ -72,8 +73,14 @@ function parseArgs(input: unknown): Record<string, unknown> {
  * success, unique tool-call id per invocation) but sources `sessionId`,
  * `requestId`, and `roomId` from `RuntimeContext` instead of LangChain'
  * configurable bag.
+ *
+ * Returns `null` when the FE declared a schema the runtime cannot convert —
+ * that action is dropped rather than failing the whole request.
  */
-function buildActionTool(action: AgAction): PluginTool {
+function buildActionTool(action: AgAction): PluginTool | null {
+  const schema = clientSchemaToZod(action.schema, action.name);
+  if (!schema) return null;
+
   return tool(
     async (input, ctx: RuntimeContext) => {
       const sessionId = ctx.session.id;
@@ -113,7 +120,7 @@ function buildActionTool(action: AgAction): PluginTool {
     {
       name: action.name,
       description: action.description,
-      schema: z.fromJSONSchema(action.schema),
+      schema,
     },
   );
 }
@@ -142,7 +149,11 @@ export class AGUIPlugin extends OraclePlugin {
     const actions = readAgActions(rtCtx);
     if (actions.length === 0) return [];
 
-    const tools = actions.map(buildActionTool);
+    const tools = actions
+      .map(buildActionTool)
+      .filter((tool): tool is PluginTool => tool !== null);
+    if (tools.length === 0) return [];
+
     return [createAguiSubAgent(tools)];
   }
 }

--- a/packages/oracle-runtime/src/plugins/portal/portal.plugin.test.ts
+++ b/packages/oracle-runtime/src/plugins/portal/portal.plugin.test.ts
@@ -28,6 +28,36 @@ const CLICK_TOOL: BrowserToolCall = {
   },
 };
 
+/** What `zod-to-json-schema`'s default `$refStrategy: 'root'` emits for a
+ * subschema used twice — a JSON pointer `z.fromJSONSchema` cannot resolve. */
+const POINTER_REF_TOOL: BrowserToolCall = {
+  name: 'apply_survey_ops',
+  description: 'Apply a batch of operations to an open survey.',
+  schema: {
+    type: 'object',
+    properties: {
+      ops: {
+        type: 'array',
+        items: {
+          type: 'object',
+          properties: { questionId: { type: 'string' } },
+        },
+      },
+      focus: { $ref: '#/properties/ops/items/properties/questionId' },
+    },
+    required: ['ops'],
+  },
+};
+
+const UNCONVERTIBLE_TOOL: BrowserToolCall = {
+  name: 'broken_tool',
+  description: 'Declares a schema the runtime cannot convert.',
+  schema: {
+    type: 'object',
+    properties: { x: { $ref: 'https://example.com/remote.json' } },
+  },
+};
+
 vi.mock('@ixo/common', () => ({
   callBrowserTool: vi.fn(async () => ({ ok: true })),
   logActionToMatrix: vi.fn(),
@@ -103,6 +133,43 @@ describe('PortalPlugin', () => {
     );
     expect(openUrlSchema?.safeParse({ url: 123 }).success).toBe(false);
     expect(openUrlSchema?.safeParse({}).success).toBe(false);
+  });
+
+  it('builds a tool from a schema carrying JSON-pointer $refs', async () => {
+    const plugin = new PortalPlugin();
+    const rtCtx = makeRuntimeContext({
+      history: {
+        messages: [],
+        recent: () => [],
+        userContext: {},
+        state: { messages: [], browserTools: [POINTER_REF_TOOL] },
+      },
+    });
+
+    const tools = await plugin.getRequestTools(rtCtx);
+    expect(tools.map((t) => t.name)).toEqual([POINTER_REF_TOOL.name]);
+    expect(
+      tools[0]?.schema.safeParse({ ops: [{ questionId: 'q1' }], focus: 'q1' })
+        .success,
+    ).toBe(true);
+  });
+
+  it('drops a tool whose schema cannot be converted, keeping the others', async () => {
+    const plugin = new PortalPlugin();
+    const rtCtx = makeRuntimeContext({
+      history: {
+        messages: [],
+        recent: () => [],
+        userContext: {},
+        state: {
+          messages: [],
+          browserTools: [UNCONVERTIBLE_TOOL, OPEN_URL_TOOL],
+        },
+      },
+    });
+
+    const tools = await plugin.getRequestTools(rtCtx);
+    expect(tools.map((t) => t.name)).toEqual([OPEN_URL_TOOL.name]);
   });
 
   it('tool handler dispatches via callBrowserTool with session id, requestId-derived toolCallId, and matrix logging when roomId is set', async () => {

--- a/packages/oracle-runtime/src/plugins/portal/portal.plugin.ts
+++ b/packages/oracle-runtime/src/plugins/portal/portal.plugin.ts
@@ -8,6 +8,7 @@ import type {
   PluginTool,
   RuntimeContext,
 } from '../../plugin-api/types.js';
+import { clientSchemaToZod } from '../../utils/client-tool-schema.js';
 
 const manifest: PluginManifest = {
   title: 'Portal',
@@ -68,8 +69,14 @@ function parseArgs(input: unknown): Record<string, unknown> {
  * success, `tc-${requestId}` tool-call id) but sources `sessionId`,
  * `requestId`, and `roomId` from `RuntimeContext` instead of LangChain's
  * configurable bag.
+ *
+ * Returns `null` when the FE declared a schema the runtime cannot convert —
+ * that tool is dropped rather than failing the whole request.
  */
-function buildBrowserTool(descriptor: BrowserToolCall): PluginTool {
+function buildBrowserTool(descriptor: BrowserToolCall): PluginTool | null {
+  const schema = clientSchemaToZod(descriptor.schema, descriptor.name);
+  if (!schema) return null;
+
   return tool(
     async (input, ctx: RuntimeContext) => {
       const sessionId = ctx.session.id;
@@ -109,7 +116,7 @@ function buildBrowserTool(descriptor: BrowserToolCall): PluginTool {
     {
       name: descriptor.name,
       description: descriptor.description,
-      schema: z.fromJSONSchema(descriptor.schema),
+      schema,
     },
   );
 }
@@ -135,6 +142,8 @@ export class PortalPlugin extends OraclePlugin {
     const browserTools = readBrowserTools(rtCtx);
     if (browserTools.length === 0) return [];
 
-    return browserTools.map(buildBrowserTool);
+    return browserTools
+      .map(buildBrowserTool)
+      .filter((tool): tool is PluginTool => tool !== null);
   }
 }

--- a/packages/oracle-runtime/src/utils/client-tool-schema.test.ts
+++ b/packages/oracle-runtime/src/utils/client-tool-schema.test.ts
@@ -1,0 +1,164 @@
+import { describe, expect, it } from 'vitest';
+import { z } from 'zod';
+import {
+  clientSchemaToZod,
+  inlineLocalJsonPointerRefs,
+} from './client-tool-schema.js';
+
+/**
+ * Shape of what `zod-to-json-schema` emits with its default
+ * `$refStrategy: 'root'` when the same subschema appears twice: the second
+ * occurrence becomes a JSON pointer into the document.
+ */
+const SCHEMA_WITH_POINTER_REF = {
+  type: 'object',
+  properties: {
+    ops: {
+      type: 'array',
+      items: {
+        anyOf: [
+          { type: 'object', properties: { blockId: { type: 'string' } } },
+          { type: 'object', properties: { pageId: { type: 'string' } } },
+          {
+            type: 'object',
+            properties: {
+              questionId: { type: 'string', minLength: 1 },
+              value: { type: 'string' },
+            },
+            required: ['questionId'],
+          },
+        ],
+      },
+    },
+    focus: {
+      type: 'object',
+      properties: {
+        questionId: {
+          $ref: '#/properties/ops/items/anyOf/2/properties/questionId',
+        },
+      },
+    },
+  },
+  required: ['ops'],
+};
+
+describe('inlineLocalJsonPointerRefs', () => {
+  it('replaces a JSON-pointer ref with the subschema it targets', () => {
+    const inlined = inlineLocalJsonPointerRefs(SCHEMA_WITH_POINTER_REF);
+
+    const focus = inlined.properties as Record<string, unknown>;
+    expect(focus.focus).toEqual({
+      type: 'object',
+      properties: {
+        questionId: { type: 'string', minLength: 1 },
+      },
+    });
+  });
+
+  it('leaves refs zod resolves itself untouched', () => {
+    const schema = {
+      type: 'object',
+      $defs: { name: { type: 'string' } },
+      properties: { name: { $ref: '#/$defs/name' } },
+    };
+
+    const inlined = inlineLocalJsonPointerRefs(schema);
+
+    expect((inlined.properties as Record<string, unknown>).name).toEqual({
+      $ref: '#/$defs/name',
+    });
+  });
+
+  it('expands a self-referential pointer once, then cuts it off', () => {
+    const schema = {
+      type: 'object',
+      properties: {
+        node: {
+          type: 'object',
+          properties: { child: { $ref: '#/properties/node' } },
+        },
+      },
+    };
+
+    const inlined = inlineLocalJsonPointerRefs(schema);
+
+    // One level of the recursive shape survives; the pointer inside that copy
+    // is already on the active path, so it collapses instead of recursing.
+    expect(inlined.properties).toEqual({
+      node: {
+        type: 'object',
+        properties: {
+          child: {
+            type: 'object',
+            properties: { child: {} },
+          },
+        },
+      },
+    });
+  });
+
+  it('drops a pointer that resolves to nothing', () => {
+    const schema = {
+      type: 'object',
+      properties: { missing: { $ref: '#/properties/nope/properties/gone' } },
+    };
+
+    const inlined = inlineLocalJsonPointerRefs(schema);
+
+    expect((inlined.properties as Record<string, unknown>).missing).toEqual({});
+  });
+
+  it('decodes RFC 6901 escapes in pointer segments', () => {
+    const schema = {
+      type: 'object',
+      properties: {
+        'a/b': { type: 'string', minLength: 2 },
+        alias: { $ref: '#/properties/a~1b' },
+      },
+    };
+
+    const inlined = inlineLocalJsonPointerRefs(schema);
+
+    expect((inlined.properties as Record<string, unknown>).alias).toEqual({
+      type: 'string',
+      minLength: 2,
+    });
+  });
+});
+
+describe('clientSchemaToZod', () => {
+  it('converts a schema that zod alone would reject', () => {
+    expect(() => z.fromJSONSchema(SCHEMA_WITH_POINTER_REF)).toThrow(
+      /Reference not found/,
+    );
+
+    const schema = clientSchemaToZod(SCHEMA_WITH_POINTER_REF, 'apply_ops');
+
+    expect(schema).not.toBeNull();
+    expect(
+      schema?.safeParse({
+        ops: [{ questionId: 'q1', value: 'yes' }],
+        focus: { questionId: 'q1' },
+      }).success,
+    ).toBe(true);
+  });
+
+  it('preserves the constraints carried by the inlined subschema', () => {
+    const schema = clientSchemaToZod(SCHEMA_WITH_POINTER_REF, 'apply_ops');
+
+    // `questionId` was pointed at a `minLength: 1` string — an empty string
+    // must still be rejected after inlining.
+    expect(
+      schema?.safeParse({ ops: [], focus: { questionId: '' } }).success,
+    ).toBe(false);
+  });
+
+  it('returns null when the schema cannot be converted at all', () => {
+    const schema = clientSchemaToZod(
+      { type: 'object', properties: { x: { $ref: 'https://example.com/x' } } },
+      'broken_tool',
+    );
+
+    expect(schema).toBeNull();
+  });
+});

--- a/packages/oracle-runtime/src/utils/client-tool-schema.ts
+++ b/packages/oracle-runtime/src/utils/client-tool-schema.ts
@@ -1,0 +1,136 @@
+import { Logger } from '@nestjs/common';
+import { z } from 'zod';
+
+const logger = new Logger('ClientToolSchema');
+
+type JsonRecord = Record<string, unknown>;
+
+function isRecord(value: unknown): value is JsonRecord {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+/**
+ * `#` and `#/$defs/*` / `#/definitions/*` are the only refs `z.fromJSONSchema`
+ * knows how to resolve — everything else it rejects outright.
+ */
+function isResolvableByZod(ref: string): boolean {
+  return ref === '#' || /^#\/(?:\$defs|definitions)\//.test(ref);
+}
+
+/** Decode the `~1` / `~0` escapes defined by RFC 6901. */
+function decodeSegment(segment: string): string {
+  return segment.replace(/~1/g, '/').replace(/~0/g, '~');
+}
+
+function resolvePointer(root: JsonRecord, ref: string): unknown {
+  const segments = ref.slice(1).split('/').filter(Boolean).map(decodeSegment);
+  let node: unknown = root;
+  for (const segment of segments) {
+    if (Array.isArray(node)) {
+      const index = Number(segment);
+      if (!Number.isInteger(index)) return undefined;
+      node = node[index];
+    } else if (isRecord(node)) {
+      node = node[segment];
+    } else {
+      return undefined;
+    }
+    if (node === undefined) return undefined;
+  }
+  return node;
+}
+
+/**
+ * Ceiling on how many pointers a single schema may expand. Inlining duplicates
+ * subtrees, so a schema built from many cross-referencing pointers can grow
+ * super-linearly; past this point the remaining refs are dropped rather than
+ * expanded. Far above what a real tool schema needs.
+ */
+const MAX_EXPANSIONS = 1_000;
+
+interface InlineState {
+  /** Pointers currently being expanded — guards self-referential targets. */
+  active: Set<string>;
+  expansions: number;
+}
+
+function inline(node: unknown, root: JsonRecord, state: InlineState): unknown {
+  if (Array.isArray(node)) {
+    return node.map((item) => inline(item, root, state));
+  }
+  if (!isRecord(node)) return node;
+
+  const inlinedSiblings: JsonRecord = {};
+  for (const [key, value] of Object.entries(node)) {
+    if (key === '$ref') continue;
+    inlinedSiblings[key] = inline(value, root, state);
+  }
+
+  const ref = node.$ref;
+  if (typeof ref !== 'string') {
+    if ('$ref' in node) inlinedSiblings.$ref = ref;
+    return inlinedSiblings;
+  }
+  // Leave refs zod handles itself, and external refs (it raises its own,
+  // clearer error for those).
+  if (isResolvableByZod(ref) || !ref.startsWith('#')) {
+    inlinedSiblings.$ref = ref;
+    return inlinedSiblings;
+  }
+  // A pointer whose target contains the pointer would expand forever. Drop the
+  // constraint — an unconstrained value still validates.
+  if (state.active.has(ref)) return inlinedSiblings;
+  if (state.expansions >= MAX_EXPANSIONS) return inlinedSiblings;
+
+  const target = resolvePointer(root, ref);
+  if (!isRecord(target)) return inlinedSiblings;
+
+  state.expansions += 1;
+  state.active.add(ref);
+  const expanded = inline(target, root, state);
+  state.active.delete(ref);
+
+  return isRecord(expanded)
+    ? { ...expanded, ...inlinedSiblings }
+    : inlinedSiblings;
+}
+
+/**
+ * Replace every local JSON-pointer `$ref` with the subschema it points at.
+ *
+ * `zod-to-json-schema` defaults to `$refStrategy: "root"`, so a subschema that
+ * appears more than once in a tool's schema is emitted once and every later
+ * occurrence becomes a pointer back into the document
+ * (`#/properties/ops/items/anyOf/2/properties/questionId`). Those pointers are
+ * valid JSON Schema but unresolvable by `z.fromJSONSchema`, so inline them
+ * before conversion.
+ */
+export function inlineLocalJsonPointerRefs(schema: JsonRecord): JsonRecord {
+  const inlined = inline(schema, schema, { active: new Set(), expansions: 0 });
+  return isRecord(inlined) ? inlined : schema;
+}
+
+/**
+ * Convert a client-declared JSON Schema (browser tool / AG-UI action) into a
+ * Zod schema.
+ *
+ * Returns `null` when the schema cannot be converted. Callers must skip that
+ * tool: these hooks run inside `collectRequest`, where a rejection fails the
+ * whole collection and kills the turn, so one malformed client schema must not
+ * be allowed to take the request down with it.
+ */
+export function clientSchemaToZod(
+  schema: JsonRecord,
+  toolName: string,
+): z.ZodType | null {
+  try {
+    return z.fromJSONSchema(inlineLocalJsonPointerRefs(schema));
+  } catch (error) {
+    logger.error(
+      `Skipping client-declared tool "${toolName}": its JSON Schema could not be converted to Zod — ${
+        error instanceof Error ? error.message : String(error)
+      }`,
+    );
+    return null;
+  }
+}

--- a/packages/oracles-client-sdk/package.json
+++ b/packages/oracles-client-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ixo/oracles-client-sdk",
-  "version": "1.3.3",
+  "version": "1.3.4",
   "type": "module",
   "private": false,
   "description": "Client SDK for interacting with QiForge oracles, designed for React applications",

--- a/packages/oracles-client-sdk/src/hooks/use-chat/v2/use-send-message.ts
+++ b/packages/oracles-client-sdk/src/hooks/use-chat/v2/use-send-message.ts
@@ -19,6 +19,19 @@ import {
   type ISendMessageOptions,
 } from './types.js';
 
+/**
+ * Inline every repeated subschema instead of emitting a JSON-pointer back
+ * reference to it.
+ *
+ * `zod-to-json-schema` defaults to `$refStrategy: 'root'`, which turns the
+ * second occurrence of a shared subschema into `$ref:
+ * '#/properties/ops/items/anyOf/2/...'`. The oracle rebuilds these schemas with
+ * `z.fromJSONSchema`, which resolves only `#` and `#/$defs/*` and throws
+ * `Reference not found` on anything else — killing the turn before the agent
+ * runs.
+ */
+const JSON_SCHEMA_OPTIONS = { $refStrategy: 'none' } as const;
+
 interface IUseSendMessageReturn {
   sendMessage: (
     message: string,
@@ -163,7 +176,7 @@ export function useSendMessage({
             ? Object.values(browserTools).map((tool) => ({
                 name: tool.toolName,
                 description: tool.description,
-                schema: zodToJsonSchema(tool.schema),
+                schema: zodToJsonSchema(tool.schema, JSON_SCHEMA_OPTIONS),
               }))
             : undefined,
           agActions:
@@ -171,7 +184,10 @@ export function useSendMessage({
               ? agActions.map((action) => ({
                   name: action.name,
                   description: action.description,
-                  schema: zodToJsonSchema(action.parameters),
+                  schema: zodToJsonSchema(
+                    action.parameters,
+                    JSON_SCHEMA_OPTIONS,
+                  ),
                   hasRender: action.hasRender,
                 }))
               : undefined,


### PR DESCRIPTION
Fixes ORA-367.

## Symptom

Sending a message returned an error frame on the SSE stream and no agent response:

```
data: {"error":"Reference not found: #/properties/ops/items/anyOf/2/properties/questionId","timestamp":"..."}
```

The turn died before the agent ran, and every subsequent message on the thread failed identically.

## Root cause

`@ixo/oracles-client-sdk` serializes each browser tool / AG-UI action's Zod schema with `zodToJsonSchema(tool.schema)` — no options. `zod-to-json-schema` defaults to `$refStrategy: 'root'`, so a subschema used more than once is emitted once and every later occurrence becomes a JSON pointer back into the document (`#/properties/ops/items/anyOf/2/properties/questionId`).

The runtime rebuilds those schemas with `z.fromJSONSchema` (zod 4) in `portal.plugin.ts` and `agui.plugin.ts`. That function resolves only `#` and `#/$defs/*` — every other local pointer hits an unconditional `throw new Error('Reference not found: ' + ref)`.

That throw lands inside `ToolRegistry.collectRequest`, where one hook rejection fails the whole collection, so a single malformed client schema took the entire request down.

Because `browserTools` / `agActions` use `reducer: (_, curr) => curr`, a bad schema also persists in the thread checkpoint and re-throws on every turn until the client resends its tool set.

Not a regression from a recent commit — `z.fromJSONSchema` has been in both plugins since the plugin-runtime transform. What changed is a frontend tool declaring a repeated subschema. #216 removing the Portal sub-agent widened the blast radius but did not cause the throw.

## Changes

**Client SDK — stop emitting pointer refs**

`use-send-message.ts` now passes `{ $refStrategy: 'none' }` to both `zodToJsonSchema` calls (browser tools and AG-UI actions), so repeated subschemas inline.

**Runtime — stop one bad schema from killing the turn**

New `packages/oracle-runtime/src/utils/client-tool-schema.ts`:

- `inlineLocalJsonPointerRefs` — resolves local JSON-pointer `$ref`s against the document before conversion. Handles RFC 6901 escapes, expands self-referential pointers once then collapses them, drops unresolvable pointers, and caps total expansions against pathological blow-up. Leaves `#` and `#/$defs/*` for zod.
- `clientSchemaToZod` — wraps `z.fromJSONSchema`, logs the tool name and reason, returns `null` on failure.

`portal.plugin.ts` and `agui.plugin.ts` build tools through that helper and filter the `null`s. AG-UI returns no sub-agent when every declared action is unconvertible.

The runtime half is worth having on its own: it repairs schemas already sitting in existing thread checkpoints, which the SDK fix cannot reach.

## Testing

- 24 new/changed unit tests (8 util, 8 portal, 8 AG-UI) — including one asserting `z.fromJSONSchema` throws on the raw schema while `clientSchemaToZod` converts it, and one confirming a `minLength` constraint survives inlining.
- Full runtime suite green: **943 tests / 94 files**.
- `tsc --noEmit` clean on both packages; `pnpm lint` shows only pre-existing warnings.

## Shipping

- `@ixo/oracle-runtime` 1.3.8 → 1.3.9
- `@ixo/oracles-client-sdk` 1.3.3 → 1.3.4

Both need publishing, then `impacts-x-web` bumps the SDK.
