### PR TITLE
feat(oracle-runtime): per-DID selective LangSmith tracing

### DIFF
--- a/packages/oracle-runtime/package.json
+++ b/packages/oracle-runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ixo/oracle-runtime",
-  "version": "1.3.9",
+  "version": "1.4.0",
   "description": "Plugin-based runtime for QiForge oracles",
   "private": false,
   "publishConfig": {

--- a/packages/oracle-runtime/src/bootstrap/create-oracle-app.ts
+++ b/packages/oracle-runtime/src/bootstrap/create-oracle-app.ts
@@ -16,6 +16,7 @@ import { DocumentBuilder, SwaggerModule } from '@nestjs/swagger';
 import pkg from '../../package.json' with { type: 'json' };
 import {
   baseEnvSchema,
+  validateLangsmithTracing,
   validateLlmProviderKey,
 } from '../config/base-env-schema.js';
 import type { MainAgentHooks } from '../graph/main-agent-types.js';
@@ -270,6 +271,23 @@ export async function createOracleApp(
     }
     throw new Error(
       `Env validation failed (${llmKeyErrors.length} issue${llmKeyErrors.length === 1 ? '' : 's'}).`,
+    );
+  }
+
+  // Cross-field check for the LangSmith selective-tracing allowlist —
+  // `LANGSMITH_TRACED_DIDS` requires an API key and must not be combined
+  // with the global `LANGSMITH_TRACING=true` switch. Failing here beats
+  // an operator believing per-user tracing is on while nothing uploads.
+  const langsmithErrors = validateLangsmithTracing(validated.config);
+  if (langsmithErrors.length > 0) {
+    for (const issue of langsmithErrors) {
+      reportBootError(
+        logger,
+        `LangSmith tracing env validation failed for '${issue.field}': ${issue.message}`,
+      );
+    }
+    throw new Error(
+      `Env validation failed (${langsmithErrors.length} issue${langsmithErrors.length === 1 ? '' : 's'}).`,
     );
   }
 

--- a/packages/oracle-runtime/src/config/base-env-schema.test.ts
+++ b/packages/oracle-runtime/src/config/base-env-schema.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { baseEnvSchema } from './base-env-schema.js';
+import { baseEnvSchema, validateLangsmithTracing } from './base-env-schema.js';
 
 describe('baseEnvSchema', () => {
   const requiredTier0Vars = {
@@ -124,8 +124,93 @@ describe('baseEnvSchema', () => {
       'LANGSMITH_API_KEY',
       'LANGSMITH_PROJECT',
       'LANGSMITH_ENDPOINT',
+      'LANGSMITH_TRACED_DIDS',
       'MAIN_REASONING_EFFORT',
     ]);
     expect(new Set(Object.keys(baseEnvSchema.shape))).toEqual(expected);
+  });
+});
+
+describe('validateLangsmithTracing', () => {
+  const USER_DID = 'did:ixo:ixo1traceduser';
+
+  it('returns no errors when LANGSMITH_TRACED_DIDS is unset', () => {
+    expect(validateLangsmithTracing({})).toEqual([]);
+    expect(validateLangsmithTracing({ LANGSMITH_TRACING: 'true' })).toEqual([]);
+  });
+
+  it('returns no errors when the allowlist is only whitespace', () => {
+    expect(validateLangsmithTracing({ LANGSMITH_TRACED_DIDS: '  ' })).toEqual(
+      [],
+    );
+  });
+
+  it('accepts a valid allowlist with an API key', () => {
+    expect(
+      validateLangsmithTracing({
+        LANGSMITH_TRACED_DIDS: `${USER_DID},did:x:zQ3shabc`,
+        LANGSMITH_API_KEY: 'ls-key',
+      }),
+    ).toEqual([]);
+  });
+
+  it('accepts the * wildcard', () => {
+    expect(
+      validateLangsmithTracing({
+        LANGSMITH_TRACED_DIDS: '*',
+        LANGSMITH_API_KEY: 'ls-key',
+      }),
+    ).toEqual([]);
+  });
+
+  it('rejects an allowlist without LANGSMITH_API_KEY', () => {
+    const errors = validateLangsmithTracing({
+      LANGSMITH_TRACED_DIDS: USER_DID,
+    });
+    expect(errors).toHaveLength(1);
+    expect(errors[0]?.field).toBe('LANGSMITH_API_KEY');
+  });
+
+  it('rejects the allowlist combined with global LANGSMITH_TRACING=true', () => {
+    const errors = validateLangsmithTracing({
+      LANGSMITH_TRACED_DIDS: USER_DID,
+      LANGSMITH_API_KEY: 'ls-key',
+      LANGSMITH_TRACING: 'true',
+    });
+    expect(errors).toHaveLength(1);
+    expect(errors[0]?.field).toBe('LANGSMITH_TRACED_DIDS');
+    expect(errors[0]?.message).toContain('LANGSMITH_TRACING=true');
+  });
+
+  it('allows the allowlist alongside LANGSMITH_TRACING=false', () => {
+    expect(
+      validateLangsmithTracing({
+        LANGSMITH_TRACED_DIDS: USER_DID,
+        LANGSMITH_API_KEY: 'ls-key',
+        LANGSMITH_TRACING: 'false',
+      }),
+    ).toEqual([]);
+  });
+
+  it('rejects entries that are neither * nor DIDs, naming the offenders', () => {
+    const errors = validateLangsmithTracing({
+      LANGSMITH_TRACED_DIDS: `${USER_DID},ixo1notadid did:ixo:ixo1space`,
+      LANGSMITH_API_KEY: 'ls-key',
+    });
+    expect(errors).toHaveLength(1);
+    expect(errors[0]?.field).toBe('LANGSMITH_TRACED_DIDS');
+    expect(errors[0]?.message).toContain('ixo1notadid');
+  });
+
+  it('reports every violated rule at once', () => {
+    const errors = validateLangsmithTracing({
+      LANGSMITH_TRACED_DIDS: 'not-a-did',
+      LANGSMITH_TRACING: 'true',
+    });
+    expect(errors.map((e) => e.field).sort()).toEqual([
+      'LANGSMITH_API_KEY',
+      'LANGSMITH_TRACED_DIDS',
+      'LANGSMITH_TRACED_DIDS',
+    ]);
   });
 });

--- a/packages/oracle-runtime/src/config/base-env-schema.ts
+++ b/packages/oracle-runtime/src/config/base-env-schema.ts
@@ -10,9 +10,10 @@ import { z } from 'zod';
  * extends onto this base schema at runtime.
  *
  * `LANGSMITH_*` keys are declared here because LangChain auto-wires tracing
- * when they are present in `process.env`; the runtime never reads them
- * directly, but documenting them in the base schema makes them visible to
- * `qiforge env` / inspect tooling.
+ * when they are present in `process.env`. The runtime reads them in exactly
+ * one place — the per-request selective-tracing decision in
+ * `modules/messages/langsmith-tracing.ts`; everything else (client
+ * construction, batching, upload) stays LangChain's own env-driven wiring.
  *
  * Field names match today's `apps/app/src/config.ts` exactly so existing
  * `.env` files keep working without renames.
@@ -106,6 +107,17 @@ export const baseEnvSchema = z.object({
   LANGSMITH_ENDPOINT: z.string().optional(),
 
   /**
+   * Selective tracing: comma-separated allowlist of user DIDs whose chat
+   * turns are traced to LangSmith without enabling the global
+   * `LANGSMITH_TRACING` switch (e.g. `did:ixo:ixo1abc...,did:x:zQ3sh...`).
+   * `*` traces every user. Requires `LANGSMITH_API_KEY`; mutually exclusive
+   * with `LANGSMITH_TRACING=true` — both misconfigurations fail the boot via
+   * `validateLangsmithTracing`. Unset = no selective tracing. Consumed
+   * per-request by `modules/messages/langsmith-tracing.ts`.
+   */
+  LANGSMITH_TRACED_DIDS: z.string().optional(),
+
+  /**
    * Extended-thinking effort for the main model. Lower = faster time-to-first
    * token, at some cost to hard multi-step reasoning. Default `medium`
    * preserves current behaviour; set `low` to trade reasoning depth for latency.
@@ -153,5 +165,76 @@ export function validateLlmProviderKey(
         'Set OPEN_ROUTER_API_KEY, or switch LLM_PROVIDER to nebius and set NEBIUS_API_KEY.',
     });
   }
+  return errors;
+}
+
+/**
+ * Cross-field check for the selective-tracing allowlist
+ * (`LANGSMITH_TRACED_DIDS`). Same contract as `validateLlmProviderKey`:
+ * returns structured errors for the boot-error reporter; empty array when
+ * the allowlist is unset.
+ *
+ * Rules (each would otherwise fail silently at request time):
+ *  - The allowlist requires `LANGSMITH_API_KEY` — without it the runtime
+ *    refuses to attach a tracer and the operator would believe tracing is
+ *    on while nothing uploads.
+ *  - The allowlist is mutually exclusive with `LANGSMITH_TRACING=true` —
+ *    the global switch already traces every user, which would make the
+ *    allowlist meaningless without any signal that it is being ignored.
+ *  - Every entry must be `*` or a `did:`-prefixed identifier — catches
+ *    delimiter typos (spaces, semicolons) that would otherwise trace nobody.
+ *
+ * Deliberately does NOT validate the global-mode combination
+ * (`LANGSMITH_TRACING=true` without `LANGSMITH_API_KEY`): LangChain also
+ * honours legacy `LANGCHAIN_*` aliases outside this schema, so rejecting
+ * that pair could break deployments that are actually working.
+ */
+export function validateLangsmithTracing(
+  env: Record<string, unknown>,
+): Array<{ field: string; message: string }> {
+  const raw = env.LANGSMITH_TRACED_DIDS;
+  if (typeof raw !== 'string' || raw.trim().length === 0) {
+    return [];
+  }
+
+  const errors: Array<{ field: string; message: string }> = [];
+
+  const apiKey = env.LANGSMITH_API_KEY;
+  if (typeof apiKey !== 'string' || apiKey.length === 0) {
+    errors.push({
+      field: 'LANGSMITH_API_KEY',
+      message:
+        'LANGSMITH_TRACED_DIDS is set but LANGSMITH_API_KEY is not — selective tracing ' +
+        'would silently upload nothing. Set LANGSMITH_API_KEY or unset LANGSMITH_TRACED_DIDS.',
+    });
+  }
+
+  const globalTracing = env.LANGSMITH_TRACING;
+  if (typeof globalTracing === 'string' && globalTracing.trim() === 'true') {
+    errors.push({
+      field: 'LANGSMITH_TRACED_DIDS',
+      message:
+        'LANGSMITH_TRACED_DIDS and LANGSMITH_TRACING=true are both set. Global tracing ' +
+        'already traces every user, which would silently ignore the allowlist. Unset one: ' +
+        'keep LANGSMITH_TRACING=true to trace everyone, or keep LANGSMITH_TRACED_DIDS to ' +
+        'trace only the listed DIDs.',
+    });
+  }
+
+  const invalidEntries = raw
+    .split(',')
+    .map((entry) => entry.trim())
+    .filter((entry) => entry.length > 0)
+    .filter((entry) => entry !== '*' && !entry.startsWith('did:'));
+  if (invalidEntries.length > 0) {
+    errors.push({
+      field: 'LANGSMITH_TRACED_DIDS',
+      message:
+        `LANGSMITH_TRACED_DIDS contains entries that are neither '*' nor DIDs: ` +
+        `${invalidEntries.join(', ')}. Use a comma-separated list of did:-prefixed ` +
+        `identifiers, or '*' to trace every user.`,
+    });
+  }
+
   return errors;
 }

--- a/packages/oracle-runtime/src/modules/messages/agent-builder.test.ts
+++ b/packages/oracle-runtime/src/modules/messages/agent-builder.test.ts
@@ -1,5 +1,6 @@
 import type { Cache } from '@nestjs/cache-manager';
 import type { ConfigService } from '@nestjs/config';
+import { LangChainTracer } from '@langchain/core/tracers/tracer_langchain';
 import type { BaseCheckpointSaver } from '@langchain/langgraph';
 import { HumanMessage, fakeModel } from 'langchain';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
@@ -610,6 +611,83 @@ describe('AgentBuilder', () => {
 
       expect(result.langGraphConfig.version).toBe('v2');
       expect(result.langGraphConfig).not.toHaveProperty('signal');
+    });
+
+    it('always attaches user + timing metadata to langGraphConfig, without callbacks when LangSmith is unconfigured', async () => {
+      const { builder } = buildHarness();
+
+      const result = await builder.build(makeArgs());
+
+      const metadata = result.langGraphConfig.metadata as Record<
+        string,
+        unknown
+      >;
+      expect(metadata.user_did).toBe(USER_DID);
+      expect(metadata.client).toBe('portal');
+      expect(typeof metadata.agent_build_duration_ms).toBe('number');
+      expect(result.langGraphConfig).not.toHaveProperty('callbacks');
+    });
+
+    it('attaches a LangChainTracer callback when the user DID is in LANGSMITH_TRACED_DIDS', async () => {
+      const { builder } = buildHarness({
+        configValues: {
+          LANGSMITH_API_KEY: 'ls-key',
+          LANGSMITH_PROJECT: 'test-project',
+          LANGSMITH_TRACED_DIDS: `did:ixo:someone-else,${USER_DID}`,
+        },
+      });
+
+      const result = await builder.build(makeArgs());
+
+      const callbacks = result.langGraphConfig.callbacks as LangChainTracer[];
+      expect(callbacks).toHaveLength(1);
+      expect(callbacks[0]).toBeInstanceOf(LangChainTracer);
+      expect(callbacks[0]?.projectName).toBe('test-project');
+    });
+
+    it('does not attach a tracer for a DID outside the allowlist', async () => {
+      const { builder } = buildHarness({
+        configValues: {
+          LANGSMITH_API_KEY: 'ls-key',
+          LANGSMITH_TRACED_DIDS: 'did:ixo:someone-else',
+        },
+      });
+
+      const result = await builder.build(makeArgs());
+
+      expect(result.langGraphConfig).not.toHaveProperty('callbacks');
+    });
+
+    it('does not attach an explicit tracer when global LANGSMITH_TRACING=true (LangChain auto-attaches)', async () => {
+      const { builder } = buildHarness({
+        configValues: {
+          LANGSMITH_TRACING: 'true',
+          LANGSMITH_API_KEY: 'ls-key',
+        },
+      });
+
+      const result = await builder.build(makeArgs());
+
+      expect(result.langGraphConfig).not.toHaveProperty('callbacks');
+      const metadata = result.langGraphConfig.metadata as Record<
+        string,
+        unknown
+      >;
+      expect(metadata.user_did).toBe(USER_DID);
+    });
+
+    it('carries prepareDurationMs from the prepared request into trace metadata', async () => {
+      const { builder } = buildHarness();
+
+      const result = await builder.build(
+        makeArgs({ prepared: { prepareDurationMs: 77 } }),
+      );
+
+      const metadata = result.langGraphConfig.metadata as Record<
+        string,
+        unknown
+      >;
+      expect(metadata.prepare_duration_ms).toBe(77);
     });
   });
 });

--- a/packages/oracle-runtime/src/modules/messages/agent-builder.ts
+++ b/packages/oracle-runtime/src/modules/messages/agent-builder.ts
@@ -17,6 +17,7 @@ import type { UcanDelegation } from '../../plugin-api/types.js';
 import { UcanService } from '../ucan/ucan.service.js';
 import { EditorPlugin } from '../../plugins/editor/editor.plugin.js';
 import { UserPreferencesService } from '../../plugins/user-preferences/service/user-preferences.service.js';
+import { resolveLangsmithTracing } from './langsmith-tracing.js';
 import type { SendMessageRequest } from './messages.service.js';
 import { OracleRuntimeBundleHolder } from './oracle-runtime-bundle.js';
 import { type PreparedRequest } from './request-preparer.js';
@@ -116,6 +117,7 @@ export class AgentBuilder {
     args: BuildAgentArgs,
     abortController?: AbortController,
   ): Promise<BuiltAgent> {
+    const buildStartedAt = performance.now();
     const { payload, prepared, inputMessages } = args;
     const bundle = this.bundleHolder.get();
     const hooks = bundle.hooks ?? {};
@@ -404,6 +406,28 @@ export class AgentBuilder {
       ...(editorSessionActive && { loadedPlugins: [EditorPlugin.NAME] }),
     };
 
+    // LangSmith: metadata (user DID, ingress client, pre-graph timings) is
+    // attached unconditionally so any active tracer — the global env-driven
+    // one or the selective per-DID one — can filter and aggregate per user;
+    // it is inert when no tracer runs. `callbacks` appears only when this
+    // user's DID is in the `LANGSMITH_TRACED_DIDS` allowlist, and the
+    // explicit tracer propagates through the whole turn (model calls, tools,
+    // sub-agents) via LangGraph's config inheritance.
+    const tracing = resolveLangsmithTracing({
+      userDid: payload.did,
+      client: clientType,
+      env: {
+        tracing: this.config.get<string>('LANGSMITH_TRACING'),
+        apiKey: this.config.get<string>('LANGSMITH_API_KEY'),
+        project: this.config.get<string>('LANGSMITH_PROJECT'),
+        tracedDids: this.config.get<string>('LANGSMITH_TRACED_DIDS'),
+      },
+      timings: {
+        prepareDurationMs: prepared.prepareDurationMs,
+        agentBuildDurationMs: Math.round(performance.now() - buildStartedAt),
+      },
+    });
+
     // `version: 'v2'` is REQUIRED for `agent.streamEvents` to emit the
     // `{event, data, tags}` envelope the SSE loop expects. Without it,
     // langchain defaults to v1 (or emits nothing) and the FE sees a
@@ -417,6 +441,8 @@ export class AgentBuilder {
       recursionLimit: 200,
       configurable: prepared.runnableConfig.configurable,
       context: requestCtx,
+      metadata: tracing.metadata,
+      ...(tracing.callbacks && { callbacks: tracing.callbacks }),
       ...(abortController && { signal: abortController.signal }),
     };
 

--- a/packages/oracle-runtime/src/modules/messages/langsmith-tracing.test.ts
+++ b/packages/oracle-runtime/src/modules/messages/langsmith-tracing.test.ts
@@ -1,0 +1,154 @@
+import { LangChainTracer } from '@langchain/core/tracers/tracer_langchain';
+import { describe, expect, it, vi } from 'vitest';
+import {
+  resolveLangsmithTracing,
+  type ResolveLangsmithTracingArgs,
+} from './langsmith-tracing.js';
+
+const USER_DID = 'did:ixo:ixo1traceduser';
+const OTHER_DID = 'did:ixo:ixo1otheruser';
+
+function makeArgs(
+  overrides: Partial<ResolveLangsmithTracingArgs> = {},
+): ResolveLangsmithTracingArgs {
+  return {
+    userDid: USER_DID,
+    client: 'portal',
+    env: {},
+    ...overrides,
+  };
+}
+
+describe('resolveLangsmithTracing', () => {
+  it('always returns user + client metadata, even with no LangSmith config', () => {
+    const decision = resolveLangsmithTracing(makeArgs());
+    expect(decision.metadata.user_did).toBe(USER_DID);
+    expect(decision.metadata.user_id).toBe(USER_DID);
+    expect(decision.metadata.client).toBe('portal');
+    expect(decision.callbacks).toBeUndefined();
+  });
+
+  it('includes pre-graph timings in metadata when provided', () => {
+    const decision = resolveLangsmithTracing(
+      makeArgs({
+        timings: { prepareDurationMs: 42, agentBuildDurationMs: 137 },
+      }),
+    );
+    expect(decision.metadata.prepare_duration_ms).toBe(42);
+    expect(decision.metadata.agent_build_duration_ms).toBe(137);
+  });
+
+  it('omits timing keys entirely when timings are absent', () => {
+    const decision = resolveLangsmithTracing(makeArgs());
+    expect(decision.metadata).not.toHaveProperty('prepare_duration_ms');
+    expect(decision.metadata).not.toHaveProperty('agent_build_duration_ms');
+  });
+
+  it('attaches a tracer when the DID is allowlisted and an API key is set', () => {
+    const decision = resolveLangsmithTracing(
+      makeArgs({
+        env: {
+          apiKey: 'ls-key',
+          project: 'account-oracle-devnet',
+          tracedDids: `${OTHER_DID},${USER_DID}`,
+        },
+      }),
+    );
+    expect(decision.callbacks).toHaveLength(1);
+    const tracer = decision.callbacks?.[0];
+    expect(tracer).toBeInstanceOf(LangChainTracer);
+    expect(tracer?.projectName).toBe('account-oracle-devnet');
+  });
+
+  it('falls back to LangChain resolution of the project name when the project env is unset', () => {
+    // The tracer resolves the project itself (process env, then 'default') —
+    // this module must not override that with an explicit undefined.
+    vi.stubEnv('LANGSMITH_PROJECT', 'env-resolved-project');
+    try {
+      const decision = resolveLangsmithTracing(
+        makeArgs({ env: { apiKey: 'ls-key', tracedDids: USER_DID } }),
+      );
+      expect(decision.callbacks?.[0]?.projectName).toBe('env-resolved-project');
+    } finally {
+      vi.unstubAllEnvs();
+    }
+  });
+
+  it('does not attach a tracer when the DID is not in the allowlist', () => {
+    const decision = resolveLangsmithTracing(
+      makeArgs({ env: { apiKey: 'ls-key', tracedDids: OTHER_DID } }),
+    );
+    expect(decision.callbacks).toBeUndefined();
+  });
+
+  it('matches DIDs exactly — a prefix of an allowlisted DID is not traced', () => {
+    const decision = resolveLangsmithTracing(
+      makeArgs({
+        userDid: 'did:ixo:ixo1trace',
+        env: { apiKey: 'ls-key', tracedDids: USER_DID },
+      }),
+    );
+    expect(decision.callbacks).toBeUndefined();
+  });
+
+  it('traces every user when the allowlist is the * wildcard', () => {
+    for (const userDid of [USER_DID, OTHER_DID]) {
+      const decision = resolveLangsmithTracing(
+        makeArgs({ userDid, env: { apiKey: 'ls-key', tracedDids: '*' } }),
+      );
+      expect(decision.callbacks).toHaveLength(1);
+    }
+  });
+
+  it('tolerates whitespace and empty entries in the allowlist', () => {
+    const decision = resolveLangsmithTracing(
+      makeArgs({
+        env: {
+          apiKey: 'ls-key',
+          tracedDids: ` ${OTHER_DID} , , ${USER_DID} ,`,
+        },
+      }),
+    );
+    expect(decision.callbacks).toHaveLength(1);
+  });
+
+  it('fails closed: no tracer without an API key even when the DID is allowlisted', () => {
+    const decision = resolveLangsmithTracing(
+      makeArgs({ env: { tracedDids: USER_DID } }),
+    );
+    expect(decision.callbacks).toBeUndefined();
+  });
+
+  it('does not attach an explicit tracer in global mode (LangChain auto-attaches its own)', () => {
+    const decision = resolveLangsmithTracing(
+      makeArgs({
+        env: { tracing: 'true', apiKey: 'ls-key', tracedDids: USER_DID },
+      }),
+    );
+    expect(decision.callbacks).toBeUndefined();
+    expect(decision.metadata.user_did).toBe(USER_DID);
+  });
+
+  it('treats only the exact string "true" as global mode, mirroring LangChain', () => {
+    const decision = resolveLangsmithTracing(
+      makeArgs({
+        env: { tracing: 'false', apiKey: 'ls-key', tracedDids: USER_DID },
+      }),
+    );
+    expect(decision.callbacks).toHaveLength(1);
+  });
+
+  it('re-parses the allowlist when the raw env value changes between calls', () => {
+    const before = resolveLangsmithTracing(
+      makeArgs({ env: { apiKey: 'ls-key', tracedDids: OTHER_DID } }),
+    );
+    expect(before.callbacks).toBeUndefined();
+
+    const after = resolveLangsmithTracing(
+      makeArgs({
+        env: { apiKey: 'ls-key', tracedDids: `${OTHER_DID},${USER_DID}` },
+      }),
+    );
+    expect(after.callbacks).toHaveLength(1);
+  });
+});

--- a/packages/oracle-runtime/src/modules/messages/langsmith-tracing.ts
+++ b/packages/oracle-runtime/src/modules/messages/langsmith-tracing.ts
@@ -1,0 +1,144 @@
+import { LangChainTracer } from '@langchain/core/tracers/tracer_langchain';
+
+/**
+ * Per-request LangSmith tracing decision.
+ *
+ * Two mutually exclusive modes (enforced at boot by
+ * `validateLangsmithTracing` in `config/base-env-schema.ts`):
+ *
+ *  - **Global** — `LANGSMITH_TRACING=true`: LangChain auto-attaches its own
+ *    tracer to every run; this module contributes only the per-request
+ *    `metadata` (user DID, ingress client, prepare/build timings) so traces
+ *    are filterable per user in the LangSmith UI.
+ *  - **Selective** — `LANGSMITH_TRACED_DIDS` allowlist: the global switch
+ *    stays off and this module attaches an explicit `LangChainTracer`
+ *    callback ONLY for turns whose (UCAN-authenticated) user DID is in the
+ *    allowlist. An explicitly passed tracer uploads regardless of the
+ *    `LANGSMITH_TRACING` flag — the env flag only controls LangChain's
+ *    automatic attachment — which is what makes per-DID tracing possible.
+ *
+ * Fail-closed: no API key, no allowlist match, or no configuration at all
+ * ⇒ no tracer is attached and nothing leaves the process. The tracer's
+ * client is LangChain's process-wide singleton (constructed from
+ * `LANGSMITH_API_KEY` / `LANGSMITH_ENDPOINT`), so per-request tracer
+ * instances are cheap and share one batched upload queue.
+ */
+
+export interface LangsmithTracingEnv {
+  /** Raw `LANGSMITH_TRACING`. `'true'` (LangChain's exact check) = global mode. */
+  tracing?: string;
+  /** Raw `LANGSMITH_API_KEY`. Selective mode refuses to attach without it. */
+  apiKey?: string;
+  /** Raw `LANGSMITH_PROJECT`. Forwarded to the tracer when set. */
+  project?: string;
+  /** Raw `LANGSMITH_TRACED_DIDS` comma-separated allowlist (`*` = everyone). */
+  tracedDids?: string;
+}
+
+export interface ResolveLangsmithTracingArgs {
+  /** The turn's user DID — from the authenticated payload, never client-set metadata. */
+  userDid: string;
+  /** Ingress surface, so latency can be sliced per client in LangSmith. */
+  client: 'portal' | 'matrix' | 'slack';
+  env: LangsmithTracingEnv;
+  /**
+   * Pre-graph wall-clock costs. The LangSmith trace only starts when the
+   * graph run starts, so slow-first-turn causes (home-server lookup,
+   * Matrix→SQLite sync, blocking first-contact userContext fetch) would be
+   * invisible without carrying them onto the trace as metadata.
+   */
+  timings?: {
+    prepareDurationMs?: number;
+    agentBuildDurationMs?: number;
+  };
+}
+
+export interface LangsmithTracingDecision {
+  /**
+   * Attached to the run config unconditionally — LangGraph forwards it to
+   * whichever tracer ends up handling the run (global or selective), and it
+   * is inert when no tracer is active.
+   */
+  metadata: Record<string, string | number>;
+  /** Present only when this turn should be selectively traced. */
+  callbacks?: [LangChainTracer];
+}
+
+/**
+ * Single-slot memo for the parsed allowlist. The raw env string is stable
+ * for the lifetime of a deployment, so this makes the per-request cost one
+ * string identity check; if the value ever does change (tests, config
+ * reload), the changed raw string repopulates the Set automatically.
+ */
+let memoRaw: string | undefined;
+let memoSet: ReadonlySet<string> = new Set();
+
+function parseTracedDids(raw: string | undefined): ReadonlySet<string> {
+  if (raw === memoRaw) return memoSet;
+  memoRaw = raw;
+  memoSet = new Set(
+    (raw ?? '')
+      .split(',')
+      .map((entry) => entry.trim())
+      .filter((entry) => entry.length > 0),
+  );
+  return memoSet;
+}
+
+/**
+ * Mirrors LangChain's own `isTracingEnabled` check (exact string `'true'`),
+ * so "global mode is on" means the same thing here as it does inside the
+ * callback manager that auto-attaches the env-driven tracer.
+ */
+function isGlobalTracingOn(tracing: string | undefined): boolean {
+  return tracing?.trim() === 'true';
+}
+
+export function resolveLangsmithTracing(
+  args: ResolveLangsmithTracingArgs,
+): LangsmithTracingDecision {
+  const { userDid, client, env, timings } = args;
+
+  // `user_id` duplicates the DID under the key LangSmith examples use for
+  // user-scoped filtering; `user_did` is the self-describing key our own
+  // dashboards should standardize on.
+  const metadata: Record<string, string | number> = {
+    user_did: userDid,
+    user_id: userDid,
+    client,
+    ...(timings?.prepareDurationMs !== undefined && {
+      prepare_duration_ms: timings.prepareDurationMs,
+    }),
+    ...(timings?.agentBuildDurationMs !== undefined && {
+      agent_build_duration_ms: timings.agentBuildDurationMs,
+    }),
+  };
+
+  // Global mode: LangChain's callback manager attaches its own tracer for
+  // every run — adding a second explicit one here would be redundant.
+  if (isGlobalTracingOn(env.tracing)) {
+    return { metadata };
+  }
+
+  // Selective mode. Fail-closed on a missing API key even though boot
+  // validation already rejects that combination — this function must never
+  // attach a tracer that cannot authenticate.
+  if (!env.apiKey) {
+    return { metadata };
+  }
+
+  const allowlist = parseTracedDids(env.tracedDids);
+  const traced = allowlist.has('*') || allowlist.has(userDid);
+  if (!traced) {
+    return { metadata };
+  }
+
+  return {
+    metadata,
+    callbacks: [
+      new LangChainTracer({
+        ...(env.project && { projectName: env.project }),
+      }),
+    ],
+  };
+}

--- a/packages/oracle-runtime/src/modules/messages/request-preparer.ts
+++ b/packages/oracle-runtime/src/modules/messages/request-preparer.ts
@@ -29,6 +29,14 @@ export interface PreparedRequest {
   targetSession: ChatSession;
   timezone?: string;
   currentTime?: string;
+  /**
+   * Wall-clock cost of `prepare()` for this request. Carried onto the
+   * LangSmith trace metadata (`prepare_duration_ms`) because the trace only
+   * starts when the graph run starts — without this, a slow first turn
+   * caused by pre-graph work (cold home-server chain lookup, Matrix→SQLite
+   * sync, session read) looks like a healthy fast trace.
+   */
+  prepareDurationMs?: number;
 }
 
 export type PrepareInput = SendMessagePayload & {
@@ -59,6 +67,7 @@ export class RequestPreparer {
   ) {}
 
   async prepare(payload: PrepareInput): Promise<PreparedRequest> {
+    const prepareStartedAt = performance.now();
     const did = payload.did;
     const sessionId = payload.sessionId;
     // Streaming requests arrive with `requestId` already resolved by
@@ -127,6 +136,7 @@ export class RequestPreparer {
       targetSession,
       timezone,
       currentTime,
+      prepareDurationMs: Math.round(performance.now() - prepareStartedAt),
     };
   }
 


### PR DESCRIPTION
## What

Per-user LangSmith tracing for latency analytics, without tracing every user.

- **`LANGSMITH_TRACED_DIDS`** (new env): comma-separated allowlist of user DIDs to trace (`*` = everyone). Works with the global `LANGSMITH_TRACING` switch **off** — an explicitly attached `LangChainTracer` uploads regardless of the env flag, which the flag only controls for automatic attachment.
- **Per-turn metadata on every request** (traced or not): `user_did` / `user_id`, ingress `client` (portal/matrix/slack), and pre-graph timings `prepare_duration_ms` + `agent_build_duration_ms`. The LangSmith trace only starts when the graph runs — these fields attribute the pre-graph cost (home-server lookup, Matrix→SQLite sync, blocking first-contact userContext fetch) that otherwise hides behind a healthy-looking trace.
- **Boot validation** (`validateLangsmithTracing`, wired next to `validateLlmProviderKey`): allowlist without `LANGSMITH_API_KEY`, allowlist combined with `LANGSMITH_TRACING=true`, or non-DID entries fail the boot with actionable errors.

## How

One hook point — `AgentBuilder.build()` composes the `langGraphConfig` shared by the SSE streaming and batch paths, so both are covered and sub-agents/tools inherit the tracer via LangGraph config propagation. The decision itself is a pure, memoized function (`modules/messages/langsmith-tracing.ts`). Fail-closed: no key, no match, or no config ⇒ no tracer attached, nothing leaves the process. No new dependency — the tracer reuses LangChain's env-driven singleton client.

## Testing

- 28 new unit tests (decision logic, boot validation, AgentBuilder wiring); full suite 970/970, typecheck + lint clean.
- Live-tested against devnet: misconfigured boot fails with the exact validator error; a real portal turn from an allowlisted DID landed in LangSmith with correct metadata (and immediately surfaced a finding: 5.9s agent build vs 3.5s graph run on a cold first turn).

## Notes

- Changeset intentionally omitted — version bumped directly to **1.4.0** in this PR.
- Ops note: the langsmith SDK sweeps non-secret `LANGSMITH_*` env vars onto trace metadata, so the allowlist itself is visible on traces to anyone with workspace access.
- Recommend landing the `langsmith` ^0.6.0 security bump (`agent/update-langsmith-security`, CVE-2026-45134) before enabling tracing in shared environments.

Authored by: Michael Pretorius <michael@ixo.world>