### PR TITLE
fix(common): update LangSmith security baseline

### DIFF
--- a/.changeset/secure-langsmith-prompt-pulls.md
+++ b/.changeset/secure-langsmith-prompt-pulls.md
@@ -1,0 +1,5 @@
+---
+'@ixo/common': patch
+---
+
+Update LangSmith to the patched 0.6 release line to address CVE-2026-45134.

--- a/apps/app/package.json
+++ b/apps/app/package.json
@@ -74,7 +74,7 @@
     "ioredis": "^5.6.1",
     "ipfs-only-hash": "^4.0.0",
     "langchain": "1.4.2",
-    "langsmith": "^0.5.25",
+    "langsmith": "^0.6.0",
     "lodash-es": "^4.17.21",
     "marked": "^18.0.2",
     "matrix-js-sdk": "^37.11.0",

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -68,7 +68,7 @@
     "duck-duck-scrape": "^2.2.5",
     "html-to-text": "9.0.5",
     "langchain": "1.4.2",
-    "langsmith": "^0.5.25",
+    "langsmith": "^0.6.0",
     "mammoth": "1.12.0",
     "node-emoji": "^2.2.0",
     "openai": "^6.34.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,6 +7,7 @@ settings:
 overrides:
   ws: 8.18.2
   form-data@<2.5.4: ^2.5.4
+  langsmith@<0.6.0: ^0.6.0
   did-resolver: 4.1.0
   '@langchain/core': 1.1.48
   '@langchain/langgraph': 1.3.2
@@ -232,8 +233,8 @@ importers:
         specifier: 1.4.2
         version: 1.4.2(@langchain/core@1.1.48(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.215.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.0(@opentelemetry/api@1.9.1))(openai@6.44.0(ws@8.18.2)(zod@4.4.3))(ws@8.18.2))(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.215.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.0(@opentelemetry/api@1.9.1))(openai@6.44.0(ws@8.18.2)(zod@4.4.3))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(ws@8.18.2)(zod-to-json-schema@3.25.2(zod@4.4.3))
       langsmith:
-        specifier: ^0.5.25
-        version: 0.5.26(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.215.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.0(@opentelemetry/api@1.9.1))(openai@6.44.0(ws@8.18.2)(zod@4.4.3))(ws@8.18.2)
+        specifier: ^0.6.0
+        version: 0.6.3(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.215.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.0(@opentelemetry/api@1.9.1))(openai@6.44.0(ws@8.18.2)(zod@4.4.3))(ws@8.18.2)
       lodash-es:
         specifier: ^4.17.21
         version: 4.18.1
@@ -447,8 +448,8 @@ importers:
         specifier: 1.4.2
         version: 1.4.2(@langchain/core@1.1.48(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.215.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.0(@opentelemetry/api@1.9.1))(openai@6.44.0(ws@8.18.2)(zod@4.4.3))(ws@8.18.2))(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.215.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.0(@opentelemetry/api@1.9.1))(openai@6.44.0(ws@8.18.2)(zod@4.4.3))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(ws@8.18.2)(zod-to-json-schema@3.25.2(zod@4.4.3))
       langsmith:
-        specifier: ^0.5.25
-        version: 0.5.26(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.215.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.0(@opentelemetry/api@1.9.1))(openai@6.44.0(ws@8.18.2)(zod@4.4.3))(ws@8.18.2)
+        specifier: ^0.6.0
+        version: 0.6.3(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.215.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.0(@opentelemetry/api@1.9.1))(openai@6.44.0(ws@8.18.2)(zod@4.4.3))(ws@8.18.2)
       mammoth:
         specifier: 1.12.0
         version: 1.12.0
@@ -9371,8 +9372,8 @@ packages:
     peerDependencies:
       '@langchain/core': 1.1.48
 
-  langsmith@0.5.26:
-    resolution: {integrity: sha512-HmmFgeQR2n9x1Kq8NiVaNL/j72ta71qN11hYjbyePJ/QuYEnOMhQjbNv9KeyKB3bOetpIzNalQbhHm+RyKoPRQ==}
+  langsmith@0.6.3:
+    resolution: {integrity: sha512-pXrQ4/4myQvjFFOAUmt5pWRrLEZR20gzIJD7MNdUH+5/S5nLI4ZRBo/SYKC6coaYj9pYTfQdBIzcs+3kfJ5uDA==}
     peerDependencies:
       '@opentelemetry/api': '*'
       '@opentelemetry/exporter-trace-otlp-proto': '*'
@@ -16399,7 +16400,7 @@ snapshots:
       duck-duck-scrape: 2.2.7
       html-to-text: 9.0.5
       langchain: 1.4.2(@langchain/core@1.1.48(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.215.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.0(@opentelemetry/api@1.9.1))(openai@6.44.0(ws@8.18.2)(zod@4.4.3))(ws@8.18.2))(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.215.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.0(@opentelemetry/api@1.9.1))(openai@6.44.0(ws@8.18.2)(zod@4.4.3))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(ws@8.18.2)(zod-to-json-schema@3.25.2(zod@4.4.3))
-      langsmith: 0.5.26(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.215.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.0(@opentelemetry/api@1.9.1))(openai@6.44.0(ws@8.18.2)(zod@4.4.3))(ws@8.18.2)
+      langsmith: 0.6.3(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.215.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.0(@opentelemetry/api@1.9.1))(openai@6.44.0(ws@8.18.2)(zod@4.4.3))(ws@8.18.2)
       mammoth: 1.12.0
       node-emoji: 2.2.0
       openai: 6.44.0(ws@8.18.2)(zod@4.4.3)
@@ -17086,7 +17087,7 @@ snapshots:
       yaml: 2.9.0
       zod: 4.4.3
     optionalDependencies:
-      langsmith: 0.5.26(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.215.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.0(@opentelemetry/api@1.9.1))(openai@6.44.0(ws@8.18.2)(zod@4.4.3))(ws@8.18.2)
+      langsmith: 0.6.3(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.215.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.0(@opentelemetry/api@1.9.1))(openai@6.44.0(ws@8.18.2)(zod@4.4.3))(ws@8.18.2)
     transitivePeerDependencies:
       - '@opentelemetry/api'
       - '@opentelemetry/exporter-trace-otlp-proto'
@@ -17105,7 +17106,7 @@ snapshots:
       flat: 5.0.2
       ibm-cloud-sdk-core: 5.5.0
       js-yaml: 4.2.0
-      langsmith: 0.5.26(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.215.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.0(@opentelemetry/api@1.9.1))(openai@6.44.0(ws@8.18.2)(zod@4.4.3))(ws@8.18.2)
+      langsmith: 0.6.3(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.215.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.0(@opentelemetry/api@1.9.1))(openai@6.44.0(ws@8.18.2)(zod@4.4.3))(ws@8.18.2)
       math-expression-evaluator: 2.0.7
       openai: 6.44.0(ws@8.18.2)(zod@4.4.3)
       uuid: 14.0.1
@@ -17136,7 +17137,7 @@ snapshots:
       '@cfworker/json-schema': 4.1.1
       '@standard-schema/spec': 1.1.0
       js-tiktoken: 1.0.21
-      langsmith: 0.5.26(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.215.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.0(@opentelemetry/api@1.9.1))(openai@6.44.0(ws@8.18.2)(zod@3.25.76))(ws@8.18.2)
+      langsmith: 0.6.3(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.215.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.0(@opentelemetry/api@1.9.1))(openai@6.44.0(ws@8.18.2)(zod@3.25.76))(ws@8.18.2)
       mustache: 4.2.0
       p-queue: 6.6.2
       zod: 4.4.3
@@ -17152,7 +17153,7 @@ snapshots:
       '@cfworker/json-schema': 4.1.1
       '@standard-schema/spec': 1.1.0
       js-tiktoken: 1.0.21
-      langsmith: 0.5.26(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.215.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.0(@opentelemetry/api@1.9.1))(openai@6.44.0(ws@8.18.2)(zod@4.4.3))(ws@8.18.2)
+      langsmith: 0.6.3(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.215.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.0(@opentelemetry/api@1.9.1))(openai@6.44.0(ws@8.18.2)(zod@4.4.3))(ws@8.18.2)
       mustache: 4.2.0
       p-queue: 6.6.2
       zod: 4.4.3
@@ -24126,7 +24127,7 @@ snapshots:
       '@langchain/core': 1.1.48(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.215.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.0(@opentelemetry/api@1.9.1))(openai@6.44.0(ws@8.18.2)(zod@4.4.3))(ws@8.18.2)
       '@langchain/langgraph': 1.3.2(@langchain/core@1.1.48(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.215.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.0(@opentelemetry/api@1.9.1))(openai@6.44.0(ws@8.18.2)(zod@4.4.3))(ws@8.18.2))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(zod-to-json-schema@3.25.2(zod@4.4.3))(zod@4.4.3)
       '@langchain/langgraph-checkpoint': 1.0.2(@langchain/core@1.1.48(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.215.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.0(@opentelemetry/api@1.9.1))(openai@6.44.0(ws@8.18.2)(zod@4.4.3))(ws@8.18.2))
-      langsmith: 0.5.26(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.215.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.0(@opentelemetry/api@1.9.1))(openai@6.44.0(ws@8.18.2)(zod@4.4.3))(ws@8.18.2)
+      langsmith: 0.6.3(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.215.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.0(@opentelemetry/api@1.9.1))(openai@6.44.0(ws@8.18.2)(zod@4.4.3))(ws@8.18.2)
       zod: 4.4.3
     transitivePeerDependencies:
       - '@opentelemetry/api'
@@ -24140,7 +24141,7 @@ snapshots:
       - ws
       - zod-to-json-schema
 
-  langsmith@0.5.26(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.215.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.0(@opentelemetry/api@1.9.1))(openai@6.44.0(ws@8.18.2)(zod@3.25.76))(ws@8.18.2):
+  langsmith@0.6.3(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.215.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.0(@opentelemetry/api@1.9.1))(openai@6.44.0(ws@8.18.2)(zod@3.25.76))(ws@8.18.2):
     dependencies:
       p-queue: 6.6.2
     optionalDependencies:
@@ -24150,7 +24151,7 @@ snapshots:
       openai: 6.44.0(ws@8.18.2)(zod@3.25.76)
       ws: 8.18.2
 
-  langsmith@0.5.26(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.215.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.0(@opentelemetry/api@1.9.1))(openai@6.44.0(ws@8.18.2)(zod@4.4.3))(ws@8.18.2):
+  langsmith@0.6.3(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.215.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.0(@opentelemetry/api@1.9.1))(openai@6.44.0(ws@8.18.2)(zod@4.4.3))(ws@8.18.2):
     dependencies:
       p-queue: 6.6.2
     optionalDependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -25,6 +25,9 @@ overrides:
   # which has a critical predictable-boundary advisory (GHSA-fjxv-7rqg-78g4
   # family). 2.5.4+ is the patched drop-in within the same major.
   'form-data@<2.5.4': '^2.5.4'
+  # LangSmith before 0.6.0 can trust public prompt pulls implicitly
+  # (CVE-2026-45134). Keep all compatible LangChain paths on the patched line.
+  'langsmith@<0.6.0': '^0.6.0'
   # @ixo/did-provider-x 0.1.x pins did-resolver@5 while the veramo 6/7
   # ecosystem (and this repo) type against ^4.1.0 — the runtime API is
   # identical; collapse to one version so resolver types line up.


### PR DESCRIPTION
## Summary

- move `@ixo/common` and the legacy app from LangSmith `^0.5.25` to the patched `^0.6.0` release line (currently resolves to `0.6.3`)
- add a targeted workspace override so compatible transitive LangChain paths cannot retain vulnerable LangSmith versions below `0.6.0`
- refresh the lockfile and add an `@ixo/common` patch changeset

## Why

LangSmith `0.5.26` is affected by [CVE-2026-45134](https://www.cve.org/CVERecord?id=CVE-2026-45134), which concerns insufficient trust handling when prompts are pulled from public `owner/name` identifiers. This was the remaining high-severity finding in the downstream `xero-oracle` image through `@ixo/oracle-runtime -> @ixo/common`.

The patched baseline is `0.6.0`; this PR resolves all qiforge LangSmith paths to `0.6.3` and removes `0.5.26` from the lockfile.

## Compatibility assessment

This should be low risk, although the `0.5 -> 0.6` change is technically a potentially breaking minor bump for a `0.x` package:

- qiforge has no direct LangSmith imports and does not call `pullPrompt` or `pullPromptCommit`
- the consuming LangChain packages accept LangSmith versions below `1.0.0`
- no application source or public `@ixo/common` API changes are required
- the common package builds and all 54 tests pass

The security change may intentionally affect a downstream consumer that directly uses LangSmith to pull a public prompt: it must follow the newer explicit trust behavior instead of implicitly trusting that prompt. No such code path exists in this repository.

## Validation

- `pnpm install --frozen-lockfile`
- `pnpm build --filter=@ixo/common` — 6/6 dependency/build tasks passed
- common Vitest suite — 9 files, 54 tests passed
- `pnpm lint` — no errors (4 existing warnings)
- `pnpm format:check`
- `pnpm audit --prod --json` — no LangSmith or CVE-2026-45134 advisory remains

## Existing validation limitations

- `pnpm test --filter=@ixo/common` cannot locate `vitest` because `@ixo/common` does not declare it directly; the same suite passes when invoked through the repository's installed `@ixo/vitest-config` Vitest binary.
- the separately excluded legacy `apps/app` build has five existing `@ixo/common` API/type mismatches (`CreateChatSessionDto` and constructor arguments). None involve LangSmith; the repository's normal root build already excludes this app.