### PR TITLE
feat(flows): round-trip Blueprint phase and skill metadata

### DIFF
--- a/.changeset/blueprint-flow-phases.md
+++ b/.changeset/blueprint-flow-phases.md
@@ -1,0 +1,5 @@
+---
+'@ixo/oracle-runtime': minor
+---
+
+Add semantic phase, human-only versus agent-capable execution, and governed skill metadata to the QiForge FlowSpec authoring contract. Preserve these fields through compile, Matrix/Yjs storage, read, edit, and validation so Portal-led Blueprint Builder flows can be resumed safely.

--- a/packages/oracle-runtime/src/plugins/flows/authoring.test.ts
+++ b/packages/oracle-runtime/src/plugins/flows/authoring.test.ts
@@ -21,6 +21,14 @@ function validateFlowTool(): PluginTool {
   return tool;
 }
 
+function updateStepTool(): PluginTool {
+  const tool = buildAuthoringTools(undefined).find(
+    (t) => t.name === 'update_step',
+  );
+  if (!tool) throw new Error('update_step tool missing');
+  return tool;
+}
+
 async function validate(
   flow: unknown,
 ): Promise<{ ok: boolean; errors: string[] }> {
@@ -137,10 +145,19 @@ describe('update_step patch routing', () => {
     expect(cleared?.trigger).toBeUndefined();
   });
 
-  it('routes phase updates through the friendly FlowSpec patch', () => {
+  it('routes phase updates and explicit clearing through the friendly FlowSpec patch', () => {
     const doc = twoStepDoc();
     applyStepPatch(doc, 'notify', { phase: 'deployment' });
     expect(readStep(doc, 'r', 'notify')?.phase).toBe('deployment');
+
+    expect(() =>
+      updateStepTool().schema.parse({
+        stepId: 'notify',
+        patch: { phase: null },
+      }),
+    ).not.toThrow();
+    applyStepPatch(doc, 'notify', { phase: null });
+    expect(readStep(doc, 'r', 'notify')?.phase).toBeUndefined();
   });
 
   it('routes execution boundaries and governed skill requirements', () => {

--- a/packages/oracle-runtime/src/plugins/flows/authoring.test.ts
+++ b/packages/oracle-runtime/src/plugins/flows/authoring.test.ts
@@ -136,4 +136,22 @@ describe('update_step patch routing', () => {
     expect(cleared?.onEvent).toBeUndefined();
     expect(cleared?.trigger).toBeUndefined();
   });
+
+  it('routes phase updates through the friendly FlowSpec patch', () => {
+    const doc = twoStepDoc();
+    applyStepPatch(doc, 'notify', { phase: 'deployment' });
+    expect(readStep(doc, 'r', 'notify')?.phase).toBe('deployment');
+  });
+
+  it('routes execution boundaries and governed skill requirements', () => {
+    const doc = twoStepDoc();
+    applyStepPatch(doc, 'notify', {
+      execution: 'agent-capable',
+      skills: ['send-provider-update'],
+    });
+    expect(readStep(doc, 'r', 'notify')).toMatchObject({
+      execution: 'agent-capable',
+      skills: ['send-provider-update'],
+    });
+  });
 });

--- a/packages/oracle-runtime/src/plugins/flows/edit.test.ts
+++ b/packages/oracle-runtime/src/plugins/flows/edit.test.ts
@@ -13,7 +13,10 @@ import {
   setStepConfirmation,
   setStepEventTrigger,
   setStepInputs,
+  setStepPhase,
   setStepSchedule,
+  setStepExecution,
+  setStepSkills,
   setStepTrigger,
   updateFlowMeta,
 } from './edit.js';
@@ -88,6 +91,30 @@ describe('edit: settings round-trip via read', () => {
     expect(step.due).toEqual({ at: '2026-07-01T00:00:00Z', within: 'PT1H' });
     expect(step.assignTo).toBe('did:ixo:assignee');
     expect(step.requireConfirmation).toBe(true);
+  });
+
+  it('phase edits round-trip without changing sibling steps', () => {
+    const doc = threeStepDoc();
+    setStepPhase(doc, 'b', 'validation');
+
+    const flow = readFlowSpec(doc, 'r')!;
+    expect(flow.steps.find((step) => step.id === 'b')?.phase).toBe(
+      'validation',
+    );
+    expect(flow.steps.find((step) => step.id === 'a')?.phase).toBeUndefined();
+
+    setStepPhase(doc, 'b', undefined);
+    expect(readStep(doc, 'r', 'b')?.phase).toBeUndefined();
+  });
+
+  it('execution and governed skill metadata round-trip', () => {
+    const doc = threeStepDoc();
+    setStepExecution(doc, 'b', 'human-only');
+    setStepSkills(doc, 'b', ['assessment-review', 'evidence-check']);
+
+    const step = readStep(doc, 'r', 'b');
+    expect(step?.execution).toBe('human-only');
+    expect(step?.skills).toEqual(['assessment-review', 'evidence-check']);
   });
 
   it('trigger round-trips flow-start and clears back to the manual default', () => {

--- a/packages/oracle-runtime/src/plugins/flows/edit.ts
+++ b/packages/oracle-runtime/src/plugins/flows/edit.ts
@@ -110,6 +110,47 @@ export function setStepConfirmation(
   });
 }
 
+/** Update the stable semantic phase stored on the compiled Flow node. */
+export function setStepPhase(
+  doc: YDoc,
+  stepId: string,
+  phase: string | undefined,
+): void {
+  requireStep(doc, stepId);
+  const node = doc.getMap('qi.flow.nodes').get(stepId);
+  if (!(node instanceof Y.Map)) {
+    throw new FlowError('step_not_found', `No step "${stepId}" in this flow.`);
+  }
+  doc.transact(() => {
+    if (phase) node.set('phase', phase);
+    else node.delete('phase');
+  });
+}
+
+/** Persist the human-only versus agent-capable execution boundary. */
+export function setStepExecution(
+  doc: YDoc,
+  stepId: string,
+  execution: 'human-only' | 'agent-capable',
+): void {
+  setStepProps(doc, stepId, {
+    flowAgentExecutionMode:
+      execution === 'human-only' ? 'human-only' : 'saved-input',
+  });
+}
+
+/** Persist governed skill requirements used by Flow Agent actor matching. */
+export function setStepSkills(
+  doc: YDoc,
+  stepId: string,
+  skills: string[],
+): void {
+  setStepProps(doc, stepId, {
+    requiredSkill: skills[0] ?? '',
+    requiredSkills: skills.length > 0 ? JSON.stringify(skills) : '',
+  });
+}
+
 /**
  * Set a step's trigger to `manual` (default) or `flow-start`. Writes the same
  * `trigger`/`triggerMode` props the compiler would. Event triggers are written

--- a/packages/oracle-runtime/src/plugins/flows/prompts.ts
+++ b/packages/oracle-runtime/src/plugins/flows/prompts.ts
@@ -42,6 +42,7 @@ You have loaded the **Flow Builder** capability. Use it whenever the user wants 
    - New flow → \`create_template\`. Editing the flow that is already open → the edit tools (\`add_step\`, \`update_step\`, \`remove_step\`, \`reorder_step\`, \`set_step_*\`, \`connect_steps\`). \`create_template\` makes a BRAND-NEW flow in its own room — never use it to change an existing or open flow.
    - Set a step's literal input values with \`set_step_inputs\`; wire data between steps with \`connect_steps\` (one upstream output → one downstream input per call). Use \`list_referenceable_fields\` to see what a step can pull from upstream, and \`check_link\` / \`compatible_actions\` to verify a wire before relying on it.
    - For a **form** step you MUST call \`set_form_schema\` to define its questions — a form with no questions cannot run. \`fill_form\` only pre-fills answers; it never submits.
+   - For a phased product journey, set each step's stable \`phase\`. Mark consequential approvals and publication \`human-only\`. Mark a step \`agent-capable\` only when an authorised Flow Agent may execute it, and list the governed \`skills\` required for matching. Never invent agent roles as a substitute for skill ids.
    - Apply conditions, schedule, assignee, and confirmation with the matching \`set_step_*\` tool.
 
 5. **Hand off.** Read it back with \`read_flow\` (and \`flow_status\` if it has run) to confirm what you built, then tell the user it's ready to review and run in the portal. You don't run it.

--- a/packages/oracle-runtime/src/plugins/flows/read.test.ts
+++ b/packages/oracle-runtime/src/plugins/flows/read.test.ts
@@ -25,7 +25,13 @@ describe('readFlowSpec: multi-source round-trip', () => {
       title: 'Round trip',
       goal: 'prove the read recovers props the node map drops',
       steps: [
-        { id: 'one', action, title: 'First', inputs: { name: 'alice' } },
+        {
+          id: 'one',
+          action,
+          title: 'First',
+          phase: 'discovery',
+          inputs: { name: 'alice' },
+        },
         {
           id: 'two',
           action,
@@ -44,6 +50,7 @@ describe('readFlowSpec: multi-source round-trip', () => {
 
     const [one, two] = flow!.steps;
     expect(one?.action).toBe(action);
+    expect(one?.phase).toBe('discovery');
     expect(one?.inputs).toEqual({ name: 'alice' });
     expect(two?.inputs).toEqual({ batches: '{{one.output.items}}', limit: 5 });
 

--- a/packages/oracle-runtime/src/plugins/flows/read.ts
+++ b/packages/oracle-runtime/src/plugins/flows/read.ts
@@ -77,6 +77,7 @@ interface FlowNode {
   registryType?: string;
   title?: string;
   description?: string;
+  phase?: string;
 }
 interface CompiledStructure {
   meta: { title: string; goal?: string };
@@ -103,6 +104,7 @@ function readCompiledStructure(doc: YDoc): CompiledStructure | null {
       registryType: asString(value.get('registryType')),
       title: asString(value.get('title')),
       description: asString(value.get('description')),
+      phase: asString(value.get('phase')),
     };
   });
 
@@ -150,6 +152,20 @@ function firstActor(value: unknown): string | undefined {
     /* ignore */
   }
   return undefined;
+}
+
+function stringList(value: unknown): string[] {
+  if (typeof value !== 'string' || value.length === 0) return [];
+  try {
+    const parsed: unknown = JSON.parse(value);
+    return Array.isArray(parsed)
+      ? parsed.filter(
+          (item): item is string => typeof item === 'string' && item.length > 0,
+        )
+      : [];
+  } catch {
+    return [];
+  }
 }
 
 /** The assignee DID from the `assignment` prop (`{ assignedActor: { did } }` JSON). */
@@ -275,6 +291,19 @@ export function readFlowSpec(doc: YDoc, ref: string): FlowSpecRead | null {
     };
     if (node.title && node.title !== node.can) step.title = node.title;
     if (node.description) step.description = node.description;
+    if (node.phase) step.phase = node.phase;
+    if (props.flowAgentExecutionMode === 'human-only') {
+      step.execution = 'human-only';
+    } else if (
+      props.flowAgentExecutionMode === 'saved-input' ||
+      props.flowAgentExecutionMode === 'runtime-input-required'
+    ) {
+      step.execution = 'agent-capable';
+    }
+    const skills = stringList(props.requiredSkills);
+    const primarySkill = asString(props.requiredSkill);
+    if (skills.length > 0) step.skills = skills;
+    else if (primarySkill) step.skills = [primarySkill];
     if (inputs) step.inputs = inputs;
     if (conditions.length === 1 && conditions[0]) step.runWhen = conditions[0];
     else if (conditions.length > 1) step.conditions = conditions;

--- a/packages/oracle-runtime/src/plugins/flows/tools/authoring.ts
+++ b/packages/oracle-runtime/src/plugins/flows/tools/authoring.ts
@@ -408,17 +408,25 @@ const connectSchema = z.object({
   toStep: z.string().min(1),
   input: z.string().min(1),
 });
+const stepPatchSchema = flowStepSchema.partial().extend({
+  phase: z
+    .string()
+    .min(1)
+    .nullable()
+    .optional()
+    .describe('Set the step phase, or use null to clear an existing phase.'),
+});
 const updateStepSchema = z.object({
   ...base,
   stepId: z.string().min(1),
-  patch: flowStepSchema.partial(),
+  patch: stepPatchSchema,
 });
 
 /** Route an update_step patch to the focused per-block edits. */
 export function applyStepPatch(
   doc: YDoc,
   stepId: string,
-  patch: Partial<FlowStep>,
+  patch: z.infer<typeof stepPatchSchema>,
 ): void {
   if (patch.inputs) setStepInputs(doc, stepId, patch.inputs);
   if (patch.runWhen !== undefined || patch.conditions !== undefined) {
@@ -433,7 +441,8 @@ export function applyStepPatch(
     setStepAssignment(doc, stepId, patch.assignTo);
   if (patch.requireConfirmation !== undefined)
     setStepConfirmation(doc, stepId, patch.requireConfirmation);
-  if (patch.phase !== undefined) setStepPhase(doc, stepId, patch.phase);
+  if (patch.phase !== undefined)
+    setStepPhase(doc, stepId, patch.phase ?? undefined);
   if (patch.execution !== undefined)
     setStepExecution(doc, stepId, patch.execution);
   if (patch.skills !== undefined) setStepSkills(doc, stepId, patch.skills);
@@ -552,7 +561,7 @@ export function buildAuthoringTools(
         description:
           "Update any subset of a step's settings in one call (phase, execution boundary, required skills, inputs, conditions, schedule, assignee, confirmation, " +
           'trigger, onEvent). onEvent takes precedence over trigger when both are given; set trigger to "manual" to ' +
-          'clear an onEvent auto-trigger.',
+          'clear an onEvent auto-trigger. Set phase to null to clear an existing phase.',
         schema: updateStepSchema,
       },
     ),

--- a/packages/oracle-runtime/src/plugins/flows/tools/authoring.ts
+++ b/packages/oracle-runtime/src/plugins/flows/tools/authoring.ts
@@ -28,8 +28,11 @@ import {
   setStepConditions,
   setStepConfirmation,
   setStepEventTrigger,
+  setStepExecution,
   setStepInputs,
+  setStepPhase,
   setStepSchedule,
+  setStepSkills,
   setStepTrigger,
   updateFlowMeta,
 } from '../edit.js';
@@ -154,6 +157,25 @@ async function applyAssignments(
   });
 }
 
+/** Apply Flow Agent execution boundaries and governed skill matching metadata. */
+async function applyExecutionPolicy(
+  ctx: RuntimeContext,
+  flowRef: string,
+  matrixClient: MatrixClient | undefined,
+  steps: FlowStep[],
+): Promise<void> {
+  const configured = steps.filter(
+    (step) => step.execution !== undefined || step.skills !== undefined,
+  );
+  if (configured.length === 0) return;
+  await withFlowDoc(ctx, flowRef, matrixClient, async (doc) => {
+    for (const step of configured) {
+      if (step.execution) setStepExecution(doc, step.id, step.execution);
+      if (step.skills) setStepSkills(doc, step.id, step.skills);
+    }
+  });
+}
+
 /** The room id a `create_template_room` browser tool returned. */
 function extractRoomId(result: unknown): string | undefined {
   if (result && typeof result === 'object') {
@@ -266,6 +288,7 @@ function buildCreateTemplateTool(
         });
         await applyConditions(ctx, roomId, matrixClient, flow.steps);
         await applyAssignments(ctx, roomId, matrixClient, flow.steps);
+        await applyExecutionPolicy(ctx, roomId, matrixClient, flow.steps);
 
         return { ok: true, flowRef: roomId };
       } catch (err) {
@@ -334,6 +357,7 @@ function buildAddStepTool(matrixClient: MatrixClient | undefined): PluginTool {
         });
         await applyConditions(ctx, roomId, matrixClient, [step]);
         await applyAssignments(ctx, roomId, matrixClient, [step]);
+        await applyExecutionPolicy(ctx, roomId, matrixClient, [step]);
 
         if (typeof position === 'number') {
           await withFlowDoc(ctx, flowRef, matrixClient, async (doc) =>
@@ -409,6 +433,10 @@ export function applyStepPatch(
     setStepAssignment(doc, stepId, patch.assignTo);
   if (patch.requireConfirmation !== undefined)
     setStepConfirmation(doc, stepId, patch.requireConfirmation);
+  if (patch.phase !== undefined) setStepPhase(doc, stepId, patch.phase);
+  if (patch.execution !== undefined)
+    setStepExecution(doc, stepId, patch.execution);
+  if (patch.skills !== undefined) setStepSkills(doc, stepId, patch.skills);
   // Both write the same trigger props; onEvent is the more specific intent.
   if (patch.onEvent !== undefined)
     setStepEventTrigger(doc, stepId, patch.onEvent);
@@ -522,7 +550,7 @@ export function buildAuthoringTools(
       {
         name: 'update_step',
         description:
-          "Update any subset of a step's settings in one call (inputs, conditions, schedule, assignee, confirmation, " +
+          "Update any subset of a step's settings in one call (phase, execution boundary, required skills, inputs, conditions, schedule, assignee, confirmation, " +
           'trigger, onEvent). onEvent takes precedence over trigger when both are given; set trigger to "manual" to ' +
           'clear an onEvent auto-trigger.',
         schema: updateStepSchema,

--- a/packages/oracle-runtime/src/plugins/flows/translator.test.ts
+++ b/packages/oracle-runtime/src/plugins/flows/translator.test.ts
@@ -175,7 +175,7 @@ describe('translator: flowSpecToBaseUcan', () => {
       title: 'Test flow',
       goal: 'do a thing',
       steps: [
-        { id: 'one', action, inputs: { x: 1 } },
+        { id: 'one', action, phase: 'discovery', inputs: { x: 1 } },
         {
           id: 'two',
           action,
@@ -198,6 +198,7 @@ describe('translator: flowSpecToBaseUcan', () => {
     expect(plan.capabilities.map((c) => c.id)).toEqual(['one', 'two']);
     expect(plan.capabilities[0]?.with).toBe('ixo:flow:test-flow:one');
     expect(plan.capabilities[0]?.nb).toEqual({ x: 1 });
+    expect(plan.capabilities[0]?.phase).toBe('discovery');
     // Conditions are NEVER emitted onto the capability — they are written to props directly.
     expect(plan.capabilities[1]?.condition).toBeUndefined();
   });

--- a/packages/oracle-runtime/src/plugins/flows/translator.ts
+++ b/packages/oracle-runtime/src/plugins/flows/translator.ts
@@ -296,6 +296,7 @@ export function stepToCapability(
   if (nb) cap.nb = nb;
   if (step.title) cap.title = step.title;
   if (step.description) cap.description = step.description;
+  if (step.phase) cap.phase = step.phase;
   const trigger = triggerForStep(step);
   if (trigger) cap.trigger = trigger;
   const ttl = ttlForStep(step);

--- a/packages/oracle-runtime/src/plugins/flows/types.ts
+++ b/packages/oracle-runtime/src/plugins/flows/types.ts
@@ -78,6 +78,19 @@ export const flowStepSchema = z.object({
     .describe('Action name from list_actions (e.g. "qi/email.send").'),
   title: z.string().optional(),
   description: z.string().optional(),
+  phase: z
+    .string()
+    .min(1)
+    .optional()
+    .describe(
+      'Stable semantic group for this step, such as "discovery" or "deployment".',
+    ),
+  execution: z
+    .enum(['human-only', 'agent-capable'])
+    .optional()
+    .describe(
+      'Whether only a person may run this step or a suitably skilled, authorised Flow Agent may run it.',
+    ),
 
   inputs: z
     .record(z.string(), z.unknown())
@@ -132,7 +145,12 @@ export const flowStepSchema = z.object({
     .record(z.string(), z.array(hookSchema))
     .optional()
     .describe('Lifecycle hooks: event name -> hooks.'),
-  skills: z.array(z.string()).optional(),
+  skills: z
+    .array(z.string())
+    .optional()
+    .describe(
+      'Governed skill ids required for agent-capable execution. The first is used for Flow Agent matching.',
+    ),
   requireConfirmation: z
     .boolean()
     .optional()


### PR DESCRIPTION
Implements the QiForge Flow Builder portion of Runtime 0.6 and IXO-4037.

- Adds five-phase metadata to Flow steps and preserves it through authoring, compilation, Yjs storage, reading, and editing.
- Adds explicit human-only versus agent-capable execution metadata.
- Adds governed skill identifiers for agent-capable steps instead of invented agent roles.
- Extends the authoring prompt and edit operations for phase, execution, and skill changes.

Validation:
- 38 focused translator/read/edit tests passed.
- Focused ESLint and Prettier checks passed.
- Git diff check passed.

Repository-wide type checking is currently blocked by pre-existing missing workspace build outputs for @ixo/oracles-chain-client and @ixo/oracle-runtime/testing/integration; none of the reported failures target the changed Flow files.

Companion action registry PR: https://github.com/ixoworld/qi-flows/pull/260