### PR TITLE
feat(oracle-runtime): add Codex provider via the App Server boundary

### DIFF
--- a/.changeset/codex-app-server-provider.md
+++ b/.changeset/codex-app-server-provider.md
@@ -1,0 +1,9 @@
+---
+'@ixo/oracle-runtime': minor
+---
+
+Add Codex as a first-class provider, integrated through the Codex App Server.
+
+The bundled `codex` plugin delegates coding tasks to a user's Codex runtime over the App Server's bidirectional JSON-RPC boundary — no UI automation and no credential reuse. Two auth modes are supported and never fall back to one another: ChatGPT sign-in for subscription-backed access, and an OpenAI API key for usage-based access. `CODEX_AUTH_MODE` is required with no default, so the billing model is always an explicit operator choice.
+
+Approvals Codex raises mid-turn block until a human answers, via an `action_call` event plus `POST /codex/approvals` or the `codex_resolve_approval` tool; unanswered approvals expire to `decline`. Sessions, credentials, `CODEX_HOME` directories and threads are scoped per tenant, and every connection transition is recorded in an auditable trail exposed at `GET /codex/transitions`.

--- a/docs/README.md
+++ b/docs/README.md
@@ -19,6 +19,7 @@ The structure mirrors the parts of the codebase a maintainer touches:
 - **Touching `packages/oracle-runtime/src/modules/`?** → update `architecture/modules.md`.
 - **Adding a graph state field?** → follow `contributing/adding-a-state-field.md`. Document the field in `ixo-docs/build-an-oracle/reference/state-schema.mdx`.
 - **Touching the meta-tools?** → update `architecture/meta-tools-and-discovery.md` and `ixo-docs/build-an-oracle/concepts/meta-tools.mdx`.
+- **Touching the Codex provider?** → update `architecture/codex-provider.md`. Method-name changes in the App Server protocol table go there too.
 - **Adding a follow-up ticket?** → append to `spec-and-roadmap/follow-ups.md`.
 
 ## What this directory is NOT

--- a/docs/architecture/codex-provider.md
+++ b/docs/architecture/codex-provider.md
@@ -29,7 +29,14 @@ The App Server is the bidirectional JSON-RPC surface Codex's own clients drive �
 - Approvals, streaming and thread resumption come from the protocol rather than being reconstructed.
 - A remote-runtime / local-client split works: the runtime lives wherever the oracle runs, and any client can drive it over the HTTP control plane.
 
-Frames are newline-delimited JSON and omit the `jsonrpc` version field. Method names are centralized in `app-server/protocol.ts` because Codex has renamed them across releases — an upgrade edits that table, not the adapter.
+Frames are newline-delimited JSON and omit the `jsonrpc` version field. Method names and enum spellings are centralized in `app-server/protocol.ts` and `domain/config.ts` because Codex has renamed them across releases — an upgrade edits those tables, not the adapter.
+
+Two things the published docs get wrong, both verified by driving `codex-cli 0.145.0` directly:
+
+- Sandbox values are `read-only` / `workspace-write` / `danger-full-access`, not camelCase. `readOnly` is rejected with `unknown variant`.
+- Approval values are `untrusted` / `on-request` / `never`. The server also has a `granular` policy, but it is a struct variant — the bare string `"granular"` is rejected — so it is not offered.
+
+The server also emits explicit `null` for absent fields (`error: null` on a successful turn, `details: null`, `extra: null`), so result and notification schemas use `.nullish()` rather than `.optional()` — a plain `.optional()` rejects `null` and would silently drop the notification.
 
 ## The two auth modes
 
@@ -49,7 +56,7 @@ The mode is **never inferred**. `CODEX_AUTH_MODE` is required with no default, a
 The App Server protocol has **no login method** — authentication is established upstream, and `account/read` reports the result. So:
 
 - **Subscription**: `codex login` writes `auth.json` into the tenant's `CODEX_HOME`. The harness never touches the OAuth tokens; it checks for the artefact, then lets the App Server read it. Missing → `requires_sign_in`.
-- **API key**: read from the room's JWE-encrypted secret store (`ctx.secrets`), injected into the child process env as `OPENAI_API_KEY`. Missing → `requires_sign_in`.
+- **API key**: read from the room's JWE-encrypted secret store (`ctx.secrets`) and registered with the App Server via `account/login/start` (`{type: 'apiKey', apiKey}`). Putting `OPENAI_API_KEY` in the child's environment is _not_ sufficient — verified against `codex-cli 0.145.0`, `account/read` returns `{account: null, requiresOpenaiAuth: true}` until the login call is made. Missing → `requires_sign_in`.
 
 Either way the App Server is the authority: `assertAuthenticated` calls `account/read` after the handshake and transitions to `invalid_credentials` if there is no account. A credential file that exists but does not work is caught here, not at the first turn.
 
@@ -70,6 +77,10 @@ stateDiagram-v2
     connected --> disconnected
 ```
 
+Turns are serialized per session: the App Server runs one turn per thread, and overlapping `codex_run_task` calls would otherwise clobber the shared pending-turn state and cross their event streams.
+
+A mode switch rebuilds the session's plan rather than relabelling it, so credential resolution, diagnostics and capabilities all follow the change.
+
 Reconnect is bounded by `CODEX_MAX_RECONNECT_ATTEMPTS`. The budget resets only when a turn **runs to completion** — not merely when the handshake succeeds — so a binary that starts fine and dies every turn still exhausts it instead of looping forever.
 
 ## Approvals
@@ -87,7 +98,7 @@ Decisions can arrive two ways, both landing on the same gate: `POST /codex/appro
 
 ## Tenancy
 
-`CodexTenantScope` is `{ userDid, oracleEntityDid }`, flattened to a filesystem-safe key. It scopes:
+`CodexTenantScope` is `{ userDid, oracleEntityDid }`, reduced to a filesystem-safe key: a readable sanitized prefix plus a digest of the exact pair. The digest matters — sanitizing alone is not injective (`did:x:a:b` and `did:x:a_b` both flatten to `did_x_a_b`), and this key indexes sessions, approvals and credential directories, so a collision would let one authenticated user reach another's runtime. It scopes:
 
 - the `CodexSession` (one App Server process per tenant),
 - the `CODEX_HOME` directory, created `0700`,
@@ -117,7 +128,9 @@ The plugin builds its registry from a plan on first use, so a misconfigured depl
 
 `session/codex-session.test.ts` drives a **real child process** — `__test-fixtures__/fake-app-server.mjs` speaks the same newline-delimited JSON-RPC framing as `codex app-server`. The stdio transport, id correlation, streaming notifications, the approval round-trip, thread resumption and crash/reconnect all run for real; only the Codex binary is substituted.
 
-**Manual verification remains:** running against a genuine `codex app-server` build to confirm the method names and payload shapes in `protocol.ts` match the installed Codex version. That table is the single place an upstream rename needs to be applied.
+The wire contract was verified by driving a real `codex-cli 0.145.0` App Server: the sandbox and approval enums, the `account/login/start` requirement for API keys, and the `{thread: {id}}` / `{turn: {id}}` result shapes all come from that session rather than from documentation.
+
+**Manual verification remains:** a full authenticated turn (streaming items, a live approval round trip) against a signed-in Codex account. Those paths are covered by the fixture but have not been exercised against the real service, which needs a funded key or a ChatGPT sign-in.
 
 ## Read next
 

--- a/docs/architecture/codex-provider.md
+++ b/docs/architecture/codex-provider.md
@@ -1,0 +1,125 @@
+# Codex provider
+
+How QiForge integrates OpenAI Codex, why the App Server is the integration boundary, and what the two auth modes actually buy.
+
+Code lives in `packages/oracle-runtime/src/plugins/codex/`.
+
+## Why a plugin, not an `LLMProvider`
+
+`src/llm/llm-provider.ts` maps a role to a `BaseChatModel` — a stateless chat-completions call. Codex is not that. The Codex App Server is an **agentic runtime**: long-lived threads, multi-step turns, streamed work items, and approval gates that block execution until a human answers.
+
+Squeezing it behind `getProviderChatModel` would throw away threads, approvals and diffs — the parts that make Codex worth integrating. So Codex is a plugin, and `openrouter` / `nebius` are untouched.
+
+```mermaid
+graph LR
+    Agent[Main agent] -->|codex_run_task| Plugin[Codex plugin]
+    Plugin --> Registry[Per-tenant registry]
+    Registry --> Session[CodexSession]
+    Session -->|JSON-RPC over stdio| AppServer[codex app-server]
+    Session --> Gate[Approval gate]
+    Gate -->|action_call event| Client[Any client]
+    Client -->|POST /codex/approvals| Gate
+```
+
+## Why the App Server
+
+The App Server is the bidirectional JSON-RPC surface Codex's own clients drive — the same boundary first-party and third-party surfaces share. Targeting it means:
+
+- No UI automation, no scraping, no reuse of browser session internals.
+- Approvals, streaming and thread resumption come from the protocol rather than being reconstructed.
+- A remote-runtime / local-client split works: the runtime lives wherever the oracle runs, and any client can drive it over the HTTP control plane.
+
+Frames are newline-delimited JSON and omit the `jsonrpc` version field. Method names are centralized in `app-server/protocol.ts` because Codex has renamed them across releases — an upgrade edits that table, not the adapter.
+
+## The two auth modes
+
+|                         | `chatgpt_subscription`          | `api_key`      |
+| ----------------------- | ------------------------------- | -------------- |
+| How the user signs in   | ChatGPT sign-in (`codex login`) | OpenAI API key |
+| Billing                 | Covered by the plan             | Per token      |
+| `directModelApi`        | **false**                       | true           |
+| Per-turn model override | No — the plan decides           | Yes            |
+
+**A subscription does not grant raw OpenAI API access.** It authorizes the Codex runtime. `resolveCodexCapabilities` encodes this as `directModelApi: false`; any code that needs the raw API must check that flag rather than infer entitlement from the presence of credentials.
+
+The mode is **never inferred**. `CODEX_AUTH_MODE` is required with no default, and `preflight` rejects a requested mode that disagrees with the configured one. Switching modes goes through `setAuthMode`, which drops the connection, declines outstanding approvals, and records an `auth_mode_changed` transition.
+
+### Where credentials come from
+
+The App Server protocol has **no login method** — authentication is established upstream, and `account/read` reports the result. So:
+
+- **Subscription**: `codex login` writes `auth.json` into the tenant's `CODEX_HOME`. The harness never touches the OAuth tokens; it checks for the artefact, then lets the App Server read it. Missing → `requires_sign_in`.
+- **API key**: read from the room's JWE-encrypted secret store (`ctx.secrets`), injected into the child process env as `OPENAI_API_KEY`. Missing → `requires_sign_in`.
+
+Either way the App Server is the authority: `assertAuthenticated` calls `account/read` after the handshake and transitions to `invalid_credentials` if there is no account. A credential file that exists but does not work is caught here, not at the first turn.
+
+## Connection lifecycle
+
+Every transition is validated against a table in `auth/connection-state.ts` and appended to a bounded audit trail (`GET /codex/transitions`). An illegal edge throws rather than corrupting the record.
+
+```mermaid
+stateDiagram-v2
+    [*] --> disconnected
+    disconnected --> connecting
+    connecting --> connected
+    connecting --> requires_sign_in
+    connecting --> invalid_credentials
+    connecting --> unsupported_environment
+    connected --> error: transport closed
+    error --> connecting: bounded reconnect
+    connected --> disconnected
+```
+
+Reconnect is bounded by `CODEX_MAX_RECONNECT_ATTEMPTS`. The budget resets only when a turn **runs to completion** — not merely when the handshake succeeds — so a binary that starts fine and dies every turn still exhausts it instead of looping forever.
+
+## Approvals
+
+Codex blocks its turn on a server→client request. `CodexApprovalGate` parks that request, emits an `action_call` event so any connected client can render the prompt, and settles when a decision arrives.
+
+Nothing auto-approves:
+
+- An unanswered approval expires to `decline`.
+- A malformed approval request is declined.
+- An approval that arrives with no turn in flight is declined (nobody is listening).
+- `gate.resolve` is tenant-scoped; a mismatch is a miss, not a grant.
+
+Decisions can arrive two ways, both landing on the same gate: `POST /codex/approvals` (for a client UI) or the `codex_resolve_approval` tool (for a decision the user gave in chat).
+
+## Tenancy
+
+`CodexTenantScope` is `{ userDid, oracleEntityDid }`, flattened to a filesystem-safe key. It scopes:
+
+- the `CodexSession` (one App Server process per tenant),
+- the `CODEX_HOME` directory, created `0700`,
+- the thread id,
+- approval ownership.
+
+Sessions are only ever created through `CodexRuntimeRegistry.for(scope)` — nothing hands one out by raw key.
+
+## Validation gates
+
+`preflight` runs before any runtime start and is the only producer of a `CodexRuntimePlan`:
+
+1. Config schema (`normalizeCodexConfig`).
+2. Auth-mode agreement.
+3. Capability resolution.
+4. Tool policy — `dangerFullAccess` + `approvalPolicy: never` is rejected, because that combination removes every guardrail at once.
+
+The plugin builds its registry from a plan on first use, so a misconfigured deployment fails at boot rather than mid-conversation.
+
+## Security notes
+
+- Credential values never reach logs, events, HTTP responses or the audit trail. `redactCredentialEnv` masks `OPENAI_API_KEY` before the process env is logged.
+- Every `/codex/*` route is UCAN-authenticated (`getAuthExcludedRoutes` returns `[]`) and derives its tenant from the authenticated DID, so a caller cannot address another tenant's runtime.
+- The transport spawns a child process. `CODEX_SANDBOX_MODE` and `CODEX_APPROVAL_POLICY` are what constrain it; the tool-policy gate stops the two from being relaxed together.
+
+## Testing
+
+`session/codex-session.test.ts` drives a **real child process** — `__test-fixtures__/fake-app-server.mjs` speaks the same newline-delimited JSON-RPC framing as `codex app-server`. The stdio transport, id correlation, streaming notifications, the approval round-trip, thread resumption and crash/reconnect all run for real; only the Codex binary is substituted.
+
+**Manual verification remains:** running against a genuine `codex app-server` build to confirm the method names and payload shapes in `protocol.ts` match the installed Codex version. That table is the single place an upstream rename needs to be applied.
+
+## Read next
+
+- [Adding a bundled plugin](../contributing/adding-a-bundled-plugin.md)
+- [Model selection](model-selection.md) — the unrelated `BaseChatModel` path

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -59,16 +59,23 @@ export default [
     },
   },
 
+  // Test fixtures spawned as standalone Node processes. `no-undef` is off for
+  // TS (the compiler covers it) but active for plain JS, so Node's globals
+  // have to be declared here.
+  {
+    files: ['**/__test-fixtures__/**/*.mjs'],
+    languageOptions: {
+      globals: { process: 'readonly' },
+    },
+  },
+
   // Test files — disable type-aware linting. Tests live outside each
   // package's tsconfig `include`, so projectService would spin up a fresh
   // TypeScript program per file and exhaust the heap on `eslint .`.
   // Type-checking still happens via vitest + tsc; ESLint only needs
   // syntactic + vitest-plugin rules here.
   {
-    files: [
-      '**/__tests__/**/*.[jt]s?(x)',
-      '**/?(*.)+(spec|test).[jt]s?(x)',
-    ],
+    files: ['**/__tests__/**/*.[jt]s?(x)', '**/?(*.)+(spec|test).[jt]s?(x)'],
     ...tseslint.configs.disableTypeChecked,
     plugins: { vitest },
     languageOptions: {

--- a/packages/oracle-runtime/src/index.ts
+++ b/packages/oracle-runtime/src/index.ts
@@ -130,6 +130,7 @@ export {
 // cover the no-arg case; pass your own instance via `plugins: [...]` to
 // `createOracleApp` to override.
 export * from './plugins/agui/index.js';
+export * from './plugins/codex/index.js';
 export * from './plugins/composio/index.js';
 export * from './plugins/credits/index.js';
 export * from './plugins/domain-indexer/index.js';

--- a/packages/oracle-runtime/src/plugins/codex/README.md
+++ b/packages/oracle-runtime/src/plugins/codex/README.md
@@ -21,30 +21,32 @@ Sign in once per user, against that user's `CODEX_HOME`:
 CODEX_HOME=<CODEX_HOME_ROOT>/<oracleDid>__<userDid> codex login
 ```
 
-The tenant directory name is the oracle DID and user DID joined by `::`, with every character outside `[A-Za-z0-9._-]` replaced by `_`. `GET /codex/status` reports `requires_sign_in` until the sign-in completes.
+The tenant directory name is a sanitized `<oracleDid>::<userDid>` prefix followed by a `-` and a 16-character digest of the exact pair (the digest is what stops two different DIDs sanitizing to the same directory). Read the exact value from `GET /codex/status` — it is reported as `tenant`. `GET /codex/status` shows `requires_sign_in` until the sign-in completes.
 
 **`api_key`** — _"Use an API key for usage-based OpenAI access."_
-Turns are billed per token. The user stores an `OPENAI_API_KEY` secret in their oracle room (rename via `CODEX_API_KEY_SECRET_NAME`); the key is read from the encrypted secret store at connect time and never leaves the process.
+Turns are billed per token. The user stores an `OPENAI_API_KEY` secret in their oracle room (rename via `CODEX_API_KEY_SECRET_NAME`); the key is read from the encrypted secret store at connect time and never leaves the process. The runtime registers it with the App Server through `account/login/start` — the server does not pick a key up from its environment.
 
 ## Environment variables
 
-| Variable                       | Default          | Purpose                                             |
-| ------------------------------ | ---------------- | --------------------------------------------------- |
-| `CODEX_AUTH_MODE`              | — (required)     | `chatgpt_subscription` or `api_key`.                |
-| `CODEX_APP_SERVER_COMMAND`     | `codex`          | Binary to spawn.                                    |
-| `CODEX_APP_SERVER_ARGS`        | `app-server`     | Space-separated argv.                               |
-| `CODEX_HOME_ROOT`              | `.codex-tenants` | Parent of the per-tenant `CODEX_HOME` directories.  |
-| `CODEX_WORKSPACE_ROOT`         | `process.cwd()`  | Directory Codex threads are rooted at.              |
-| `CODEX_MODEL`                  | —                | Model override. Ignored under a subscription.       |
-| `CODEX_REASONING_EFFORT`       | `medium`         | `low` / `medium` / `high`.                          |
-| `CODEX_SANDBOX_MODE`           | `readOnly`       | `readOnly` / `workspaceWrite` / `dangerFullAccess`. |
-| `CODEX_APPROVAL_POLICY`        | `onRequest`      | `never` / `onRequest` / `unlessTrusted`.            |
-| `CODEX_API_KEY_SECRET_NAME`    | `OPENAI_API_KEY` | Secret holding the key in `api_key` mode.           |
-| `CODEX_STARTUP_TIMEOUT_MS`     | `30000`          | Handshake and thread-call timeout.                  |
-| `CODEX_TURN_TIMEOUT_MS`        | `600000`         | Per-turn timeout.                                   |
-| `CODEX_MAX_RECONNECT_ATTEMPTS` | `3`              | Reconnects after an App Server crash.               |
+| Variable                       | Default          | Purpose                                                 |
+| ------------------------------ | ---------------- | ------------------------------------------------------- |
+| `CODEX_AUTH_MODE`              | — (required)     | `chatgpt_subscription` or `api_key`.                    |
+| `CODEX_APP_SERVER_COMMAND`     | `codex`          | Binary to spawn.                                        |
+| `CODEX_APP_SERVER_ARGS`        | `app-server`     | Space-separated argv.                                   |
+| `CODEX_HOME_ROOT`              | `.codex-tenants` | Parent of the per-tenant `CODEX_HOME` directories.      |
+| `CODEX_WORKSPACE_ROOT`         | `process.cwd()`  | Directory Codex threads are rooted at.                  |
+| `CODEX_MODEL`                  | —                | Model override. Ignored under a subscription.           |
+| `CODEX_REASONING_EFFORT`       | `medium`         | `low` / `medium` / `high`.                              |
+| `CODEX_SANDBOX_MODE`           | `read-only`      | `read-only` / `workspace-write` / `danger-full-access`. |
+| `CODEX_APPROVAL_POLICY`        | `on-request`     | `untrusted` / `on-request` / `never`.                   |
+| `CODEX_API_KEY_SECRET_NAME`    | `OPENAI_API_KEY` | Secret holding the key in `api_key` mode.               |
+| `CODEX_STARTUP_TIMEOUT_MS`     | `30000`          | Handshake and thread-call timeout.                      |
+| `CODEX_TURN_TIMEOUT_MS`        | `600000`         | Per-turn timeout.                                       |
+| `CODEX_MAX_RECONNECT_ATTEMPTS` | `3`              | Reconnects after an App Server crash.                   |
 
-`CODEX_SANDBOX_MODE=dangerFullAccess` together with `CODEX_APPROVAL_POLICY=never` is rejected at boot: that pair removes both guardrails at once.
+`CODEX_SANDBOX_MODE=danger-full-access` together with `CODEX_APPROVAL_POLICY=never` is rejected at boot: that pair removes both guardrails at once.
+
+These enum values are the App Server's own wire spellings, verified against `codex-cli 0.145.0` — anything else is rejected with `unknown variant`.
 
 ## Control plane
 

--- a/packages/oracle-runtime/src/plugins/codex/README.md
+++ b/packages/oracle-runtime/src/plugins/codex/README.md
@@ -1,0 +1,72 @@
+# Codex — setup
+
+Connects an oracle to a user's OpenAI Codex runtime through the Codex App Server.
+
+Framework internals and design rationale: [`docs/architecture/codex-provider.md`](../../../../../docs/architecture/codex-provider.md).
+
+## Prerequisites
+
+The `codex` CLI must be installed and on `PATH` wherever the oracle runs (override with `CODEX_APP_SERVER_COMMAND`).
+
+## Choose an auth mode
+
+`CODEX_AUTH_MODE` is required and has no default — the mode decides how the user's Codex usage is billed, so the runtime will not pick one for you. The plugin stays off until it is set.
+
+**`chatgpt_subscription`** — _"Use ChatGPT sign-in for Codex subscription access."_
+The user's ChatGPT plan covers Codex runtime usage. It does **not** grant direct OpenAI API access.
+
+Sign in once per user, against that user's `CODEX_HOME`:
+
+```bash
+CODEX_HOME=<CODEX_HOME_ROOT>/<oracleDid>__<userDid> codex login
+```
+
+The tenant directory name is the oracle DID and user DID joined by `::`, with every character outside `[A-Za-z0-9._-]` replaced by `_`. `GET /codex/status` reports `requires_sign_in` until the sign-in completes.
+
+**`api_key`** — _"Use an API key for usage-based OpenAI access."_
+Turns are billed per token. The user stores an `OPENAI_API_KEY` secret in their oracle room (rename via `CODEX_API_KEY_SECRET_NAME`); the key is read from the encrypted secret store at connect time and never leaves the process.
+
+## Environment variables
+
+| Variable                       | Default          | Purpose                                             |
+| ------------------------------ | ---------------- | --------------------------------------------------- |
+| `CODEX_AUTH_MODE`              | — (required)     | `chatgpt_subscription` or `api_key`.                |
+| `CODEX_APP_SERVER_COMMAND`     | `codex`          | Binary to spawn.                                    |
+| `CODEX_APP_SERVER_ARGS`        | `app-server`     | Space-separated argv.                               |
+| `CODEX_HOME_ROOT`              | `.codex-tenants` | Parent of the per-tenant `CODEX_HOME` directories.  |
+| `CODEX_WORKSPACE_ROOT`         | `process.cwd()`  | Directory Codex threads are rooted at.              |
+| `CODEX_MODEL`                  | —                | Model override. Ignored under a subscription.       |
+| `CODEX_REASONING_EFFORT`       | `medium`         | `low` / `medium` / `high`.                          |
+| `CODEX_SANDBOX_MODE`           | `readOnly`       | `readOnly` / `workspaceWrite` / `dangerFullAccess`. |
+| `CODEX_APPROVAL_POLICY`        | `onRequest`      | `never` / `onRequest` / `unlessTrusted`.            |
+| `CODEX_API_KEY_SECRET_NAME`    | `OPENAI_API_KEY` | Secret holding the key in `api_key` mode.           |
+| `CODEX_STARTUP_TIMEOUT_MS`     | `30000`          | Handshake and thread-call timeout.                  |
+| `CODEX_TURN_TIMEOUT_MS`        | `600000`         | Per-turn timeout.                                   |
+| `CODEX_MAX_RECONNECT_ATTEMPTS` | `3`              | Reconnects after an App Server crash.               |
+
+`CODEX_SANDBOX_MODE=dangerFullAccess` together with `CODEX_APPROVAL_POLICY=never` is rejected at boot: that pair removes both guardrails at once.
+
+## Control plane
+
+All routes are UCAN-authenticated and scoped to the calling user.
+
+| Route                    | Purpose                                                            |
+| ------------------------ | ------------------------------------------------------------------ |
+| `GET /codex/status`      | Provider descriptor, connection status, resolved capabilities.     |
+| `POST /codex/connect`    | Start or re-authorize the runtime.                                 |
+| `POST /codex/disconnect` | Stop it.                                                           |
+| `POST /codex/auth-mode`  | Switch mode. Explicit — never inferred.                            |
+| `GET /codex/transitions` | Audit trail of connection transitions.                             |
+| `GET /codex/approvals`   | Approvals Codex is blocked on.                                     |
+| `POST /codex/approvals`  | Answer one (`accept` / `acceptForSession` / `decline` / `cancel`). |
+
+## Approvals
+
+When Codex wants to run a command or change a file, the turn blocks and an `action_call` event (`codex.approval.required`) is emitted. Answer it via `POST /codex/approvals`, or let the agent relay a decision the user gave in chat via the `codex_resolve_approval` tool.
+
+Unanswered approvals expire to `decline` after five minutes. Nothing is ever auto-approved.
+
+## Tools
+
+- `codex_run_task` — hand Codex a coding task; returns its output, or an actionable auth status.
+- `codex_resolve_approval` — relay a user's approval decision.

--- a/packages/oracle-runtime/src/plugins/codex/__test-fixtures__/fake-app-server.mjs
+++ b/packages/oracle-runtime/src/plugins/codex/__test-fixtures__/fake-app-server.mjs
@@ -1,0 +1,172 @@
+#!/usr/bin/env node
+/**
+ * Minimal Codex App Server stand-in: speaks the real newline-delimited
+ * JSON-RPC framing over stdio so the transport, client, approval round-trip
+ * and event mapping are exercised against a real process rather than a stub.
+ *
+ * Behaviour is driven by env vars so one fixture covers every scenario:
+ *   FAKE_CODEX_ACCOUNT=none      → `account/read` reports no signed-in account
+ *   FAKE_CODEX_REQUIRE_APPROVAL=1 → asks for command approval mid-turn
+ *   FAKE_CODEX_EXIT_ON_TURN=1     → exits mid-turn to exercise reconnect
+ */
+import { createInterface } from 'node:readline';
+
+const send = (frame) => process.stdout.write(`${JSON.stringify(frame)}\n`);
+
+let turnCounter = 0;
+let threadCounter = 0;
+const approvals = new Map();
+
+const rl = createInterface({ input: process.stdin });
+
+rl.on('line', (line) => {
+  if (!line.trim()) return;
+  let frame;
+  try {
+    frame = JSON.parse(line);
+  } catch {
+    return;
+  }
+
+  // A response to one of our own server→client requests (an approval).
+  if (frame.id !== undefined && frame.method === undefined) {
+    const pending = approvals.get(frame.id);
+    if (pending) {
+      approvals.delete(frame.id);
+      pending(frame.result?.decision ?? 'decline');
+    }
+    return;
+  }
+
+  handle(frame);
+});
+
+function handle({ id, method, params }) {
+  switch (method) {
+    case 'initialize':
+      send({
+        id,
+        result: { userAgent: 'fake-codex/1.0', platformFamily: 'test' },
+      });
+      return;
+
+    case 'initialized':
+      return;
+
+    case 'account/read':
+      send({
+        id,
+        result:
+          process.env.FAKE_CODEX_ACCOUNT === 'none'
+            ? { account: null }
+            : { account: { authMode: 'chatgpt', planType: 'pro' } },
+      });
+      return;
+
+    case 'thread/start':
+      threadCounter += 1;
+      send({ id, result: { thread: { id: `thr_${threadCounter}` } } });
+      return;
+
+    case 'thread/resume':
+      if (params?.threadId === 'thr_missing') {
+        send({ id, error: { code: -32000, message: 'unknown thread' } });
+        return;
+      }
+      send({ id, result: { thread: { id: params.threadId } } });
+      return;
+
+    case 'turn/start':
+      void runTurn(id, params);
+      return;
+
+    case 'turn/interrupt':
+      send({ id, result: {} });
+      return;
+
+    default:
+      send({ id, error: { code: -32601, message: `unknown: ${method}` } });
+  }
+}
+
+async function runTurn(id, params) {
+  turnCounter += 1;
+  const turnId = `turn_${turnCounter}`;
+  const { threadId } = params;
+
+  send({ id, result: { turn: { id: turnId, status: 'inProgress' } } });
+  send({ method: 'turn/started', params: { turn: { id: turnId } } });
+
+  if (process.env.FAKE_CODEX_EXIT_ON_TURN === '1') {
+    process.exit(3);
+  }
+
+  send({
+    method: 'item/reasoning/textDelta',
+    params: { itemId: 'r1', delta: 'planning' },
+  });
+
+  if (process.env.FAKE_CODEX_REQUIRE_APPROVAL === '1') {
+    const decision = await requestApproval(threadId, turnId);
+    if (decision !== 'accept' && decision !== 'acceptForSession') {
+      send({
+        method: 'item/completed',
+        params: {
+          item: {
+            id: 'm1',
+            type: 'agentMessage',
+            text: `declined: ${decision}`,
+          },
+        },
+      });
+      send({
+        method: 'turn/completed',
+        params: { turn: { id: turnId, status: 'completed' } },
+      });
+      return;
+    }
+    send({
+      method: 'item/completed',
+      params: {
+        item: { id: 'c1', type: 'commandExecution', text: 'exit 0' },
+      },
+    });
+  }
+
+  send({
+    method: 'item/agentMessage/delta',
+    params: { itemId: 'm1', delta: 'partial' },
+  });
+  send({
+    method: 'item/completed',
+    params: {
+      item: {
+        id: 'm1',
+        type: 'agentMessage',
+        text: `handled: ${params.input?.[0]?.text ?? ''}`,
+      },
+    },
+  });
+  send({
+    method: 'turn/completed',
+    params: { turn: { id: turnId, status: 'completed' } },
+  });
+}
+
+function requestApproval(threadId, turnId) {
+  const approvalRpcId = 9000 + approvals.size;
+  return new Promise((resolve) => {
+    approvals.set(approvalRpcId, resolve);
+    send({
+      id: approvalRpcId,
+      method: 'item/commandExecution/requestApproval',
+      params: {
+        itemId: 'c1',
+        threadId,
+        turnId,
+        command: 'rm -rf build',
+        cwd: '/workspace',
+      },
+    });
+  });
+}

--- a/packages/oracle-runtime/src/plugins/codex/__test-fixtures__/fake-app-server.mjs
+++ b/packages/oracle-runtime/src/plugins/codex/__test-fixtures__/fake-app-server.mjs
@@ -4,12 +4,34 @@
  * JSON-RPC framing over stdio so the transport, client, approval round-trip
  * and event mapping are exercised against a real process rather than a stub.
  *
- * Behaviour is driven by env vars so one fixture covers every scenario:
- *   FAKE_CODEX_ACCOUNT=none      → `account/read` reports no signed-in account
- *   FAKE_CODEX_REQUIRE_APPROVAL=1 → asks for command approval mid-turn
- *   FAKE_CODEX_EXIT_ON_TURN=1     → exits mid-turn to exercise reconnect
+ * Scenarios are selected with CLI flags rather than environment variables so
+ * a test never has to mutate global state to steer the server:
+ *
+ *   --account=none            `account/read` reports no signed-in account
+ *   --require-login           mirror the real server: no account until
+ *                             `account/login/start` registers a key
+ *   --require-approval        ask for command approval mid-turn
+ *   --exit-on-turn            exit mid-turn, every turn
+ *   --exit-on-turn-once=FILE  exit mid-turn unless FILE exists, creating it on
+ *                             the way out — so the next spawn behaves normally
+ *                             and a reconnect can be observed
  */
+import { existsSync, writeFileSync } from 'node:fs';
 import { createInterface } from 'node:readline';
+
+const argv = process.argv.slice(2);
+const hasFlag = (name) => argv.includes(name);
+const flagValue = (name) => {
+  const match = argv.find((arg) => arg.startsWith(`${name}=`));
+  return match ? match.slice(name.length + 1) : undefined;
+};
+
+const noAccount = flagValue('--account') === 'none';
+const requireLogin = hasFlag('--require-login');
+let loggedIn = false;
+const requireApproval = hasFlag('--require-approval');
+const exitOnEveryTurn = hasFlag('--exit-on-turn');
+const exitOnceMarker = flagValue('--exit-on-turn-once');
 
 const send = (frame) => process.stdout.write(`${JSON.stringify(frame)}\n`);
 
@@ -53,14 +75,30 @@ function handle({ id, method, params }) {
     case 'initialized':
       return;
 
-    case 'account/read':
+    case 'account/read': {
+      // The real App Server does not read OPENAI_API_KEY from its environment
+      // for account purposes — a key has to be registered through
+      // `account/login/start` first.
+      const signedIn = !noAccount && (!requireLogin || loggedIn);
       send({
         id,
-        result:
-          process.env.FAKE_CODEX_ACCOUNT === 'none'
-            ? { account: null }
-            : { account: { authMode: 'chatgpt', planType: 'pro' } },
+        result: signedIn
+          ? {
+              account: { type: 'apiKey', planType: 'pro' },
+              requiresOpenaiAuth: false,
+            }
+          : { account: null, requiresOpenaiAuth: true },
       });
+      return;
+    }
+
+    case 'account/login/start':
+      if (params?.type !== 'apiKey' || !params?.apiKey) {
+        send({ id, error: { code: -32600, message: 'Invalid request' } });
+        return;
+      }
+      loggedIn = true;
+      send({ id, result: { type: 'apiKey' } });
       return;
 
     case 'thread/start':
@@ -89,6 +127,15 @@ function handle({ id, method, params }) {
   }
 }
 
+/** True when this process should die mid-turn to exercise reconnect. */
+function shouldExitMidTurn() {
+  if (exitOnEveryTurn) return true;
+  if (!exitOnceMarker) return false;
+  if (existsSync(exitOnceMarker)) return false;
+  writeFileSync(exitOnceMarker, 'crashed');
+  return true;
+}
+
 async function runTurn(id, params) {
   turnCounter += 1;
   const turnId = `turn_${turnCounter}`;
@@ -97,7 +144,7 @@ async function runTurn(id, params) {
   send({ id, result: { turn: { id: turnId, status: 'inProgress' } } });
   send({ method: 'turn/started', params: { turn: { id: turnId } } });
 
-  if (process.env.FAKE_CODEX_EXIT_ON_TURN === '1') {
+  if (shouldExitMidTurn()) {
     process.exit(3);
   }
 
@@ -106,7 +153,7 @@ async function runTurn(id, params) {
     params: { itemId: 'r1', delta: 'planning' },
   });
 
-  if (process.env.FAKE_CODEX_REQUIRE_APPROVAL === '1') {
+  if (requireApproval) {
     const decision = await requestApproval(threadId, turnId);
     if (decision !== 'accept' && decision !== 'acceptForSession') {
       send({
@@ -149,7 +196,8 @@ async function runTurn(id, params) {
   });
   send({
     method: 'turn/completed',
-    params: { turn: { id: turnId, status: 'completed' } },
+    // The real server includes an explicit `error: null` on success.
+    params: { turn: { id: turnId, status: 'completed', error: null } },
   });
 }
 

--- a/packages/oracle-runtime/src/plugins/codex/app-server/client.ts
+++ b/packages/oracle-runtime/src/plugins/codex/app-server/client.ts
@@ -1,0 +1,246 @@
+import {
+  CODEX_APPROVAL_REQUESTS,
+  CODEX_METHODS,
+  approvalParamsSchema,
+  classifyFrame,
+  type CodexApprovalDecision,
+  type CodexApprovalParams,
+  type JsonRpcId,
+} from './protocol.js';
+import type { CodexTransport } from './transport.js';
+
+/** A request the App Server makes of us. Today: the two approval gates. */
+export interface CodexApprovalRequest {
+  readonly kind: 'commandExecution' | 'fileChange';
+  readonly params: CodexApprovalParams;
+}
+
+export type CodexApprovalHandler = (
+  request: CodexApprovalRequest,
+) => Promise<CodexApprovalDecision>;
+
+export type CodexNotificationHandler = (
+  method: string,
+  params: unknown,
+) => void;
+
+export interface CodexClientOptions {
+  transport: CodexTransport;
+  /** Applied to every request that does not pass its own timeout. */
+  requestTimeoutMs: number;
+  onNotification: CodexNotificationHandler;
+  /**
+   * Answers server-initiated approval requests. Required — an App Server that
+   * asks for approval must never be auto-allowed by the adapter.
+   */
+  onApproval: CodexApprovalHandler;
+  onClose?: (info: { code: number | null; detail?: string }) => void;
+  clientInfo: { name: string; title: string; version: string };
+}
+
+/** Structured error carrying the upstream JSON-RPC code when there was one. */
+export class CodexRpcError extends Error {
+  constructor(
+    message: string,
+    readonly method: string,
+    readonly code?: number,
+  ) {
+    super(`codex: ${method} failed — ${message}`);
+    this.name = 'CodexRpcError';
+  }
+}
+
+interface Pending {
+  resolve: (value: unknown) => void;
+  reject: (error: Error) => void;
+  method: string;
+  timer: NodeJS.Timeout;
+}
+
+const APPROVAL_METHOD_KINDS: Record<string, CodexApprovalRequest['kind']> = {
+  [CODEX_APPROVAL_REQUESTS.commandExecution]: 'commandExecution',
+  [CODEX_APPROVAL_REQUESTS.fileChange]: 'fileChange',
+};
+
+/**
+ * Bidirectional JSON-RPC client for one App Server connection. Owns id
+ * correlation, per-request timeouts, cancellation, and the approval
+ * round-trip; knows nothing about threads or QiForge events.
+ */
+export class CodexAppServerClient {
+  private nextId = 1;
+
+  private readonly pending = new Map<JsonRpcId, Pending>();
+
+  private closed = false;
+
+  private closeReason?: string;
+
+  constructor(private readonly options: CodexClientOptions) {
+    options.transport.onMessage((frame) => this.handleFrame(frame));
+    options.transport.onClose((info) => this.handleClose(info));
+  }
+
+  /** Handshake. Must complete before any thread or turn call. */
+  async initialize(timeoutMs: number): Promise<unknown> {
+    const result = await this.request(
+      CODEX_METHODS.initialize,
+      {
+        clientInfo: this.options.clientInfo,
+        capabilities: { experimentalApi: false },
+      },
+      { timeoutMs },
+    );
+    this.notify(CODEX_METHODS.initialized, {});
+    return result;
+  }
+
+  async request(
+    method: string,
+    params: unknown,
+    opts: { timeoutMs?: number; signal?: AbortSignal } = {},
+  ): Promise<unknown> {
+    if (this.closed) {
+      throw new CodexRpcError(this.closeReason ?? 'connection closed', method);
+    }
+
+    const id = this.nextId++;
+    const timeoutMs = opts.timeoutMs ?? this.options.requestTimeoutMs;
+
+    return new Promise<unknown>((resolvePromise, rejectPromise) => {
+      const settleReject = (error: Error) => {
+        const entry = this.pending.get(id);
+        if (!entry) return;
+        clearTimeout(entry.timer);
+        this.pending.delete(id);
+        opts.signal?.removeEventListener('abort', onAbort);
+        rejectPromise(error);
+      };
+
+      const onAbort = () => {
+        settleReject(new CodexRpcError('cancelled by caller', method));
+      };
+
+      const timer = setTimeout(() => {
+        settleReject(
+          new CodexRpcError(`timed out after ${timeoutMs}ms`, method),
+        );
+      }, timeoutMs);
+      timer.unref?.();
+
+      this.pending.set(id, {
+        method,
+        timer,
+        reject: settleReject,
+        resolve: (value) => {
+          clearTimeout(timer);
+          this.pending.delete(id);
+          opts.signal?.removeEventListener('abort', onAbort);
+          resolvePromise(value);
+        },
+      });
+
+      if (opts.signal) {
+        if (opts.signal.aborted) {
+          onAbort();
+          return;
+        }
+        opts.signal.addEventListener('abort', onAbort, { once: true });
+      }
+
+      try {
+        this.options.transport.send({ id, method, params });
+      } catch (error) {
+        settleReject(
+          new CodexRpcError(
+            error instanceof Error ? error.message : String(error),
+            method,
+          ),
+        );
+      }
+    });
+  }
+
+  notify(method: string, params: unknown): void {
+    if (this.closed) return;
+    this.options.transport.send({ method, params });
+  }
+
+  async close(): Promise<void> {
+    this.handleClose({ code: null, detail: 'closed by client' });
+    await this.options.transport.close();
+  }
+
+  private handleFrame(raw: unknown): void {
+    const frame = classifyFrame(raw);
+    if (!frame) return;
+
+    if (frame.kind === 'response') {
+      const entry = this.pending.get(frame.id);
+      if (!entry) return;
+      if (frame.error) {
+        entry.reject(
+          new CodexRpcError(
+            frame.error.message,
+            entry.method,
+            frame.error.code,
+          ),
+        );
+        return;
+      }
+      entry.resolve(frame.result);
+      return;
+    }
+
+    if (frame.kind === 'notification') {
+      this.options.onNotification(frame.method, frame.params);
+      return;
+    }
+
+    void this.handleServerRequest(frame.id, frame.method, frame.params);
+  }
+
+  private async handleServerRequest(
+    id: JsonRpcId,
+    method: string,
+    params: unknown,
+  ): Promise<void> {
+    const kind = APPROVAL_METHOD_KINDS[method];
+    if (!kind) {
+      this.options.transport.send({
+        id,
+        error: { code: -32601, message: `unsupported request: ${method}` },
+      });
+      return;
+    }
+
+    const parsed = approvalParamsSchema.safeParse(params);
+    if (!parsed.success) {
+      // A malformed approval request is refused, never accepted by default.
+      this.options.transport.send({ id, result: { decision: 'decline' } });
+      return;
+    }
+
+    let decision: CodexApprovalDecision;
+    try {
+      decision = await this.options.onApproval({ kind, params: parsed.data });
+    } catch {
+      decision = 'decline';
+    }
+
+    if (this.closed) return;
+    this.options.transport.send({ id, result: { decision } });
+  }
+
+  private handleClose(info: { code: number | null; detail?: string }): void {
+    if (this.closed) return;
+    this.closed = true;
+    this.closeReason = info.detail ?? `app server exited (code ${info.code})`;
+
+    for (const [, entry] of this.pending) {
+      entry.reject(new CodexRpcError(this.closeReason, entry.method));
+    }
+    this.pending.clear();
+    this.options.onClose?.(info);
+  }
+}

--- a/packages/oracle-runtime/src/plugins/codex/app-server/event-mapper.test.ts
+++ b/packages/oracle-runtime/src/plugins/codex/app-server/event-mapper.test.ts
@@ -60,6 +60,18 @@ describe('mapNotification', () => {
     );
   });
 
+  it('accepts the explicit null error the server sends on success', () => {
+    expect(
+      mapNotification('turn/completed', {
+        turn: { id: 'turn_1', status: 'completed', error: null },
+      }),
+    ).toEqual({
+      type: 'turn.completed',
+      turnId: 'turn_1',
+      status: 'completed',
+    });
+  });
+
   it('preserves the failure reason on a failed turn', () => {
     expect(
       mapNotification('turn/completed', {

--- a/packages/oracle-runtime/src/plugins/codex/app-server/event-mapper.test.ts
+++ b/packages/oracle-runtime/src/plugins/codex/app-server/event-mapper.test.ts
@@ -1,0 +1,196 @@
+import { describe, expect, it, vi } from 'vitest';
+import { classifyFrame } from './protocol.js';
+import {
+  CodexTurnTranscript,
+  emitCodexEvent,
+  mapNotification,
+} from './event-mapper.js';
+
+const mockEmit = () => ({
+  toolCall: vi.fn(() => {}),
+  actionCall: vi.fn(() => {}),
+  renderComponent: vi.fn(() => {}),
+  reasoning: vi.fn(() => {}),
+  browserToolCall: vi.fn(() => {}),
+  router: vi.fn(() => {}),
+  messageCacheInvalidation: vi.fn(() => {}),
+});
+
+describe('classifyFrame', () => {
+  it('reads a response by its id without a jsonrpc version field', () => {
+    expect(classifyFrame({ id: 1, result: { ok: true } })).toEqual({
+      kind: 'response',
+      id: 1,
+      result: { ok: true },
+    });
+  });
+
+  it('reads a server-initiated request as a request, not a response', () => {
+    const frame = classifyFrame({ id: 7, method: 'x', params: { a: 1 } });
+    expect(frame?.kind).toBe('request');
+  });
+
+  it('reads a notification as one', () => {
+    const frame = classifyFrame({ method: 'turn/started', params: {} });
+    expect(frame?.kind).toBe('notification');
+  });
+
+  it('preserves an error response', () => {
+    const frame = classifyFrame({
+      id: 2,
+      error: { code: -32001, message: 'overloaded' },
+    });
+    expect(frame).toMatchObject({
+      kind: 'response',
+      error: { code: -32001, message: 'overloaded' },
+    });
+  });
+
+  it('ignores junk rather than throwing', () => {
+    expect(classifyFrame({ nonsense: true })).toBeNull();
+    expect(classifyFrame('a string')).toBeNull();
+    expect(classifyFrame(null)).toBeNull();
+  });
+});
+
+describe('mapNotification', () => {
+  it('maps a turn start', () => {
+    expect(mapNotification('turn/started', { turn: { id: 'turn_1' } })).toEqual(
+      { type: 'turn.started', turnId: 'turn_1' },
+    );
+  });
+
+  it('preserves the failure reason on a failed turn', () => {
+    expect(
+      mapNotification('turn/completed', {
+        turn: { id: 'turn_1', status: 'failed', error: { message: 'boom' } },
+      }),
+    ).toEqual({
+      type: 'turn.completed',
+      turnId: 'turn_1',
+      status: 'failed',
+      error: 'boom',
+    });
+  });
+
+  it('preserves the command on a command-execution item', () => {
+    expect(
+      mapNotification('item/started', {
+        item: { id: 'item_1', type: 'commandExecution', command: 'pnpm test' },
+      }),
+    ).toEqual({
+      type: 'item.started',
+      itemId: 'item_1',
+      itemType: 'commandExecution',
+      command: 'pnpm test',
+    });
+  });
+
+  it('maps agent-message and reasoning deltas distinctly', () => {
+    expect(
+      mapNotification('item/agentMessage/delta', {
+        itemId: 'i1',
+        delta: 'hello',
+      }),
+    ).toEqual({ type: 'message.delta', itemId: 'i1', delta: 'hello' });
+
+    expect(
+      mapNotification('item/reasoning/textDelta', { delta: 'thinking' }),
+    ).toEqual({ type: 'reasoning.delta', delta: 'thinking' });
+  });
+
+  it('ignores an unmodelled notification instead of throwing', () => {
+    expect(mapNotification('thread/name/set', { any: 'thing' })).toBeNull();
+  });
+
+  it('ignores a malformed payload for a known method', () => {
+    expect(mapNotification('turn/started', { turn: {} })).toBeNull();
+  });
+});
+
+describe('emitCodexEvent', () => {
+  it('routes reasoning to the reasoning channel', () => {
+    const emit = mockEmit();
+    emitCodexEvent(
+      { type: 'reasoning.delta', delta: 'why' },
+      { emit },
+      'thr_1',
+    );
+    expect(emit.reasoning).toHaveBeenCalledWith(
+      expect.objectContaining({
+        provider: 'codex',
+        threadId: 'thr_1',
+        text: 'why',
+      }),
+    );
+  });
+
+  it('routes item lifecycle to the tool-call channel with its status', () => {
+    const emit = mockEmit();
+    emitCodexEvent(
+      {
+        type: 'item.started',
+        itemId: 'i1',
+        itemType: 'commandExecution',
+        command: 'ls',
+      },
+      { emit },
+      'thr_1',
+    );
+    expect(emit.toolCall).toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: 'codex.commandExecution',
+        status: 'started',
+        command: 'ls',
+      }),
+    );
+  });
+
+  it('routes turn lifecycle to the router channel', () => {
+    const emit = mockEmit();
+    emitCodexEvent(
+      { type: 'turn.completed', turnId: 't1', status: 'interrupted' },
+      { emit },
+      'thr_1',
+    );
+    expect(emit.router).toHaveBeenCalledWith(
+      expect.objectContaining({ phase: 'completed', status: 'interrupted' }),
+    );
+  });
+});
+
+describe('CodexTurnTranscript', () => {
+  it('prefers the completed item text over accumulated deltas', () => {
+    const transcript = new CodexTurnTranscript();
+    transcript.record({ type: 'message.delta', delta: 'par' });
+    transcript.record({ type: 'message.delta', delta: 'tial' });
+    transcript.record({
+      type: 'item.completed',
+      itemId: 'i1',
+      itemType: 'agentMessage',
+      text: 'the final answer',
+    });
+
+    expect(transcript.text()).toBe('the final answer');
+  });
+
+  it('falls back to deltas when no terminal item arrives', () => {
+    const transcript = new CodexTurnTranscript();
+    transcript.record({ type: 'message.delta', delta: 'strea' });
+    transcript.record({ type: 'message.delta', delta: 'med' });
+
+    expect(transcript.text()).toBe('streamed');
+  });
+
+  it('ignores non-message items', () => {
+    const transcript = new CodexTurnTranscript();
+    transcript.record({
+      type: 'item.completed',
+      itemId: 'i1',
+      itemType: 'commandExecution',
+      text: 'exit 0',
+    });
+
+    expect(transcript.text()).toBe('');
+  });
+});

--- a/packages/oracle-runtime/src/plugins/codex/app-server/event-mapper.ts
+++ b/packages/oracle-runtime/src/plugins/codex/app-server/event-mapper.ts
@@ -1,0 +1,197 @@
+import type { RuntimeContext } from '../../../plugin-api/types.js';
+import { CODEX_PROVIDER_ID } from '../domain/provider.js';
+import {
+  CODEX_NOTIFICATIONS,
+  deltaParamsSchema,
+  itemParamsSchema,
+  turnCompletedParamsSchema,
+  turnStartedParamsSchema,
+} from './protocol.js';
+
+/**
+ * QiForge's normalized view of an App Server notification. Every field the
+ * protocol carries that a caller can act on is preserved — item identity, item
+ * type, turn status and failure reason all survive the mapping.
+ */
+export type CodexRuntimeEvent =
+  | { readonly type: 'turn.started'; readonly turnId: string }
+  | {
+      readonly type: 'turn.completed';
+      readonly turnId: string;
+      readonly status: 'completed' | 'interrupted' | 'failed';
+      readonly error?: string;
+    }
+  | {
+      readonly type: 'item.started';
+      readonly itemId: string;
+      readonly itemType: string;
+      readonly command?: string;
+    }
+  | {
+      readonly type: 'item.completed';
+      readonly itemId: string;
+      readonly itemType: string;
+      readonly text?: string;
+    }
+  | {
+      readonly type: 'message.delta';
+      readonly itemId?: string;
+      readonly delta: string;
+    }
+  | {
+      readonly type: 'reasoning.delta';
+      readonly itemId?: string;
+      readonly delta: string;
+    };
+
+/**
+ * Translate one App Server notification. Returns null for notifications the
+ * harness does not model, so unknown methods are ignored rather than throwing
+ * on a protocol addition.
+ */
+export function mapNotification(
+  method: string,
+  params: unknown,
+): CodexRuntimeEvent | null {
+  switch (method) {
+    case CODEX_NOTIFICATIONS.turnStarted: {
+      const parsed = turnStartedParamsSchema.safeParse(params);
+      return parsed.success
+        ? { type: 'turn.started', turnId: parsed.data.turn.id }
+        : null;
+    }
+    case CODEX_NOTIFICATIONS.turnCompleted: {
+      const parsed = turnCompletedParamsSchema.safeParse(params);
+      if (!parsed.success) return null;
+      const { turn } = parsed.data;
+      return {
+        type: 'turn.completed',
+        turnId: turn.id,
+        status: turn.status ?? 'completed',
+        ...(turn.error?.message ? { error: turn.error.message } : {}),
+      };
+    }
+    case CODEX_NOTIFICATIONS.itemStarted: {
+      const parsed = itemParamsSchema.safeParse(params);
+      if (!parsed.success) return null;
+      const { item } = parsed.data;
+      return {
+        type: 'item.started',
+        itemId: item.id,
+        itemType: item.type ?? 'unknown',
+        ...(item.command ? { command: item.command } : {}),
+      };
+    }
+    case CODEX_NOTIFICATIONS.itemCompleted: {
+      const parsed = itemParamsSchema.safeParse(params);
+      if (!parsed.success) return null;
+      const { item } = parsed.data;
+      return {
+        type: 'item.completed',
+        itemId: item.id,
+        itemType: item.type ?? 'unknown',
+        ...(item.text ? { text: item.text } : {}),
+      };
+    }
+    case CODEX_NOTIFICATIONS.agentMessageDelta: {
+      const parsed = deltaParamsSchema.safeParse(params);
+      if (!parsed.success) return null;
+      return {
+        type: 'message.delta',
+        ...(parsed.data.itemId ? { itemId: parsed.data.itemId } : {}),
+        delta: parsed.data.delta,
+      };
+    }
+    case CODEX_NOTIFICATIONS.reasoningDelta: {
+      const parsed = deltaParamsSchema.safeParse(params);
+      if (!parsed.success) return null;
+      return {
+        type: 'reasoning.delta',
+        ...(parsed.data.itemId ? { itemId: parsed.data.itemId } : {}),
+        delta: parsed.data.delta,
+      };
+    }
+    default:
+      return null;
+  }
+}
+
+/** Bridge a normalized Codex event onto QiForge's typed event emitter. */
+export function emitCodexEvent(
+  event: CodexRuntimeEvent,
+  ctx: Pick<RuntimeContext, 'emit'>,
+  threadId: string,
+): void {
+  const base = { provider: CODEX_PROVIDER_ID, threadId };
+
+  switch (event.type) {
+    case 'reasoning.delta':
+      ctx.emit.reasoning({ ...base, itemId: event.itemId, text: event.delta });
+      return;
+    case 'message.delta':
+      ctx.emit.renderComponent({
+        ...base,
+        component: 'codex.message',
+        itemId: event.itemId,
+        delta: event.delta,
+      });
+      return;
+    case 'item.started':
+    case 'item.completed':
+      ctx.emit.toolCall({
+        ...base,
+        name: `codex.${event.itemType}`,
+        itemId: event.itemId,
+        status: event.type === 'item.started' ? 'started' : 'completed',
+        ...(event.type === 'item.started' && event.command
+          ? { command: event.command }
+          : {}),
+        ...(event.type === 'item.completed' && event.text
+          ? { text: event.text }
+          : {}),
+      });
+      return;
+    case 'turn.started':
+    case 'turn.completed':
+      ctx.emit.router({
+        ...base,
+        turnId: event.turnId,
+        phase: event.type === 'turn.started' ? 'started' : 'completed',
+        ...(event.type === 'turn.completed' ? { status: event.status } : {}),
+        ...(event.type === 'turn.completed' && event.error
+          ? { error: event.error }
+          : {}),
+      });
+  }
+}
+
+/**
+ * Accumulates the agent's visible text across a turn. `item/completed` for an
+ * agentMessage carries the authoritative text; deltas are used only when the
+ * server streams without a terminal item.
+ */
+export class CodexTurnTranscript {
+  private deltas: string[] = [];
+
+  private completed: string[] = [];
+
+  record(event: CodexRuntimeEvent): void {
+    if (event.type === 'message.delta') {
+      this.deltas.push(event.delta);
+      return;
+    }
+    if (
+      event.type === 'item.completed' &&
+      event.itemType === 'agentMessage' &&
+      event.text
+    ) {
+      this.completed.push(event.text);
+      this.deltas = [];
+    }
+  }
+
+  text(): string {
+    if (this.completed.length > 0) return this.completed.join('\n\n').trim();
+    return this.deltas.join('').trim();
+  }
+}

--- a/packages/oracle-runtime/src/plugins/codex/app-server/protocol.ts
+++ b/packages/oracle-runtime/src/plugins/codex/app-server/protocol.ts
@@ -13,6 +13,7 @@ export const CODEX_METHODS = {
   turnStart: 'turn/start',
   turnInterrupt: 'turn/interrupt',
   accountRead: 'account/read',
+  accountLoginStart: 'account/login/start',
 } as const;
 
 /** Notifications the server pushes during a turn. */
@@ -133,7 +134,7 @@ export const threadStartResultSchema = z.object({
 });
 
 export const turnStartResultSchema = z.object({
-  turn: z.object({ id: z.string().min(1), status: z.string().optional() }),
+  turn: z.object({ id: z.string().min(1), status: z.string().nullish() }),
 });
 
 /**
@@ -144,12 +145,12 @@ export const turnStartResultSchema = z.object({
 export const accountReadResultSchema = z.object({
   account: z
     .object({
-      authMode: z.string().optional(),
-      planType: z.string().optional(),
-      email: z.string().optional(),
+      type: z.string().nullish(),
+      planType: z.string().nullish(),
+      email: z.string().nullish(),
     })
-    .nullable()
-    .optional(),
+    .nullish(),
+  requiresOpenaiAuth: z.boolean().nullish(),
 });
 
 // ---------------------------------------------------------------------------
@@ -163,33 +164,33 @@ export const turnStartedParamsSchema = z.object({
 export const turnCompletedParamsSchema = z.object({
   turn: z.object({
     id: z.string(),
-    status: z.enum(['completed', 'interrupted', 'failed']).optional(),
-    error: z.object({ message: z.string() }).optional(),
+    status: z.enum(['completed', 'interrupted', 'failed']).nullish(),
+    error: z.object({ message: z.string() }).nullish(),
   }),
 });
 
 export const itemParamsSchema = z.object({
   item: z.object({
     id: z.string(),
-    type: z.string().optional(),
-    status: z.string().optional(),
-    text: z.string().optional(),
-    command: z.string().optional(),
+    type: z.string().nullish(),
+    status: z.string().nullish(),
+    text: z.string().nullish(),
+    command: z.string().nullish(),
   }),
 });
 
 export const deltaParamsSchema = z.object({
-  itemId: z.string().optional(),
+  itemId: z.string().nullish(),
   delta: z.string(),
 });
 
 export const approvalParamsSchema = z.object({
-  itemId: z.string().optional(),
-  threadId: z.string().optional(),
-  turnId: z.string().optional(),
-  command: z.string().optional(),
-  cwd: z.string().optional(),
-  reason: z.string().optional(),
+  itemId: z.string().nullish(),
+  threadId: z.string().nullish(),
+  turnId: z.string().nullish(),
+  command: z.string().nullish(),
+  cwd: z.string().nullish(),
+  reason: z.string().nullish(),
 });
 
 export type CodexApprovalParams = z.infer<typeof approvalParamsSchema>;

--- a/packages/oracle-runtime/src/plugins/codex/app-server/protocol.ts
+++ b/packages/oracle-runtime/src/plugins/codex/app-server/protocol.ts
@@ -1,0 +1,195 @@
+import { z } from 'zod';
+
+/**
+ * Wire method names for the Codex App Server. Centralized here because the
+ * protocol has renamed methods across Codex releases — an upgrade changes
+ * this table, not the adapter.
+ */
+export const CODEX_METHODS = {
+  initialize: 'initialize',
+  initialized: 'initialized',
+  threadStart: 'thread/start',
+  threadResume: 'thread/resume',
+  turnStart: 'turn/start',
+  turnInterrupt: 'turn/interrupt',
+  accountRead: 'account/read',
+} as const;
+
+/** Notifications the server pushes during a turn. */
+export const CODEX_NOTIFICATIONS = {
+  turnStarted: 'turn/started',
+  turnCompleted: 'turn/completed',
+  itemStarted: 'item/started',
+  itemCompleted: 'item/completed',
+  agentMessageDelta: 'item/agentMessage/delta',
+  reasoningDelta: 'item/reasoning/textDelta',
+} as const;
+
+/** Server→client requests. Each one blocks the turn until answered. */
+export const CODEX_APPROVAL_REQUESTS = {
+  commandExecution: 'item/commandExecution/requestApproval',
+  fileChange: 'item/fileChange/requestApproval',
+} as const;
+
+export const CODEX_APPROVAL_DECISIONS = [
+  'accept',
+  'acceptForSession',
+  'decline',
+  'cancel',
+] as const;
+export type CodexApprovalDecision = (typeof CODEX_APPROVAL_DECISIONS)[number];
+
+/**
+ * The App Server speaks a JSON-RPC variant that omits the `jsonrpc` version
+ * field on the wire. Frames are newline-delimited JSON.
+ */
+export const jsonRpcIdSchema = z.union([z.string(), z.number()]);
+
+export const jsonRpcRequestSchema = z.object({
+  id: jsonRpcIdSchema,
+  method: z.string(),
+  params: z.unknown().optional(),
+});
+
+export const jsonRpcResponseSchema = z.object({
+  id: jsonRpcIdSchema,
+  result: z.unknown().optional(),
+  error: z
+    .object({
+      code: z.number(),
+      message: z.string(),
+      data: z.unknown().optional(),
+    })
+    .optional(),
+});
+
+export const jsonRpcNotificationSchema = z.object({
+  method: z.string(),
+  params: z.unknown().optional(),
+});
+
+export type JsonRpcId = z.infer<typeof jsonRpcIdSchema>;
+
+/** An inbound frame, discriminated by shape rather than by a version field. */
+export type CodexInboundFrame =
+  | {
+      kind: 'response';
+      id: JsonRpcId;
+      result?: unknown;
+      error?: { code: number; message: string };
+    }
+  | { kind: 'request'; id: JsonRpcId; method: string; params: unknown }
+  | { kind: 'notification'; method: string; params: unknown };
+
+/** Classify a decoded JSON frame. Returns null for anything unrecognised. */
+export function classifyFrame(raw: unknown): CodexInboundFrame | null {
+  if (typeof raw !== 'object' || raw === null) return null;
+  const frame = raw as Record<string, unknown>;
+
+  const hasId = 'id' in frame && frame.id !== null && frame.id !== undefined;
+  const hasMethod = typeof frame.method === 'string';
+
+  if (hasId && hasMethod) {
+    const parsed = jsonRpcRequestSchema.safeParse(frame);
+    if (!parsed.success) return null;
+    return {
+      kind: 'request',
+      id: parsed.data.id,
+      method: parsed.data.method,
+      params: parsed.data.params ?? {},
+    };
+  }
+
+  if (hasId) {
+    const parsed = jsonRpcResponseSchema.safeParse(frame);
+    if (!parsed.success) return null;
+    return {
+      kind: 'response',
+      id: parsed.data.id,
+      ...(parsed.data.error ? { error: parsed.data.error } : {}),
+      result: parsed.data.result,
+    };
+  }
+
+  if (hasMethod) {
+    const parsed = jsonRpcNotificationSchema.safeParse(frame);
+    if (!parsed.success) return null;
+    return {
+      kind: 'notification',
+      method: parsed.data.method,
+      params: parsed.data.params ?? {},
+    };
+  }
+
+  return null;
+}
+
+// ---------------------------------------------------------------------------
+// Result payloads
+// ---------------------------------------------------------------------------
+
+export const threadStartResultSchema = z.object({
+  thread: z.object({ id: z.string().min(1) }),
+});
+
+export const turnStartResultSchema = z.object({
+  turn: z.object({ id: z.string().min(1), status: z.string().optional() }),
+});
+
+/**
+ * `account/read` reports how the App Server itself is authenticated. The
+ * harness uses it as the authoritative check — the presence of a credential
+ * file or env var is necessary, not sufficient.
+ */
+export const accountReadResultSchema = z.object({
+  account: z
+    .object({
+      authMode: z.string().optional(),
+      planType: z.string().optional(),
+      email: z.string().optional(),
+    })
+    .nullable()
+    .optional(),
+});
+
+// ---------------------------------------------------------------------------
+// Notification payloads
+// ---------------------------------------------------------------------------
+
+export const turnStartedParamsSchema = z.object({
+  turn: z.object({ id: z.string() }),
+});
+
+export const turnCompletedParamsSchema = z.object({
+  turn: z.object({
+    id: z.string(),
+    status: z.enum(['completed', 'interrupted', 'failed']).optional(),
+    error: z.object({ message: z.string() }).optional(),
+  }),
+});
+
+export const itemParamsSchema = z.object({
+  item: z.object({
+    id: z.string(),
+    type: z.string().optional(),
+    status: z.string().optional(),
+    text: z.string().optional(),
+    command: z.string().optional(),
+  }),
+});
+
+export const deltaParamsSchema = z.object({
+  itemId: z.string().optional(),
+  delta: z.string(),
+});
+
+export const approvalParamsSchema = z.object({
+  itemId: z.string().optional(),
+  threadId: z.string().optional(),
+  turnId: z.string().optional(),
+  command: z.string().optional(),
+  cwd: z.string().optional(),
+  reason: z.string().optional(),
+});
+
+export type CodexApprovalParams = z.infer<typeof approvalParamsSchema>;

--- a/packages/oracle-runtime/src/plugins/codex/app-server/transport.ts
+++ b/packages/oracle-runtime/src/plugins/codex/app-server/transport.ts
@@ -1,0 +1,167 @@
+import { spawn, type ChildProcessWithoutNullStreams } from 'node:child_process';
+
+/**
+ * Byte pipe to an App Server instance. Framing (newline-delimited JSON) is the
+ * transport's concern; the client above it deals only in decoded frames.
+ */
+export interface CodexTransport {
+  send(frame: unknown): void;
+  onMessage(handler: (frame: unknown) => void): void;
+  /** Fired once when the pipe closes, for any reason. */
+  onClose(
+    handler: (info: { code: number | null; detail?: string }) => void,
+  ): void;
+  close(): Promise<void>;
+}
+
+export interface StdioTransportOptions {
+  command: string;
+  args: readonly string[];
+  cwd: string;
+  /** Spread over the inherited env. Contains credential material. */
+  env: Readonly<Record<string, string>>;
+  /** Receives the child's stderr, line by line. */
+  onStderr?: (line: string) => void;
+}
+
+export class CodexTransportError extends Error {
+  constructor(
+    message: string,
+    readonly cause?: unknown,
+  ) {
+    super(`codex: ${message}`);
+    this.name = 'CodexTransportError';
+  }
+}
+
+/** Split a growing buffer into complete lines, returning the remainder. */
+export function drainLines(buffer: string): {
+  lines: string[];
+  rest: string;
+} {
+  const parts = buffer.split('\n');
+  const rest = parts.pop() ?? '';
+  return { lines: parts.filter((line) => line.trim().length > 0), rest };
+}
+
+/**
+ * Spawns `codex app-server` and speaks newline-delimited JSON over its stdio.
+ * The default transport; `CodexAppServerClient` accepts any `CodexTransport`
+ * so a WebSocket-hosted App Server can be swapped in without touching the
+ * client.
+ */
+export class StdioCodexTransport implements CodexTransport {
+  private child: ChildProcessWithoutNullStreams | null = null;
+
+  private stdoutBuffer = '';
+
+  private stderrBuffer = '';
+
+  private messageHandler: ((frame: unknown) => void) | null = null;
+
+  private closeHandler:
+    | ((info: { code: number | null; detail?: string }) => void)
+    | null = null;
+
+  private closed = false;
+
+  constructor(private readonly options: StdioTransportOptions) {}
+
+  start(): void {
+    if (this.child) throw new CodexTransportError('transport already started');
+
+    try {
+      this.child = spawn(this.options.command, [...this.options.args], {
+        cwd: this.options.cwd,
+        env: { ...process.env, ...this.options.env },
+        stdio: ['pipe', 'pipe', 'pipe'],
+      });
+    } catch (error) {
+      throw new CodexTransportError(
+        `failed to spawn '${this.options.command}'`,
+        error,
+      );
+    }
+
+    this.child.stdout.setEncoding('utf8');
+    this.child.stdout.on('data', (chunk: string) => {
+      this.stdoutBuffer += chunk;
+      const { lines, rest } = drainLines(this.stdoutBuffer);
+      this.stdoutBuffer = rest;
+      for (const line of lines) {
+        let decoded: unknown;
+        try {
+          decoded = JSON.parse(line);
+        } catch {
+          // Non-JSON on stdout is diagnostic noise from the binary, not a
+          // protocol frame. Surface it through the stderr channel instead of
+          // tearing down a working connection.
+          this.options.onStderr?.(line);
+          continue;
+        }
+        this.messageHandler?.(decoded);
+      }
+    });
+
+    this.child.stderr.setEncoding('utf8');
+    this.child.stderr.on('data', (chunk: string) => {
+      this.stderrBuffer += chunk;
+      const { lines, rest } = drainLines(this.stderrBuffer);
+      this.stderrBuffer = rest;
+      for (const line of lines) this.options.onStderr?.(line);
+    });
+
+    const fail = (detail: string) => (code: number | null) => {
+      if (this.closed) return;
+      this.closed = true;
+      this.closeHandler?.({ code, detail });
+    };
+
+    this.child.on('exit', (code) => fail('app server exited')(code));
+    this.child.on('error', (error) => {
+      if (this.closed) return;
+      this.closed = true;
+      this.closeHandler?.({ code: null, detail: error.message });
+    });
+  }
+
+  send(frame: unknown): void {
+    if (!this.child || this.closed) {
+      throw new CodexTransportError('transport is not open');
+    }
+    this.child.stdin.write(`${JSON.stringify(frame)}\n`);
+  }
+
+  onMessage(handler: (frame: unknown) => void): void {
+    this.messageHandler = handler;
+  }
+
+  onClose(
+    handler: (info: { code: number | null; detail?: string }) => void,
+  ): void {
+    this.closeHandler = handler;
+  }
+
+  async close(): Promise<void> {
+    const child = this.child;
+    if (!child || this.closed) {
+      this.closed = true;
+      return;
+    }
+    this.closed = true;
+    await new Promise<void>((resolveClose) => {
+      const done = () => resolveClose();
+      child.once('exit', done);
+      child.stdin.end();
+      child.kill('SIGTERM');
+      // The binary flushes and exits on SIGTERM; escalate only if it doesn't.
+      const escalate = setTimeout(() => {
+        child.kill('SIGKILL');
+        resolveClose();
+      }, 5_000);
+      escalate.unref?.();
+      child.once('exit', () => clearTimeout(escalate));
+    });
+    this.child = null;
+  }
+}

--- a/packages/oracle-runtime/src/plugins/codex/auth/connection-state.test.ts
+++ b/packages/oracle-runtime/src/plugins/codex/auth/connection-state.test.ts
@@ -1,0 +1,117 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import type { CodexTenantScope } from '../domain/provider.js';
+import {
+  CodexConnectionState,
+  CodexTransitionError,
+  canTransition,
+} from './connection-state.js';
+
+const scope: CodexTenantScope = {
+  userDid: 'did:ixo:user1',
+  oracleEntityDid: 'did:ixo:oracle1',
+};
+
+describe('CodexConnectionState', () => {
+  let clock: number;
+  let state: CodexConnectionState;
+
+  beforeEach(() => {
+    clock = 1_000;
+    state = new CodexConnectionState(scope, 'api_key', () => clock);
+  });
+
+  it('starts disconnected', () => {
+    expect(state.current()).toBe('disconnected');
+    expect(state.snapshot().authMode).toBe('api_key');
+  });
+
+  it('records the happy-path connect sequence in the audit trail', () => {
+    state.transition('connecting', 'connect_requested');
+    clock = 2_000;
+    state.transition('connected', 'handshake_ok');
+
+    const history = state.history();
+    expect(history.map((entry) => entry.to)).toEqual([
+      'connecting',
+      'connected',
+    ]);
+    expect(history[1]?.from).toBe('connecting');
+    expect(history[1]?.at).toBe(2_000);
+    expect(history[1]?.reason).toBe('handshake_ok');
+  });
+
+  it('scopes every transition to the tenant key', () => {
+    state.transition('connecting', 'connect_requested');
+    expect(state.history()[0]?.tenant).toBe('did_ixo_oracle1__did_ixo_user1');
+  });
+
+  it('rejects an illegal edge instead of silently corrupting state', () => {
+    expect(() => state.transition('connected', 'handshake_ok')).toThrow(
+      CodexTransitionError,
+    );
+    expect(state.current()).toBe('disconnected');
+  });
+
+  it('allows a same-state transition so repeated signals are idempotent', () => {
+    expect(() =>
+      state.transition('disconnected', 'disconnect_requested'),
+    ).not.toThrow();
+  });
+
+  it('surfaces an authorization url only while awaiting device authorization', () => {
+    state.transition('connecting', 'connect_requested');
+    state.transition('requires_device_authorization', 'auth_pending_browser', {
+      authorizationUrl: 'https://auth.example/device',
+    });
+    expect(state.snapshot().authorizationUrl).toBe(
+      'https://auth.example/device',
+    );
+
+    state.transition('connecting', 'connect_requested');
+    expect(state.snapshot().authorizationUrl).toBeUndefined();
+  });
+
+  it('caps the audit trail', () => {
+    const bounded = new CodexConnectionState(scope, 'api_key', () => clock, 3);
+    for (let i = 0; i < 6; i += 1) {
+      bounded.transition('connecting', 'connect_requested');
+      bounded.transition('disconnected', 'disconnect_requested');
+    }
+    expect(bounded.history()).toHaveLength(3);
+  });
+
+  describe('setAuthMode', () => {
+    it('emits a transition so the switch is observable', () => {
+      const record = state.setAuthMode('chatgpt_subscription');
+
+      expect(record.reason).toBe('auth_mode_changed');
+      expect(state.snapshot().authMode).toBe('chatgpt_subscription');
+    });
+
+    it('drops an established connection so credentials cannot carry over', () => {
+      state.transition('connecting', 'connect_requested');
+      state.transition('connected', 'handshake_ok');
+
+      state.setAuthMode('chatgpt_subscription');
+
+      expect(state.current()).toBe('disconnected');
+      expect(state.history().some((entry) => entry.from === 'connected')).toBe(
+        true,
+      );
+    });
+
+    it('refuses a no-op switch rather than logging a meaningless change', () => {
+      expect(() => state.setAuthMode('api_key')).toThrow(/already/u);
+    });
+  });
+});
+
+describe('canTransition', () => {
+  it('permits recovery from a failed auth', () => {
+    expect(canTransition('invalid_credentials', 'connecting')).toBe(true);
+  });
+
+  it('forbids jumping straight from disconnected to connected', () => {
+    expect(canTransition('disconnected', 'connected')).toBe(false);
+  });
+});

--- a/packages/oracle-runtime/src/plugins/codex/auth/connection-state.test.ts
+++ b/packages/oracle-runtime/src/plugins/codex/auth/connection-state.test.ts
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, it } from 'vitest';
-import type { CodexTenantScope } from '../domain/provider.js';
+import { tenantScopeKey, type CodexTenantScope } from '../domain/provider.js';
 import {
   CodexConnectionState,
   CodexTransitionError,
@@ -42,7 +42,7 @@ describe('CodexConnectionState', () => {
 
   it('scopes every transition to the tenant key', () => {
     state.transition('connecting', 'connect_requested');
-    expect(state.history()[0]?.tenant).toBe('did_ixo_oracle1__did_ixo_user1');
+    expect(state.history()[0]?.tenant).toBe(tenantScopeKey(scope));
   });
 
   it('rejects an illegal edge instead of silently corrupting state', () => {

--- a/packages/oracle-runtime/src/plugins/codex/auth/connection-state.ts
+++ b/packages/oracle-runtime/src/plugins/codex/auth/connection-state.ts
@@ -1,0 +1,198 @@
+import type {
+  CodexAuthMode,
+  CodexConnectionStatus,
+  CodexTenantScope,
+} from '../domain/provider.js';
+import { tenantScopeKey } from '../domain/provider.js';
+
+/** Why a transition happened. Recorded verbatim in the audit trail. */
+export type CodexTransitionReason =
+  | 'connect_requested'
+  | 'handshake_ok'
+  | 'auth_missing'
+  | 'auth_pending_browser'
+  | 'auth_rejected'
+  | 'environment_unusable'
+  | 'transport_closed'
+  | 'reconnect_attempt'
+  | 'disconnect_requested'
+  | 'auth_mode_changed'
+  | 'runtime_error';
+
+/** One auditable state transition. Never carries credential material. */
+export interface CodexTransition {
+  readonly tenant: string;
+  readonly authMode: CodexAuthMode;
+  readonly from: CodexConnectionStatus;
+  readonly to: CodexConnectionStatus;
+  readonly reason: CodexTransitionReason;
+  readonly at: number;
+  /** Operator-facing detail. Callers must pass sanitized text only. */
+  readonly detail?: string;
+}
+
+/**
+ * Legal edges. Anything absent is a bug in the caller, not a state to fall
+ * into silently — `transition` throws rather than corrupting the record.
+ */
+const CONNECTION_TRANSITIONS: Record<
+  CodexConnectionStatus,
+  readonly CodexConnectionStatus[]
+> = {
+  disconnected: ['connecting', 'unsupported_environment'],
+  connecting: [
+    'connected',
+    'requires_sign_in',
+    'requires_device_authorization',
+    'invalid_credentials',
+    'unsupported_environment',
+    'error',
+    'disconnected',
+  ],
+  connected: ['disconnected', 'error', 'invalid_credentials', 'connecting'],
+  requires_sign_in: ['connecting', 'disconnected'],
+  requires_device_authorization: [
+    'connecting',
+    'requires_sign_in',
+    'disconnected',
+  ],
+  invalid_credentials: ['connecting', 'disconnected'],
+  unsupported_environment: ['connecting', 'disconnected'],
+  error: ['connecting', 'disconnected'],
+};
+
+export class CodexTransitionError extends Error {
+  constructor(
+    from: CodexConnectionStatus,
+    to: CodexConnectionStatus,
+    reason: CodexTransitionReason,
+  ) {
+    super(`codex: illegal connection transition ${from} → ${to} (${reason})`);
+    this.name = 'CodexTransitionError';
+  }
+}
+
+export function canTransition(
+  from: CodexConnectionStatus,
+  to: CodexConnectionStatus,
+): boolean {
+  return CONNECTION_TRANSITIONS[from].includes(to);
+}
+
+/** Snapshot returned to the settings UI. Credential-free by construction. */
+export interface CodexConnectionSnapshot {
+  readonly tenant: string;
+  readonly authMode: CodexAuthMode;
+  readonly status: CodexConnectionStatus;
+  readonly since: number;
+  readonly detail?: string;
+  /** URL the user must open to finish a ChatGPT sign-in, when one is pending. */
+  readonly authorizationUrl?: string;
+}
+
+/**
+ * Per-tenant connection state with a bounded audit trail. Holds no
+ * credentials — only the status derived from them.
+ */
+export class CodexConnectionState {
+  private status: CodexConnectionStatus = 'disconnected';
+
+  private since: number;
+
+  private detail: string | undefined;
+
+  private authorizationUrl: string | undefined;
+
+  private readonly log: CodexTransition[] = [];
+
+  private readonly tenant: string;
+
+  constructor(
+    scope: CodexTenantScope,
+    private authMode: CodexAuthMode,
+    private readonly now: () => number = Date.now,
+    private readonly maxLogEntries = 50,
+  ) {
+    this.tenant = tenantScopeKey(scope);
+    this.since = this.now();
+  }
+
+  current(): CodexConnectionStatus {
+    return this.status;
+  }
+
+  mode(): CodexAuthMode {
+    return this.authMode;
+  }
+
+  snapshot(): CodexConnectionSnapshot {
+    return {
+      tenant: this.tenant,
+      authMode: this.authMode,
+      status: this.status,
+      since: this.since,
+      ...(this.detail ? { detail: this.detail } : {}),
+      ...(this.authorizationUrl
+        ? { authorizationUrl: this.authorizationUrl }
+        : {}),
+    };
+  }
+
+  /** Chronological audit trail, oldest first. */
+  history(): readonly CodexTransition[] {
+    return [...this.log];
+  }
+
+  transition(
+    to: CodexConnectionStatus,
+    reason: CodexTransitionReason,
+    extra: { detail?: string; authorizationUrl?: string } = {},
+  ): CodexTransition {
+    const from = this.status;
+    if (from !== to && !canTransition(from, to)) {
+      throw new CodexTransitionError(from, to, reason);
+    }
+
+    const record: CodexTransition = {
+      tenant: this.tenant,
+      authMode: this.authMode,
+      from,
+      to,
+      reason,
+      at: this.now(),
+      ...(extra.detail ? { detail: extra.detail } : {}),
+    };
+
+    this.status = to;
+    this.since = record.at;
+    this.detail = extra.detail;
+    // Only a pending browser authorization carries a URL; every other
+    // transition clears it so a stale link is never shown as actionable.
+    this.authorizationUrl =
+      to === 'requires_device_authorization'
+        ? extra.authorizationUrl
+        : undefined;
+
+    this.log.push(record);
+    if (this.log.length > this.maxLogEntries) this.log.shift();
+    return record;
+  }
+
+  /**
+   * Change the billing/auth mode. Always emits a transition so the switch is
+   * observable, and drops the connection: credentials from the previous mode
+   * must not carry into the new one.
+   */
+  setAuthMode(next: CodexAuthMode): CodexTransition {
+    if (next === this.authMode) {
+      throw new Error(`codex: auth mode is already '${next}'`);
+    }
+    if (this.status !== 'disconnected') {
+      this.transition('disconnected', 'auth_mode_changed');
+    }
+    this.authMode = next;
+    return this.transition('disconnected', 'auth_mode_changed', {
+      detail: `auth mode set to ${next}`,
+    });
+  }
+}

--- a/packages/oracle-runtime/src/plugins/codex/auth/credentials.test.ts
+++ b/packages/oracle-runtime/src/plugins/codex/auth/credentials.test.ts
@@ -1,0 +1,147 @@
+import { mkdtemp, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { normalizeCodexConfig } from '../domain/config.js';
+import type { CodexTenantScope } from '../domain/provider.js';
+import {
+  redactCredentialEnv,
+  resolveCodexCredentials,
+  tenantHomePath,
+  type CodexSecretReader,
+} from './credentials.js';
+
+const scope: CodexTenantScope = {
+  userDid: 'did:ixo:user1',
+  oracleEntityDid: 'did:ixo:oracle1',
+};
+const otherScope: CodexTenantScope = {
+  userDid: 'did:ixo:user2',
+  oracleEntityDid: 'did:ixo:oracle1',
+};
+
+const emptySecrets: CodexSecretReader = { getValues: async () => ({}) };
+
+describe('resolveCodexCredentials', () => {
+  let homeRoot: string;
+
+  beforeEach(async () => {
+    homeRoot = await mkdtemp(join(tmpdir(), 'codex-cred-'));
+  });
+
+  const configFor = (overrides: Record<string, string> = {}) =>
+    normalizeCodexConfig({
+      CODEX_AUTH_MODE: 'api_key',
+      CODEX_HOME_ROOT: homeRoot,
+      ...overrides,
+    });
+
+  it('reads the API key from the room secret store', async () => {
+    const secrets: CodexSecretReader = {
+      getValues: vi.fn(async () => ({ OPENAI_API_KEY: 'sk-test-value' })),
+    };
+
+    const outcome = await resolveCodexCredentials({
+      config: configFor(),
+      scope,
+      secrets,
+    });
+
+    expect(outcome.kind).toBe('ready');
+    if (outcome.kind !== 'ready') return;
+    expect(outcome.credentials.env.OPENAI_API_KEY).toBe('sk-test-value');
+    expect(secrets.getValues).toHaveBeenCalledWith(['OPENAI_API_KEY']);
+  });
+
+  it('honours a custom secret name', async () => {
+    const secrets: CodexSecretReader = {
+      getValues: vi.fn(async () => ({ CODEX_KEY: 'sk-other' })),
+    };
+
+    await resolveCodexCredentials({
+      config: configFor({ CODEX_API_KEY_SECRET_NAME: 'CODEX_KEY' }),
+      scope,
+      secrets,
+    });
+
+    expect(secrets.getValues).toHaveBeenCalledWith(['CODEX_KEY']);
+  });
+
+  it('asks for sign-in rather than starting without a key', async () => {
+    const outcome = await resolveCodexCredentials({
+      config: configFor(),
+      scope,
+      secrets: emptySecrets,
+    });
+
+    expect(outcome.kind).toBe('requires_sign_in');
+    if (outcome.kind !== 'requires_sign_in') return;
+    expect(outcome.detail).toMatch(/OPENAI_API_KEY/u);
+  });
+
+  it('asks for sign-in when a subscription has no completed ChatGPT login', async () => {
+    const outcome = await resolveCodexCredentials({
+      config: configFor({ CODEX_AUTH_MODE: 'chatgpt_subscription' }),
+      scope,
+      secrets: emptySecrets,
+    });
+
+    expect(outcome.kind).toBe('requires_sign_in');
+    if (outcome.kind !== 'requires_sign_in') return;
+    expect(outcome.detail).toMatch(/ChatGPT sign-in/u);
+  });
+
+  it('uses the tenant CODEX_HOME once the ChatGPT login artefact exists', async () => {
+    const config = configFor({ CODEX_AUTH_MODE: 'chatgpt_subscription' });
+    const home = tenantHomePath(config, scope);
+    // Creating the home is the resolver's job on first call.
+    await resolveCodexCredentials({ config, scope, secrets: emptySecrets });
+    await writeFile(join(home, 'auth.json'), '{"tokens":{}}');
+
+    const outcome = await resolveCodexCredentials({
+      config,
+      scope,
+      secrets: emptySecrets,
+    });
+
+    expect(outcome.kind).toBe('ready');
+    if (outcome.kind !== 'ready') return;
+    expect(outcome.credentials.codexHome).toBe(home);
+    // A subscription never injects an API key into the child environment.
+    expect(outcome.credentials.env.OPENAI_API_KEY).toBeUndefined();
+  });
+
+  it('does not let one tenant see another tenant sign-in', async () => {
+    const config = configFor({ CODEX_AUTH_MODE: 'chatgpt_subscription' });
+    await resolveCodexCredentials({ config, scope, secrets: emptySecrets });
+    await writeFile(join(tenantHomePath(config, scope), 'auth.json'), '{}');
+
+    const outcome = await resolveCodexCredentials({
+      config,
+      scope: otherScope,
+      secrets: emptySecrets,
+    });
+
+    expect(outcome.kind).toBe('requires_sign_in');
+  });
+
+  it('gives each tenant a distinct home directory', () => {
+    const config = configFor();
+    expect(tenantHomePath(config, scope)).not.toBe(
+      tenantHomePath(config, otherScope),
+    );
+  });
+});
+
+describe('redactCredentialEnv', () => {
+  it('hides the API key but keeps non-secret entries readable', () => {
+    const redacted = redactCredentialEnv({
+      CODEX_HOME: '/tmp/codex/tenant',
+      OPENAI_API_KEY: 'sk-super-secret',
+    });
+
+    expect(redacted.OPENAI_API_KEY).toBe('[redacted]');
+    expect(redacted.CODEX_HOME).toBe('/tmp/codex/tenant');
+    expect(JSON.stringify(redacted)).not.toContain('sk-super-secret');
+  });
+});

--- a/packages/oracle-runtime/src/plugins/codex/auth/credentials.ts
+++ b/packages/oracle-runtime/src/plugins/codex/auth/credentials.ts
@@ -1,0 +1,125 @@
+import { mkdir, stat } from 'node:fs/promises';
+import { isAbsolute, join, resolve } from 'node:path';
+import type { CodexNormalizedConfig } from '../domain/config.js';
+import type { CodexTenantScope } from '../domain/provider.js';
+import { tenantScopeKey } from '../domain/provider.js';
+
+/** File the Codex CLI writes once a ChatGPT sign-in completes. */
+const CODEX_AUTH_FILE = 'auth.json';
+
+/**
+ * Credential material for one tenant's App Server process. `env` is spread
+ * into the child process environment and must never be logged, emitted,
+ * serialized into events, or returned over HTTP.
+ */
+export interface CodexCredentials {
+  readonly codexHome: string;
+  readonly env: Readonly<Record<string, string>>;
+}
+
+export type CodexCredentialOutcome =
+  | { readonly kind: 'ready'; readonly credentials: CodexCredentials }
+  | {
+      readonly kind: 'requires_sign_in';
+      /** Sanitized, operator-facing reason. Contains no secret material. */
+      readonly detail: string;
+    };
+
+/** The slice of `RuntimeContext.secrets` the resolver needs. */
+export interface CodexSecretReader {
+  getValues: (keys: string[]) => Promise<Record<string, string>>;
+}
+
+/** Per-tenant `CODEX_HOME`, created with owner-only permissions. */
+export function tenantHomePath(
+  config: CodexNormalizedConfig,
+  scope: CodexTenantScope,
+): string {
+  const root = isAbsolute(config.homeRoot)
+    ? config.homeRoot
+    : resolve(process.cwd(), config.homeRoot);
+  return join(root, tenantScopeKey(scope));
+}
+
+async function ensureTenantHome(path: string): Promise<void> {
+  await mkdir(path, { recursive: true, mode: 0o700 });
+}
+
+async function fileExists(path: string): Promise<boolean> {
+  try {
+    const info = await stat(path);
+    return info.isFile();
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Resolve credentials for the active auth mode.
+ *
+ * Subscription mode reads the ChatGPT sign-in artefact the Codex CLI writes
+ * into the tenant's `CODEX_HOME`; the harness never handles the OAuth tokens
+ * itself. API-key mode pulls the key from the room's encrypted secret store.
+ * Neither path reuses the other's material — a missing credential surfaces as
+ * `requires_sign_in` rather than falling through to the other mode.
+ */
+export async function resolveCodexCredentials(params: {
+  config: CodexNormalizedConfig;
+  scope: CodexTenantScope;
+  secrets: CodexSecretReader;
+}): Promise<CodexCredentialOutcome> {
+  const { config, scope, secrets } = params;
+  const codexHome = tenantHomePath(config, scope);
+  await ensureTenantHome(codexHome);
+
+  if (config.authMode === 'chatgpt_subscription') {
+    const authFile = join(codexHome, CODEX_AUTH_FILE);
+    if (!(await fileExists(authFile))) {
+      return {
+        kind: 'requires_sign_in',
+        detail:
+          'No ChatGPT sign-in found for this tenant. Complete the Codex sign-in to authorize subscription access.',
+      };
+    }
+    // The App Server reads auth.json from CODEX_HOME itself; nothing is
+    // injected into the environment on this path.
+    return {
+      kind: 'ready',
+      credentials: { codexHome, env: { CODEX_HOME: codexHome } },
+    };
+  }
+
+  const values = await secrets.getValues([config.apiKeySecretName]);
+  const apiKey = values[config.apiKeySecretName];
+  if (!apiKey) {
+    return {
+      kind: 'requires_sign_in',
+      detail: `No API key found. Store a secret named '${config.apiKeySecretName}' to use usage-based access.`,
+    };
+  }
+
+  return {
+    kind: 'ready',
+    credentials: {
+      codexHome,
+      env: { CODEX_HOME: codexHome, OPENAI_API_KEY: apiKey },
+    },
+  };
+}
+
+/**
+ * Env keys whose values are credential material. Used to keep them out of
+ * logs and diagnostics.
+ */
+const SECRET_ENV_KEYS = new Set(['OPENAI_API_KEY']);
+
+/** Redacted view of a credential env, safe to log. */
+export function redactCredentialEnv(
+  env: Readonly<Record<string, string>>,
+): Record<string, string> {
+  const out: Record<string, string> = {};
+  for (const [key, value] of Object.entries(env)) {
+    out[key] = SECRET_ENV_KEYS.has(key) ? '[redacted]' : value;
+  }
+  return out;
+}

--- a/packages/oracle-runtime/src/plugins/codex/auth/credentials.ts
+++ b/packages/oracle-runtime/src/plugins/codex/auth/credentials.ts
@@ -9,12 +9,19 @@ const CODEX_AUTH_FILE = 'auth.json';
 
 /**
  * Credential material for one tenant's App Server process. `env` is spread
- * into the child process environment and must never be logged, emitted,
- * serialized into events, or returned over HTTP.
+ * into the child process environment and `apiKey` is sent to
+ * `account/login/start`; neither must ever be logged, emitted, serialized into
+ * events, or returned over HTTP.
  */
 export interface CodexCredentials {
   readonly codexHome: string;
   readonly env: Readonly<Record<string, string>>;
+  /**
+   * Present only in `api_key` mode. The App Server does not pick the key up
+   * from the environment — it has to be registered through
+   * `account/login/start`, so the value is carried here explicitly.
+   */
+  readonly apiKey?: string;
 }
 
 export type CodexCredentialOutcome =
@@ -103,6 +110,7 @@ export async function resolveCodexCredentials(params: {
     credentials: {
       codexHome,
       env: { CODEX_HOME: codexHome, OPENAI_API_KEY: apiKey },
+      apiKey,
     },
   };
 }

--- a/packages/oracle-runtime/src/plugins/codex/codex-tools.ts
+++ b/packages/oracle-runtime/src/plugins/codex/codex-tools.ts
@@ -1,0 +1,159 @@
+import { z } from 'zod';
+import { tool } from '../../plugin-api/tool-helper.js';
+import type { PluginTool, RuntimeContext } from '../../plugin-api/types.js';
+import type { CodexTenantScope } from './domain/provider.js';
+import { CodexSessionError } from './session/codex-session.js';
+import type { CodexRuntimeRegistry } from './session/registry.js';
+
+const runTaskSchema = z.object({
+  task: z
+    .string()
+    .min(1)
+    .describe(
+      'The coding task for Codex, stated as you would to an engineer: what to change and what "done" looks like.',
+    ),
+  threadId: z
+    .string()
+    .optional()
+    .describe(
+      "Continue an existing Codex thread. Omit to continue this user's current thread, or to start one.",
+    ),
+});
+
+/** Shape returned to the agent. Deliberately explicit about non-success. */
+interface CodexToolResult {
+  ok: boolean;
+  status: string;
+  threadId?: string;
+  turnId?: string;
+  output?: string;
+  error?: string;
+  actionRequired?: string;
+}
+
+function scopeFor(
+  ctx: RuntimeContext,
+  oracleEntityDid: string,
+): CodexTenantScope {
+  return { userDid: ctx.user.did, oracleEntityDid };
+}
+
+/**
+ * Hands a task to the tenant's Codex runtime and returns the agent's output.
+ *
+ * Approvals raised mid-turn are surfaced through the approval gate (an
+ * `action_call` event plus `POST /codex/approvals`), so a human decides. If
+ * nobody answers, Codex is declined and the tool reports it — the agent never
+ * silently gains unapproved access.
+ */
+export function createCodexRunTaskTool(params: {
+  registry: CodexRuntimeRegistry;
+  oracleEntityDid: string;
+}): PluginTool {
+  const { registry, oracleEntityDid } = params;
+
+  return tool(
+    async (args, ctx): Promise<CodexToolResult> => {
+      const { task, threadId } = runTaskSchema.parse(args);
+      const scope = scopeFor(ctx, oracleEntityDid);
+      const session = registry.for(scope);
+
+      try {
+        const result = await session.runTurn({
+          prompt: task,
+          ...(threadId ? { threadId } : {}),
+          ctx,
+        });
+
+        return {
+          ok: result.status === 'completed',
+          status: result.status,
+          threadId: result.threadId,
+          turnId: result.turnId,
+          output: result.text,
+          ...(result.error ? { error: result.error } : {}),
+        };
+      } catch (error) {
+        if (error instanceof CodexSessionError) {
+          const guidance = authGuidance(error.status);
+          return {
+            ok: false,
+            status: error.status,
+            error: error.message,
+            ...(guidance ? { actionRequired: guidance } : {}),
+          };
+        }
+        return {
+          ok: false,
+          status: 'error',
+          error: error instanceof Error ? error.message : String(error),
+        };
+      }
+    },
+    {
+      name: 'codex_run_task',
+      description:
+        "Delegate a coding task to the user's Codex runtime and return its result. Codex works in the configured workspace and may ask for approval before running commands or editing files.",
+      schema: runTaskSchema,
+    },
+  );
+}
+
+/** What the user must do, in plain language, for each actionable auth state. */
+function authGuidance(status: string): string | undefined {
+  switch (status) {
+    case 'requires_sign_in':
+      return 'Ask the user to connect Codex in settings — ChatGPT sign-in for subscription access, or an API key for usage-based access.';
+    case 'requires_device_authorization':
+      return 'A ChatGPT sign-in is pending. Ask the user to finish authorizing in their browser.';
+    case 'invalid_credentials':
+      return 'Codex rejected the stored credentials. Ask the user to reauthorize in settings.';
+    case 'unsupported_environment':
+      return 'The Codex App Server could not start in this deployment. This needs an operator, not the user.';
+    default:
+      return undefined;
+  }
+}
+
+const approvalSchema = z.object({
+  approvalId: z.string().min(1).describe('Id from the approval request.'),
+  decision: z
+    .enum(['accept', 'acceptForSession', 'decline', 'cancel'])
+    .describe("The user's decision. Only pass what the user actually said."),
+});
+
+/**
+ * Relays a decision the user gave in chat to a Codex approval that is blocking.
+ * Exists so an approval can be answered conversationally as well as through the
+ * HTTP control plane; both paths land on the same gate.
+ */
+export function createCodexResolveApprovalTool(params: {
+  registry: CodexRuntimeRegistry;
+  oracleEntityDid: string;
+}): PluginTool {
+  const { registry, oracleEntityDid } = params;
+
+  return tool(
+    async (args, ctx) => {
+      const { approvalId, decision } = approvalSchema.parse(args);
+      const settled = registry.resolveApproval(
+        scopeFor(ctx, oracleEntityDid),
+        approvalId,
+        decision,
+      );
+      return settled
+        ? { ok: true, approvalId, decision }
+        : {
+            ok: false,
+            error:
+              'No pending approval with that id. It may have already been answered or timed out.',
+          };
+    },
+    {
+      name: 'codex_resolve_approval',
+      description:
+        'Answer a Codex approval the user has decided on. Never call this without an explicit decision from the user.',
+      schema: approvalSchema,
+    },
+  );
+}

--- a/packages/oracle-runtime/src/plugins/codex/codex.plugin.test.ts
+++ b/packages/oracle-runtime/src/plugins/codex/codex.plugin.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from 'vitest';
+import { createTestRuntime } from '../../testing/create-test-runtime.js';
+import { CodexPlugin } from './codex.plugin.js';
+
+const config = {
+  CODEX_AUTH_MODE: 'api_key',
+  ORACLE_ENTITY_DID: 'did:ixo:oracle1',
+};
+
+const runtimeWith = (overrides: Record<string, unknown> = {}) =>
+  createTestRuntime({
+    plugins: [new CodexPlugin()],
+    config: { ...config, ...overrides },
+  });
+
+describe('CodexPlugin', () => {
+  it('registers a valid manifest and no colliding names', async () => {
+    const runtime = await runtimeWith();
+
+    runtime.assertManifestValid();
+    runtime.assertNoCollisions();
+    expect(runtime.getManifest('codex').title).toBe('Codex');
+  });
+
+  it('is discoverable on demand rather than costing prompt budget every turn', async () => {
+    const runtime = await runtimeWith();
+    expect(runtime.getManifest('codex').visibility).toBe('on-demand');
+  });
+
+  it('exposes the run and approval tools', async () => {
+    const runtime = await runtimeWith();
+
+    expect(
+      runtime
+        .listTools('codex')
+        .map((tool) => tool.name)
+        .sort(),
+    ).toEqual(['codex_resolve_approval', 'codex_run_task']);
+  });
+
+  it('stays off until an operator picks an auth mode', () => {
+    const plugin = new CodexPlugin();
+
+    expect(plugin.autoDetect({})).toBe(false);
+    expect(plugin.autoDetect({ CODEX_AUTH_MODE: 'api_key' })).toBe(true);
+    // Credentials alone must not switch it on — that would pick a billing
+    // model on the operator's behalf.
+    expect(plugin.autoDetect({ OPENAI_API_KEY: 'sk-x' })).toBe(false);
+  });
+
+  it('fails the build when the tool policy leaves no guardrail', async () => {
+    await expect(
+      runtimeWith({
+        CODEX_SANDBOX_MODE: 'dangerFullAccess',
+        CODEX_APPROVAL_POLICY: 'never',
+      }),
+    ).rejects.toThrow(/removes every guardrail/u);
+  });
+
+  it('fails the build on an unknown auth mode instead of defaulting', async () => {
+    await expect(runtimeWith({ CODEX_AUTH_MODE: 'chatgpt' })).rejects.toThrow(
+      /invalid configuration/u,
+    );
+  });
+
+  it('keeps every route behind UCAN auth', () => {
+    expect(new CodexPlugin().getAuthExcludedRoutes()).toEqual([]);
+  });
+});

--- a/packages/oracle-runtime/src/plugins/codex/codex.plugin.test.ts
+++ b/packages/oracle-runtime/src/plugins/codex/codex.plugin.test.ts
@@ -51,7 +51,7 @@ describe('CodexPlugin', () => {
   it('fails the build when the tool policy leaves no guardrail', async () => {
     await expect(
       runtimeWith({
-        CODEX_SANDBOX_MODE: 'dangerFullAccess',
+        CODEX_SANDBOX_MODE: 'danger-full-access',
         CODEX_APPROVAL_POLICY: 'never',
       }),
     ).rejects.toThrow(/removes every guardrail/u);

--- a/packages/oracle-runtime/src/plugins/codex/codex.plugin.ts
+++ b/packages/oracle-runtime/src/plugins/codex/codex.plugin.ts
@@ -1,0 +1,157 @@
+import type { DynamicModule, Type } from '@nestjs/common';
+import { z } from 'zod';
+import { OraclePlugin } from '../../plugin-api/oracle-plugin.js';
+import type {
+  AuthExcludedRoute,
+  PluginContext,
+  PluginManifest,
+  PluginTool,
+} from '../../plugin-api/types.js';
+import {
+  createCodexResolveApprovalTool,
+  createCodexRunTaskTool,
+} from './codex-tools.js';
+import { codexConfigSchema } from './domain/config.js';
+import { preflight } from './domain/preflight.js';
+import { CodexHttpModule } from './http/codex.module.js';
+import {
+  CodexRuntimeRegistry,
+  type CodexRegistryOptions,
+} from './session/registry.js';
+import type { CodexTransportFactory } from './session/codex-session.js';
+
+const NAME = 'codex';
+const VERSION = '1.0.0';
+
+/** Env the plugin reads but does not own — declared in the core base schema. */
+const siblingEnvSchema = z.object({
+  ORACLE_ENTITY_DID: z.string().min(1),
+});
+
+/** How long a Codex approval may sit unanswered before it is declined. */
+const APPROVAL_TIMEOUT_MS = 5 * 60 * 1000;
+
+const manifest: PluginManifest = {
+  title: 'Codex',
+  summary:
+    "Delegates coding work to the user's OpenAI Codex runtime — reading, writing and running code in a configured workspace, with human approval for commands and file changes.",
+  whenToUse: [
+    'User asks for a change to a codebase that needs more than one file read or edited: "refactor the auth middleware", "add a migration and wire it up", "fix the failing test in the parser".',
+    'User asks Codex by name — "run this through Codex", "have Codex look at it".',
+    'A task needs to run commands in the workspace and inspect their output before deciding the next step (build, test, lint loops).',
+    'When `codex_run_task` returns `status: "requires_sign_in"` or `"invalid_credentials"`, relay the `actionRequired` text to the user — do not retry the call.',
+    'When Codex asks for approval, tell the user exactly what it wants to run and wait. Call `codex_resolve_approval` only after the user answers.',
+  ],
+  whenNotToUse: [
+    'Running a one-off script or command with no repository context — use the Sandbox.',
+    'Answering a question about code that is already in the conversation — just answer it.',
+    'The user has not connected Codex. Point them at settings instead of retrying.',
+    "Approving on the user's behalf. Never call `codex_resolve_approval` with `accept` unless the user said so.",
+  ],
+  examples: [
+    {
+      user: 'Have Codex add retry logic to the HTTP client and run the tests.',
+      thought:
+        'A multi-file coding task in the workspace — exactly what the Codex runtime is for.',
+      tool: 'codex_run_task',
+      args: {
+        task: 'Add bounded exponential-backoff retry to the HTTP client, then run the test suite and report failures.',
+      },
+    },
+    {
+      user: 'Yes, let it run the test command.',
+      thought:
+        'The user answered the pending approval. Relay the decision verbatim.',
+      tool: 'codex_resolve_approval',
+      args: {
+        approvalId: 'the id from the approval request',
+        decision: 'accept',
+      },
+    },
+  ],
+  tags: ['codex', 'openai', 'coding', 'approvals'],
+  category: 'integration',
+  visibility: 'on-demand',
+  stability: 'experimental',
+};
+
+export interface CodexPluginOptions {
+  /**
+   * Override how the App Server process is started. Tests point this at a
+   * fixture server so the protocol is exercised without the Codex binary.
+   */
+  transportFactory?: CodexTransportFactory;
+}
+
+/**
+ * Codex provider plugin.
+ *
+ * Integrates through the Codex App Server — the same bidirectional JSON-RPC
+ * boundary Codex's own clients use — rather than driving a UI or reusing
+ * browser credentials. Auth is an explicit operator choice between ChatGPT
+ * subscription access and an OpenAI API key; the two never fall back to one
+ * another. Runtime state and credentials are scoped per tenant.
+ */
+export class CodexPlugin extends OraclePlugin {
+  readonly name = NAME;
+
+  readonly version = VERSION;
+
+  readonly manifest = manifest;
+
+  override readonly configSchema = codexConfigSchema;
+
+  override readonly autoDetectHint = 'CODEX_AUTH_MODE';
+
+  private registry: CodexRuntimeRegistry | null = null;
+
+  constructor(private readonly options: CodexPluginOptions = {}) {
+    super();
+  }
+
+  /**
+   * Off unless an operator has chosen a mode. There is no default: picking one
+   * silently would decide how the user's Codex usage is billed.
+   */
+  override autoDetect(env: NodeJS.ProcessEnv): boolean {
+    return Boolean(env.CODEX_AUTH_MODE);
+  }
+
+  override getTools(ctx: PluginContext): PluginTool[] {
+    const registry = this.ensureRegistry(ctx);
+    const { ORACLE_ENTITY_DID } = siblingEnvSchema.parse(ctx.config);
+    const args = { registry, oracleEntityDid: ORACLE_ENTITY_DID };
+    return [createCodexRunTaskTool(args), createCodexResolveApprovalTool(args)];
+  }
+
+  override getNestModules(ctx?: PluginContext): Array<Type | DynamicModule> {
+    if (!ctx) return [];
+    return [CodexHttpModule.register(this.ensureRegistry(ctx))];
+  }
+
+  /** Every Codex route is UCAN-authenticated — the control plane is per-user. */
+  override getAuthExcludedRoutes(): AuthExcludedRoute[] {
+    return [];
+  }
+
+  /**
+   * The registry is built once, on first use, from a validated plan. Boot fails
+   * here rather than at the first turn if config or tool policy is wrong.
+   */
+  private ensureRegistry(ctx: PluginContext): CodexRuntimeRegistry {
+    if (this.registry) return this.registry;
+
+    const plan = preflight(ctx.config);
+    const options: CodexRegistryOptions = {
+      plan,
+      logger: ctx.logger,
+      clientVersion: VERSION,
+      approvalTimeoutMs: APPROVAL_TIMEOUT_MS,
+      ...(this.options.transportFactory
+        ? { transportFactory: this.options.transportFactory }
+        : {}),
+    };
+    this.registry = new CodexRuntimeRegistry(options);
+    return this.registry;
+  }
+}

--- a/packages/oracle-runtime/src/plugins/codex/domain/capabilities.ts
+++ b/packages/oracle-runtime/src/plugins/codex/domain/capabilities.ts
@@ -1,0 +1,37 @@
+import type { CodexAuthMode, CodexCapabilities } from './provider.js';
+
+/**
+ * Resolve what an auth mode permits.
+ *
+ * The `directModelApi: false` on the subscription path is the load-bearing
+ * distinction: a ChatGPT plan authorises the Codex runtime, not token-billed
+ * OpenAI API access. Code that needs the raw API must check this flag rather
+ * than assume the presence of credentials implies API entitlement.
+ */
+export function resolveCodexCapabilities(
+  mode: CodexAuthMode,
+): CodexCapabilities {
+  if (mode === 'chatgpt_subscription') {
+    return {
+      runtimeThreads: true,
+      directModelApi: false,
+      billing: 'subscription',
+      // The plan decides which models are reachable; forcing an override
+      // produces an opaque upstream rejection rather than a useful error.
+      modelOverride: false,
+    };
+  }
+  return {
+    runtimeThreads: true,
+    directModelApi: true,
+    billing: 'usage_based',
+    modelOverride: true,
+  };
+}
+
+/** One-line explanation of the active mode, for settings help text. */
+export function describeCodexAuthMode(mode: CodexAuthMode): string {
+  return mode === 'chatgpt_subscription'
+    ? 'Use ChatGPT sign-in for Codex subscription access. Your plan covers Codex runtime usage; it does not grant direct OpenAI API access.'
+    : 'Use an API key for usage-based OpenAI access. Turns are billed per token against the key.';
+}

--- a/packages/oracle-runtime/src/plugins/codex/domain/config.test.ts
+++ b/packages/oracle-runtime/src/plugins/codex/domain/config.test.ts
@@ -4,6 +4,7 @@ import {
   resolveCodexCapabilities,
 } from './capabilities.js';
 import { CodexConfigError, normalizeCodexConfig } from './config.js';
+import { tenantScopeKey } from './provider.js';
 import { preflight } from './preflight.js';
 
 const base = { CODEX_AUTH_MODE: 'api_key' };
@@ -15,8 +16,8 @@ describe('normalizeCodexConfig', () => {
     expect(cfg.authMode).toBe('api_key');
     expect(cfg.command).toBe('codex');
     expect(cfg.args).toEqual(['app-server']);
-    expect(cfg.sandboxMode).toBe('readOnly');
-    expect(cfg.approvalPolicy).toBe('onRequest');
+    expect(cfg.sandboxMode).toBe('read-only');
+    expect(cfg.approvalPolicy).toBe('on-request');
     expect(cfg.apiKeySecretName).toBe('OPENAI_API_KEY');
   });
 
@@ -56,7 +57,7 @@ describe('normalizeCodexConfig', () => {
     expect(() =>
       normalizeCodexConfig({
         ...base,
-        CODEX_SANDBOX_MODE: 'dangerFullAccess',
+        CODEX_SANDBOX_MODE: 'danger-full-access',
         CODEX_APPROVAL_POLICY: 'never',
       }),
     ).toThrow(/removes every guardrail/u);
@@ -65,10 +66,10 @@ describe('normalizeCodexConfig', () => {
   it('allows full host access when an approval gate remains', () => {
     const cfg = normalizeCodexConfig({
       ...base,
-      CODEX_SANDBOX_MODE: 'dangerFullAccess',
-      CODEX_APPROVAL_POLICY: 'onRequest',
+      CODEX_SANDBOX_MODE: 'danger-full-access',
+      CODEX_APPROVAL_POLICY: 'on-request',
     });
-    expect(cfg.sandboxMode).toBe('dangerFullAccess');
+    expect(cfg.sandboxMode).toBe('danger-full-access');
   });
 });
 
@@ -117,5 +118,35 @@ describe('preflight', () => {
     expect(preflight(base, { requestedAuthMode: 'api_key' }).authMode).toBe(
       'api_key',
     );
+  });
+});
+
+describe('tenantScopeKey', () => {
+  const oracleEntityDid = 'did:ixo:oracle1';
+
+  it('keeps a readable prefix so credential directories stay diagnosable', () => {
+    expect(
+      tenantScopeKey({ oracleEntityDid, userDid: 'did:ixo:user1' }),
+    ).toMatch(/^did_ixo_oracle1__did_ixo_user1-[0-9a-f]{16}$/u);
+  });
+
+  it('does not collide when sanitizing makes two DIDs look identical', () => {
+    // Both sanitize to `did_x_a_b`; only the digest keeps them apart, and this
+    // key indexes sessions, approvals and credential directories.
+    const first = tenantScopeKey({ oracleEntityDid, userDid: 'did:x:a:b' });
+    const second = tenantScopeKey({ oracleEntityDid, userDid: 'did:x:a_b' });
+
+    expect(first).not.toBe(second);
+  });
+
+  it('separates the oracle and user fields unambiguously', () => {
+    expect(tenantScopeKey({ oracleEntityDid: 'a:b', userDid: 'c' })).not.toBe(
+      tenantScopeKey({ oracleEntityDid: 'a', userDid: 'b:c' }),
+    );
+  });
+
+  it('is stable for the same scope', () => {
+    const scope = { oracleEntityDid, userDid: 'did:ixo:user1' };
+    expect(tenantScopeKey(scope)).toBe(tenantScopeKey(scope));
   });
 });

--- a/packages/oracle-runtime/src/plugins/codex/domain/config.test.ts
+++ b/packages/oracle-runtime/src/plugins/codex/domain/config.test.ts
@@ -1,0 +1,121 @@
+import { describe, expect, it } from 'vitest';
+import {
+  describeCodexAuthMode,
+  resolveCodexCapabilities,
+} from './capabilities.js';
+import { CodexConfigError, normalizeCodexConfig } from './config.js';
+import { preflight } from './preflight.js';
+
+const base = { CODEX_AUTH_MODE: 'api_key' };
+
+describe('normalizeCodexConfig', () => {
+  it('applies defaults and splits the app-server argv', () => {
+    const cfg = normalizeCodexConfig(base);
+
+    expect(cfg.authMode).toBe('api_key');
+    expect(cfg.command).toBe('codex');
+    expect(cfg.args).toEqual(['app-server']);
+    expect(cfg.sandboxMode).toBe('readOnly');
+    expect(cfg.approvalPolicy).toBe('onRequest');
+    expect(cfg.apiKeySecretName).toBe('OPENAI_API_KEY');
+  });
+
+  it('splits multi-word argv on whitespace', () => {
+    const cfg = normalizeCodexConfig({
+      ...base,
+      CODEX_APP_SERVER_ARGS: 'app-server  --listen ws://127.0.0.1:4500',
+    });
+    expect(cfg.args).toEqual(['app-server', '--listen', 'ws://127.0.0.1:4500']);
+  });
+
+  it('coerces numeric env strings', () => {
+    const cfg = normalizeCodexConfig({
+      ...base,
+      CODEX_TURN_TIMEOUT_MS: '1234',
+    });
+    expect(cfg.turnTimeoutMs).toBe(1234);
+  });
+
+  it('rejects a missing auth mode rather than guessing one', () => {
+    expect(() => normalizeCodexConfig({})).toThrow(CodexConfigError);
+  });
+
+  it('rejects an unknown auth mode', () => {
+    expect(() => normalizeCodexConfig({ CODEX_AUTH_MODE: 'chatgpt' })).toThrow(
+      CodexConfigError,
+    );
+  });
+
+  it('rejects an empty argv', () => {
+    expect(() =>
+      normalizeCodexConfig({ ...base, CODEX_APP_SERVER_ARGS: '   ' }),
+    ).toThrow(/empty argv/u);
+  });
+
+  it('rejects full host access with approvals disabled', () => {
+    expect(() =>
+      normalizeCodexConfig({
+        ...base,
+        CODEX_SANDBOX_MODE: 'dangerFullAccess',
+        CODEX_APPROVAL_POLICY: 'never',
+      }),
+    ).toThrow(/removes every guardrail/u);
+  });
+
+  it('allows full host access when an approval gate remains', () => {
+    const cfg = normalizeCodexConfig({
+      ...base,
+      CODEX_SANDBOX_MODE: 'dangerFullAccess',
+      CODEX_APPROVAL_POLICY: 'onRequest',
+    });
+    expect(cfg.sandboxMode).toBe('dangerFullAccess');
+  });
+});
+
+describe('resolveCodexCapabilities', () => {
+  it('does not grant direct API access to a subscription', () => {
+    const caps = resolveCodexCapabilities('chatgpt_subscription');
+
+    expect(caps.runtimeThreads).toBe(true);
+    expect(caps.directModelApi).toBe(false);
+    expect(caps.billing).toBe('subscription');
+    expect(caps.modelOverride).toBe(false);
+  });
+
+  it('grants usage-billed API access to an API key', () => {
+    const caps = resolveCodexCapabilities('api_key');
+
+    expect(caps.directModelApi).toBe(true);
+    expect(caps.billing).toBe('usage_based');
+    expect(caps.modelOverride).toBe(true);
+  });
+
+  it('describes each mode distinctly for the settings UI', () => {
+    expect(describeCodexAuthMode('chatgpt_subscription')).toMatch(
+      /ChatGPT sign-in/u,
+    );
+    expect(describeCodexAuthMode('api_key')).toMatch(/usage-based/u);
+  });
+});
+
+describe('preflight', () => {
+  it('returns a plan whose capabilities match the configured mode', () => {
+    const plan = preflight({ CODEX_AUTH_MODE: 'chatgpt_subscription' });
+
+    expect(plan.authMode).toBe('chatgpt_subscription');
+    expect(plan.capabilities.billing).toBe('subscription');
+    expect(plan.config.command).toBe('codex');
+  });
+
+  it('refuses a requested mode that disagrees with the configured one', () => {
+    expect(() =>
+      preflight(base, { requestedAuthMode: 'chatgpt_subscription' }),
+    ).toThrow(/does not match the configured mode/u);
+  });
+
+  it('accepts a requested mode that agrees', () => {
+    expect(preflight(base, { requestedAuthMode: 'api_key' }).authMode).toBe(
+      'api_key',
+    );
+  });
+});

--- a/packages/oracle-runtime/src/plugins/codex/domain/config.ts
+++ b/packages/oracle-runtime/src/plugins/codex/domain/config.ts
@@ -1,0 +1,142 @@
+import { z } from 'zod';
+import { CODEX_AUTH_MODES, type CodexAuthMode } from './provider.js';
+
+/**
+ * Sandbox policy handed to `thread/start`. Values mirror the App Server's
+ * `sandbox` enum verbatim so they pass through without translation.
+ */
+export const CODEX_SANDBOX_MODES = [
+  'readOnly',
+  'workspaceWrite',
+  'dangerFullAccess',
+] as const;
+export type CodexSandboxMode = (typeof CODEX_SANDBOX_MODES)[number];
+
+/** Approval policy handed to `thread/start`. Mirrors the App Server enum. */
+export const CODEX_APPROVAL_POLICIES = [
+  'never',
+  'onRequest',
+  'unlessTrusted',
+] as const;
+export type CodexApprovalPolicy = (typeof CODEX_APPROVAL_POLICIES)[number];
+
+export const CODEX_REASONING_EFFORTS = ['low', 'medium', 'high'] as const;
+export type CodexReasoningEffort = (typeof CODEX_REASONING_EFFORTS)[number];
+
+/**
+ * Plugin-owned env vars. `CODEX_AUTH_MODE` is required with no default: the
+ * mode is an explicit operator choice, never inferred from which credential
+ * happens to be present.
+ */
+export const codexConfigSchema = z.object({
+  CODEX_AUTH_MODE: z.enum(CODEX_AUTH_MODES),
+  CODEX_APP_SERVER_COMMAND: z.string().min(1).default('codex'),
+  /** Space-separated argv appended to the command. */
+  CODEX_APP_SERVER_ARGS: z.string().default('app-server'),
+  /**
+   * Parent directory for per-tenant `CODEX_HOME` roots. Each tenant gets an
+   * isolated subdirectory so credential material never crosses tenants.
+   */
+  CODEX_HOME_ROOT: z.string().min(1).default('.codex-tenants'),
+  /** Working directory Codex threads are rooted at. */
+  CODEX_WORKSPACE_ROOT: z.string().min(1).default(process.cwd()),
+  CODEX_MODEL: z.string().min(1).optional(),
+  CODEX_REASONING_EFFORT: z.enum(CODEX_REASONING_EFFORTS).default('medium'),
+  CODEX_SANDBOX_MODE: z.enum(CODEX_SANDBOX_MODES).default('readOnly'),
+  CODEX_APPROVAL_POLICY: z.enum(CODEX_APPROVAL_POLICIES).default('onRequest'),
+  /** Name of the per-room secret holding the OpenAI API key in `api_key` mode. */
+  CODEX_API_KEY_SECRET_NAME: z.string().min(1).default('OPENAI_API_KEY'),
+  CODEX_STARTUP_TIMEOUT_MS: z.coerce.number().int().positive().default(30_000),
+  CODEX_TURN_TIMEOUT_MS: z.coerce.number().int().positive().default(600_000),
+  /** Reconnect attempts after an unexpected App Server exit. */
+  CODEX_MAX_RECONNECT_ATTEMPTS: z.coerce
+    .number()
+    .int()
+    .min(0)
+    .max(10)
+    .default(3),
+});
+
+export type CodexRawConfig = z.infer<typeof codexConfigSchema>;
+
+/** Config after parsing, argv splitting and cross-field policy checks. */
+export interface CodexNormalizedConfig {
+  readonly authMode: CodexAuthMode;
+  readonly command: string;
+  readonly args: readonly string[];
+  readonly homeRoot: string;
+  readonly workspaceRoot: string;
+  readonly model?: string;
+  readonly reasoningEffort: CodexReasoningEffort;
+  readonly sandboxMode: CodexSandboxMode;
+  readonly approvalPolicy: CodexApprovalPolicy;
+  readonly apiKeySecretName: string;
+  readonly startupTimeoutMs: number;
+  readonly turnTimeoutMs: number;
+  readonly maxReconnectAttempts: number;
+}
+
+export class CodexConfigError extends Error {
+  constructor(message: string) {
+    super(`codex: ${message}`);
+    this.name = 'CodexConfigError';
+  }
+}
+
+/**
+ * Parse and normalize raw merged env into the runtime's config shape.
+ * Throws `CodexConfigError` on anything the runtime cannot start under.
+ */
+export function normalizeCodexConfig(raw: unknown): CodexNormalizedConfig {
+  const parsed = codexConfigSchema.safeParse(raw);
+  if (!parsed.success) {
+    const detail = parsed.error.issues
+      .map((issue) => `${issue.path.join('.') || '(root)'}: ${issue.message}`)
+      .join('; ');
+    throw new CodexConfigError(`invalid configuration — ${detail}`);
+  }
+
+  const cfg = parsed.data;
+  const args = cfg.CODEX_APP_SERVER_ARGS.split(/\s+/u).filter(Boolean);
+  if (args.length === 0) {
+    throw new CodexConfigError(
+      'CODEX_APP_SERVER_ARGS resolved to an empty argv — expected at least `app-server`.',
+    );
+  }
+
+  const normalized: CodexNormalizedConfig = {
+    authMode: cfg.CODEX_AUTH_MODE,
+    command: cfg.CODEX_APP_SERVER_COMMAND,
+    args,
+    homeRoot: cfg.CODEX_HOME_ROOT,
+    workspaceRoot: cfg.CODEX_WORKSPACE_ROOT,
+    ...(cfg.CODEX_MODEL ? { model: cfg.CODEX_MODEL } : {}),
+    reasoningEffort: cfg.CODEX_REASONING_EFFORT,
+    sandboxMode: cfg.CODEX_SANDBOX_MODE,
+    approvalPolicy: cfg.CODEX_APPROVAL_POLICY,
+    apiKeySecretName: cfg.CODEX_API_KEY_SECRET_NAME,
+    startupTimeoutMs: cfg.CODEX_STARTUP_TIMEOUT_MS,
+    turnTimeoutMs: cfg.CODEX_TURN_TIMEOUT_MS,
+    maxReconnectAttempts: cfg.CODEX_MAX_RECONNECT_ATTEMPTS,
+  };
+
+  assertToolPolicy(normalized);
+  return normalized;
+}
+
+/**
+ * Reject sandbox/approval combinations that leave the agent with no guardrail
+ * at all. `dangerFullAccess` gives Codex unrestricted host access; pairing it
+ * with `never` also removes the approval gate, so nothing remains to stop a
+ * destructive command.
+ */
+export function assertToolPolicy(config: CodexNormalizedConfig): void {
+  if (
+    config.sandboxMode === 'dangerFullAccess' &&
+    config.approvalPolicy === 'never'
+  ) {
+    throw new CodexConfigError(
+      'CODEX_SANDBOX_MODE=dangerFullAccess with CODEX_APPROVAL_POLICY=never removes every guardrail. Set an approval policy of `onRequest` or `unlessTrusted`, or narrow the sandbox.',
+    );
+  }
+}

--- a/packages/oracle-runtime/src/plugins/codex/domain/config.ts
+++ b/packages/oracle-runtime/src/plugins/codex/domain/config.ts
@@ -2,21 +2,29 @@ import { z } from 'zod';
 import { CODEX_AUTH_MODES, type CodexAuthMode } from './provider.js';
 
 /**
- * Sandbox policy handed to `thread/start`. Values mirror the App Server's
- * `sandbox` enum verbatim so they pass through without translation.
+ * Sandbox policy handed to `thread/start`. These are the App Server's wire
+ * spellings, verified against `codex-cli` — sending anything else is rejected
+ * with `unknown variant`. Kept verbatim so they pass through untranslated.
  */
 export const CODEX_SANDBOX_MODES = [
-  'readOnly',
-  'workspaceWrite',
-  'dangerFullAccess',
+  'read-only',
+  'workspace-write',
+  'danger-full-access',
 ] as const;
 export type CodexSandboxMode = (typeof CODEX_SANDBOX_MODES)[number];
 
-/** Approval policy handed to `thread/start`. Mirrors the App Server enum. */
+/**
+ * Approval policy handed to `thread/start`. App Server wire spellings.
+ *
+ * The server also has a `granular` policy, but it is a struct variant rather
+ * than a plain string — sending `"granular"` fails with `invalid type: unit
+ * variant, expected struct variant`. It is omitted until it is worth
+ * modelling the object form.
+ */
 export const CODEX_APPROVAL_POLICIES = [
+  'untrusted',
+  'on-request',
   'never',
-  'onRequest',
-  'unlessTrusted',
 ] as const;
 export type CodexApprovalPolicy = (typeof CODEX_APPROVAL_POLICIES)[number];
 
@@ -42,8 +50,8 @@ export const codexConfigSchema = z.object({
   CODEX_WORKSPACE_ROOT: z.string().min(1).default(process.cwd()),
   CODEX_MODEL: z.string().min(1).optional(),
   CODEX_REASONING_EFFORT: z.enum(CODEX_REASONING_EFFORTS).default('medium'),
-  CODEX_SANDBOX_MODE: z.enum(CODEX_SANDBOX_MODES).default('readOnly'),
-  CODEX_APPROVAL_POLICY: z.enum(CODEX_APPROVAL_POLICIES).default('onRequest'),
+  CODEX_SANDBOX_MODE: z.enum(CODEX_SANDBOX_MODES).default('read-only'),
+  CODEX_APPROVAL_POLICY: z.enum(CODEX_APPROVAL_POLICIES).default('on-request'),
   /** Name of the per-room secret holding the OpenAI API key in `api_key` mode. */
   CODEX_API_KEY_SECRET_NAME: z.string().min(1).default('OPENAI_API_KEY'),
   CODEX_STARTUP_TIMEOUT_MS: z.coerce.number().int().positive().default(30_000),
@@ -132,11 +140,11 @@ export function normalizeCodexConfig(raw: unknown): CodexNormalizedConfig {
  */
 export function assertToolPolicy(config: CodexNormalizedConfig): void {
   if (
-    config.sandboxMode === 'dangerFullAccess' &&
+    config.sandboxMode === 'danger-full-access' &&
     config.approvalPolicy === 'never'
   ) {
     throw new CodexConfigError(
-      'CODEX_SANDBOX_MODE=dangerFullAccess with CODEX_APPROVAL_POLICY=never removes every guardrail. Set an approval policy of `onRequest` or `unlessTrusted`, or narrow the sandbox.',
+      'CODEX_SANDBOX_MODE=danger-full-access with CODEX_APPROVAL_POLICY=never removes every guardrail. Set an approval policy of `on-request` or `untrusted`, or narrow the sandbox.',
     );
   }
 }

--- a/packages/oracle-runtime/src/plugins/codex/domain/preflight.ts
+++ b/packages/oracle-runtime/src/plugins/codex/domain/preflight.ts
@@ -1,0 +1,47 @@
+import { resolveCodexCapabilities } from './capabilities.js';
+import {
+  assertToolPolicy,
+  normalizeCodexConfig,
+  CodexConfigError,
+  type CodexNormalizedConfig,
+} from './config.js';
+import type { CodexAuthMode, CodexCapabilities } from './provider.js';
+
+/** Everything the runtime needs, validated. Produced only by `preflight`. */
+export interface CodexRuntimePlan {
+  readonly config: CodexNormalizedConfig;
+  readonly authMode: CodexAuthMode;
+  readonly capabilities: CodexCapabilities;
+}
+
+/**
+ * The single gate every runtime start passes through: config schema →
+ * auth-mode validation → capability resolution → tool policy. Nothing
+ * downstream re-derives these; they take the plan.
+ */
+export function preflight(
+  rawConfig: unknown,
+  options: { requestedAuthMode?: string } = {},
+): CodexRuntimePlan {
+  const config = normalizeCodexConfig(rawConfig);
+
+  // A caller-supplied mode must match the configured one. Silent fallback
+  // between subscription and API-key billing is never acceptable — an
+  // operator changes the mode deliberately, through `setAuthMode`.
+  if (
+    options.requestedAuthMode !== undefined &&
+    options.requestedAuthMode !== config.authMode
+  ) {
+    throw new CodexConfigError(
+      `requested auth mode '${options.requestedAuthMode}' does not match the configured mode '${config.authMode}'. Change the mode explicitly rather than relying on a fallback.`,
+    );
+  }
+
+  assertToolPolicy(config);
+
+  return {
+    config,
+    authMode: config.authMode,
+    capabilities: resolveCodexCapabilities(config.authMode),
+  };
+}

--- a/packages/oracle-runtime/src/plugins/codex/domain/provider.ts
+++ b/packages/oracle-runtime/src/plugins/codex/domain/provider.ts
@@ -1,3 +1,5 @@
+import { createHash } from 'node:crypto';
+
 /** Stable provider identifier used in config, events and audit records. */
 export const CODEX_PROVIDER_ID = 'codex';
 
@@ -58,10 +60,21 @@ export interface CodexTenantScope {
   readonly oracleEntityDid: string;
 }
 
-/** Opaque, filesystem-safe key derived from a tenant scope. */
+/**
+ * Filesystem-safe key for a tenant scope.
+ *
+ * Sanitizing alone is not injective — `did:x:a:b` and `did:x:a_b` would
+ * collapse to the same key, and this value indexes sessions, approvals and
+ * credential directories. The readable prefix is therefore paired with a
+ * digest of the exact scope, so distinct DIDs can never collide.
+ */
 export function tenantScopeKey(scope: CodexTenantScope): string {
-  const raw = `${scope.oracleEntityDid}::${scope.userDid}`;
-  return raw.replace(/[^a-zA-Z0-9._-]/g, '_');
+  const raw = `${scope.oracleEntityDid}\u0000${scope.userDid}`;
+  const readable = `${scope.oracleEntityDid}::${scope.userDid}`
+    .replace(/[^a-zA-Z0-9._-]/g, '_')
+    .slice(0, 80);
+  const digest = createHash('sha256').update(raw).digest('hex').slice(0, 16);
+  return `${readable}-${digest}`;
 }
 
 /** True when the status is resolvable by the user re-authenticating. */

--- a/packages/oracle-runtime/src/plugins/codex/domain/provider.ts
+++ b/packages/oracle-runtime/src/plugins/codex/domain/provider.ts
@@ -1,0 +1,74 @@
+/** Stable provider identifier used in config, events and audit records. */
+export const CODEX_PROVIDER_ID = 'codex';
+
+/** Human-readable provider name shown in settings UIs. */
+export const CODEX_PROVIDER_DISPLAY_NAME = 'OpenAI Codex';
+
+/**
+ * How the operator authenticates the Codex runtime.
+ *
+ * A ChatGPT subscription authorises the Codex *runtime*; it does not grant
+ * raw OpenAI API access. `api_key` is the usage-billed path. The two are never
+ * interchangeable — see `resolveCodexCapabilities`.
+ */
+export const CODEX_AUTH_MODES = ['chatgpt_subscription', 'api_key'] as const;
+export type CodexAuthMode = (typeof CODEX_AUTH_MODES)[number];
+
+/**
+ * Connection lifecycle. Every value is reachable and observable over
+ * `GET /codex/status`; transitions are constrained by `CONNECTION_TRANSITIONS`.
+ */
+export const CODEX_CONNECTION_STATUSES = [
+  'disconnected',
+  'connecting',
+  'connected',
+  'requires_sign_in',
+  'requires_device_authorization',
+  'invalid_credentials',
+  'unsupported_environment',
+  'error',
+] as const;
+export type CodexConnectionStatus = (typeof CODEX_CONNECTION_STATUSES)[number];
+
+/** What the active auth mode actually permits. Resolved, never assumed. */
+export interface CodexCapabilities {
+  /** App Server thread/turn operations are available. */
+  readonly runtimeThreads: boolean;
+  /**
+   * Credentials may be used for direct, token-billed OpenAI API calls.
+   * False under a ChatGPT subscription — the plan covers the Codex runtime
+   * only, and reusing those credentials against the raw API is unsupported.
+   */
+  readonly directModelApi: boolean;
+  /** Who pays, and how. Surfaced in the settings UI. */
+  readonly billing: 'subscription' | 'usage_based';
+  /** Whether a per-turn `model` override may be sent to the App Server. */
+  readonly modelOverride: boolean;
+}
+
+/**
+ * Tenant scoping for runtime state and credentials. One Codex runtime context
+ * per tenant-facing workload — threads and credential material never cross
+ * this boundary.
+ */
+export interface CodexTenantScope {
+  /** DID of the user the runtime is acting for. */
+  readonly userDid: string;
+  /** Oracle entity DID — distinguishes deployments sharing a homeserver. */
+  readonly oracleEntityDid: string;
+}
+
+/** Opaque, filesystem-safe key derived from a tenant scope. */
+export function tenantScopeKey(scope: CodexTenantScope): string {
+  const raw = `${scope.oracleEntityDid}::${scope.userDid}`;
+  return raw.replace(/[^a-zA-Z0-9._-]/g, '_');
+}
+
+/** True when the status is resolvable by the user re-authenticating. */
+export function isAuthActionable(status: CodexConnectionStatus): boolean {
+  return (
+    status === 'requires_sign_in' ||
+    status === 'requires_device_authorization' ||
+    status === 'invalid_credentials'
+  );
+}

--- a/packages/oracle-runtime/src/plugins/codex/http/codex.controller.ts
+++ b/packages/oracle-runtime/src/plugins/codex/http/codex.controller.ts
@@ -1,0 +1,205 @@
+import {
+  BadRequestException,
+  Body,
+  Controller,
+  Get,
+  Inject,
+  Logger,
+  NotFoundException,
+  Post,
+  Req,
+} from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
+import type { Request } from 'express';
+import { z } from 'zod';
+import {
+  CODEX_APPROVAL_DECISIONS,
+  type CodexApprovalDecision,
+} from '../app-server/protocol.js';
+import type { CodexConnectionSnapshot } from '../auth/connection-state.js';
+import { describeCodexAuthMode } from '../domain/capabilities.js';
+import {
+  CODEX_AUTH_MODES,
+  CODEX_PROVIDER_DISPLAY_NAME,
+  CODEX_PROVIDER_ID,
+  isAuthActionable,
+  type CodexAuthMode,
+  type CodexTenantScope,
+} from '../domain/provider.js';
+import type { CodexRuntimeRegistry } from '../session/registry.js';
+import { CODEX_REGISTRY } from './codex.tokens.js';
+import { createRoomSecretReader } from './room-secret-reader.js';
+
+const authModeBody = z.object({ mode: z.enum(CODEX_AUTH_MODES) });
+const approvalBody = z.object({
+  approvalId: z.string().min(1),
+  decision: z.enum(CODEX_APPROVAL_DECISIONS),
+});
+
+/** Provider descriptor + live connection state, as rendered by a settings UI. */
+export interface CodexProviderStatus {
+  provider: string;
+  displayName: string;
+  authMode: CodexAuthMode;
+  authModeDescription: string;
+  status: CodexConnectionSnapshot['status'];
+  /** True when the user can fix the current status by (re)authenticating. */
+  actionRequired: boolean;
+  capabilities: {
+    runtimeThreads: boolean;
+    directModelApi: boolean;
+    billing: 'subscription' | 'usage_based';
+    modelOverride: boolean;
+  };
+  detail?: string;
+  authorizationUrl?: string;
+  threadId: string | null;
+  pendingApprovals: number;
+}
+
+/**
+ * Settings + control surface for the Codex provider.
+ *
+ * Every route is tenant-scoped from the authenticated DID — a caller can only
+ * ever read or mutate its own runtime. Responses are credential-free by
+ * construction: the API key and ChatGPT tokens never leave the process.
+ */
+@ApiTags('codex')
+@Controller('codex')
+export class CodexController {
+  private readonly logger = new Logger(CodexController.name);
+
+  constructor(
+    @Inject(CODEX_REGISTRY) private readonly registry: CodexRuntimeRegistry,
+    private readonly config: ConfigService,
+  ) {}
+
+  private scope(req: Request): CodexTenantScope {
+    return {
+      userDid: req.authData.did,
+      oracleEntityDid: this.config.getOrThrow<string>('ORACLE_ENTITY_DID'),
+    };
+  }
+
+  private describe(req: Request): CodexProviderStatus {
+    const scope = this.scope(req);
+    const session = this.registry.for(scope);
+    const snapshot = session.snapshot();
+    const { capabilities } = this.registry.plan();
+
+    return {
+      provider: CODEX_PROVIDER_ID,
+      displayName: CODEX_PROVIDER_DISPLAY_NAME,
+      authMode: snapshot.authMode,
+      authModeDescription: describeCodexAuthMode(snapshot.authMode),
+      status: snapshot.status,
+      actionRequired: isAuthActionable(snapshot.status),
+      capabilities: { ...capabilities },
+      ...(snapshot.detail ? { detail: snapshot.detail } : {}),
+      ...(snapshot.authorizationUrl
+        ? { authorizationUrl: snapshot.authorizationUrl }
+        : {}),
+      threadId: session.currentThreadId(),
+      pendingApprovals: this.registry.pendingApprovals(scope).length,
+    };
+  }
+
+  @Get('status')
+  @ApiOperation({ summary: 'Codex provider status for the calling user.' })
+  @ApiResponse({ status: 200, description: 'Provider descriptor and status.' })
+  getStatus(@Req() req: Request): CodexProviderStatus {
+    return this.describe(req);
+  }
+
+  @Get('transitions')
+  @ApiOperation({
+    summary: 'Audit trail of Codex connection transitions for this user.',
+  })
+  getTransitions(@Req() req: Request) {
+    return { transitions: this.registry.for(this.scope(req)).history() };
+  }
+
+  @Post('connect')
+  @ApiOperation({
+    summary:
+      'Start (or re-authorize) the Codex runtime using the configured auth mode.',
+  })
+  async connect(@Req() req: Request): Promise<CodexProviderStatus> {
+    const scope = this.scope(req);
+    try {
+      await this.registry.connect(scope, {
+        secrets: createRoomSecretReader(scope),
+      });
+    } catch (error) {
+      // The status carries the reason; a failed connect is a state, not a 500.
+      this.logger.warn(
+        `codex connect failed for ${scope.userDid}: ${
+          error instanceof Error ? error.message : String(error)
+        }`,
+      );
+    }
+    return this.describe(req);
+  }
+
+  @Post('disconnect')
+  @ApiOperation({ summary: 'Stop the Codex runtime for this user.' })
+  async disconnect(@Req() req: Request): Promise<CodexProviderStatus> {
+    await this.registry.disconnect(this.scope(req));
+    return this.describe(req);
+  }
+
+  @Post('auth-mode')
+  @ApiOperation({
+    summary:
+      'Switch between ChatGPT subscription and API key access. Always explicit — never inferred.',
+  })
+  async setAuthMode(
+    @Req() req: Request,
+    @Body() body: unknown,
+  ): Promise<CodexProviderStatus> {
+    const parsed = authModeBody.safeParse(body);
+    if (!parsed.success) {
+      throw new BadRequestException(
+        `mode must be one of: ${CODEX_AUTH_MODES.join(', ')}`,
+      );
+    }
+    const session = this.registry.for(this.scope(req));
+    if (session.snapshot().authMode === parsed.data.mode) {
+      return this.describe(req);
+    }
+    await session.setAuthMode(parsed.data.mode);
+    return this.describe(req);
+  }
+
+  @Get('approvals')
+  @ApiOperation({ summary: 'Approvals Codex is currently blocked on.' })
+  listApprovals(@Req() req: Request) {
+    return { approvals: this.registry.pendingApprovals(this.scope(req)) };
+  }
+
+  @Post('approvals')
+  @ApiOperation({
+    summary: 'Answer a pending Codex approval. Never auto-granted server-side.',
+  })
+  resolveApproval(@Req() req: Request, @Body() body: unknown) {
+    const parsed = approvalBody.safeParse(body);
+    if (!parsed.success) {
+      throw new BadRequestException(
+        `approvalId is required and decision must be one of: ${CODEX_APPROVAL_DECISIONS.join(', ')}`,
+      );
+    }
+    const decision: CodexApprovalDecision = parsed.data.decision;
+    const settled = this.registry.resolveApproval(
+      this.scope(req),
+      parsed.data.approvalId,
+      decision,
+    );
+    if (!settled) {
+      throw new NotFoundException(
+        'No pending approval with that id for this user.',
+      );
+    }
+    return { approvalId: parsed.data.approvalId, decision };
+  }
+}

--- a/packages/oracle-runtime/src/plugins/codex/http/codex.controller.ts
+++ b/packages/oracle-runtime/src/plugins/codex/http/codex.controller.ts
@@ -86,7 +86,9 @@ export class CodexController {
     const scope = this.scope(req);
     const session = this.registry.for(scope);
     const snapshot = session.snapshot();
-    const { capabilities } = this.registry.plan();
+    // Read from the session, not the registry: a mode switch rebuilds the
+    // session's plan, so the registry's boot-time capabilities would be stale.
+    const { capabilities } = session.currentPlan();
 
     return {
       provider: CODEX_PROVIDER_ID,

--- a/packages/oracle-runtime/src/plugins/codex/http/codex.module.ts
+++ b/packages/oracle-runtime/src/plugins/codex/http/codex.module.ts
@@ -1,0 +1,41 @@
+import {
+  Inject,
+  Injectable,
+  Module,
+  type DynamicModule,
+  type OnModuleDestroy,
+} from '@nestjs/common';
+import type { CodexRuntimeRegistry } from '../session/registry.js';
+import { CodexController } from './codex.controller.js';
+import { CODEX_REGISTRY } from './codex.tokens.js';
+
+/** Stops every tenant's App Server when the Nest app shuts down. */
+@Injectable()
+export class CodexRegistryLifecycle implements OnModuleDestroy {
+  constructor(
+    @Inject(CODEX_REGISTRY) private readonly registry: CodexRuntimeRegistry,
+  ) {}
+
+  async onModuleDestroy(): Promise<void> {
+    await this.registry.shutdown();
+  }
+}
+
+/**
+ * Plugin-owned HTTP surface. The registry instance is created by the plugin and
+ * injected here, so the controller and the agent's tools drive the same
+ * per-tenant sessions.
+ */
+@Module({})
+export class CodexHttpModule {
+  static register(registry: CodexRuntimeRegistry): DynamicModule {
+    return {
+      module: CodexHttpModule,
+      controllers: [CodexController],
+      providers: [
+        { provide: CODEX_REGISTRY, useValue: registry },
+        CodexRegistryLifecycle,
+      ],
+    };
+  }
+}

--- a/packages/oracle-runtime/src/plugins/codex/http/codex.tokens.ts
+++ b/packages/oracle-runtime/src/plugins/codex/http/codex.tokens.ts
@@ -1,0 +1,2 @@
+/** DI token for the plugin-owned `CodexRuntimeRegistry` singleton. */
+export const CODEX_REGISTRY = Symbol('CODEX_REGISTRY');

--- a/packages/oracle-runtime/src/plugins/codex/http/room-secret-reader.ts
+++ b/packages/oracle-runtime/src/plugins/codex/http/room-secret-reader.ts
@@ -1,0 +1,39 @@
+import { MatrixManager } from '@ixo/matrix';
+import { getMatrixHomeServerCroppedForDid } from '@ixo/oracles-chain-client';
+import { SecretsService } from '../../../modules/secrets/index.js';
+import type { CodexSecretReader } from '../auth/credentials.js';
+import type { CodexTenantScope } from '../domain/provider.js';
+
+/**
+ * Reads per-room encrypted secrets outside a graph run.
+ *
+ * The tool path gets `ctx.secrets` from the RuntimeContext; the HTTP control
+ * plane has no graph run, so it resolves the user↔oracle room the same way the
+ * runtime does and reads through the same `SecretsService`. Values are handed
+ * straight to the App Server process env and never returned to the caller.
+ */
+export function createRoomSecretReader(
+  scope: CodexTenantScope,
+): CodexSecretReader {
+  return {
+    async getValues(keys: string[]): Promise<Record<string, string>> {
+      const userHomeServer = await getMatrixHomeServerCroppedForDid(
+        scope.userDid,
+      );
+      const { roomId } =
+        await MatrixManager.getInstance().getOracleRoomIdWithHomeServer({
+          userDid: scope.userDid,
+          oracleEntityDid: scope.oracleEntityDid,
+          userHomeServer,
+        });
+      if (!roomId) return {};
+
+      const service = SecretsService.getInstance();
+      const requested = new Set(keys);
+      const index = await service.getSecretIndex(roomId);
+      const matching = index.filter((entry) => requested.has(entry.name));
+      if (matching.length === 0) return {};
+      return service.loadSecretValues(roomId, matching);
+    },
+  };
+}

--- a/packages/oracle-runtime/src/plugins/codex/index.ts
+++ b/packages/oracle-runtime/src/plugins/codex/index.ts
@@ -1,0 +1,95 @@
+export { CodexPlugin, type CodexPluginOptions } from './codex.plugin.js';
+
+export {
+  CODEX_AUTH_MODES,
+  CODEX_CONNECTION_STATUSES,
+  CODEX_PROVIDER_DISPLAY_NAME,
+  CODEX_PROVIDER_ID,
+  isAuthActionable,
+  tenantScopeKey,
+  type CodexAuthMode,
+  type CodexCapabilities,
+  type CodexConnectionStatus,
+  type CodexTenantScope,
+} from './domain/provider.js';
+
+export {
+  describeCodexAuthMode,
+  resolveCodexCapabilities,
+} from './domain/capabilities.js';
+
+export {
+  CodexConfigError,
+  codexConfigSchema,
+  normalizeCodexConfig,
+  type CodexApprovalPolicy,
+  type CodexNormalizedConfig,
+  type CodexSandboxMode,
+} from './domain/config.js';
+
+export { preflight, type CodexRuntimePlan } from './domain/preflight.js';
+
+export {
+  CodexConnectionState,
+  CodexTransitionError,
+  canTransition,
+  type CodexConnectionSnapshot,
+  type CodexTransition,
+} from './auth/connection-state.js';
+
+export {
+  redactCredentialEnv,
+  resolveCodexCredentials,
+  tenantHomePath,
+  type CodexCredentialOutcome,
+  type CodexSecretReader,
+} from './auth/credentials.js';
+
+export {
+  CODEX_APPROVAL_DECISIONS,
+  CODEX_APPROVAL_REQUESTS,
+  CODEX_METHODS,
+  CODEX_NOTIFICATIONS,
+  classifyFrame,
+  type CodexApprovalDecision,
+} from './app-server/protocol.js';
+
+export {
+  CodexAppServerClient,
+  CodexRpcError,
+  type CodexApprovalHandler,
+  type CodexApprovalRequest,
+} from './app-server/client.js';
+
+export {
+  StdioCodexTransport,
+  type CodexTransport,
+  type StdioTransportOptions,
+} from './app-server/transport.js';
+
+export {
+  CodexTurnTranscript,
+  emitCodexEvent,
+  mapNotification,
+  type CodexRuntimeEvent,
+} from './app-server/event-mapper.js';
+
+export {
+  CodexApprovalGate,
+  type PendingCodexApproval,
+} from './session/approval-gate.js';
+
+export {
+  CodexSession,
+  CodexSessionError,
+  defaultTransportFactory,
+  type CodexTransportFactory,
+  type CodexTurnResult,
+} from './session/codex-session.js';
+
+export {
+  CodexRuntimeRegistry,
+  type CodexRegistryOptions,
+} from './session/registry.js';
+
+export { type CodexProviderStatus } from './http/codex.controller.js';

--- a/packages/oracle-runtime/src/plugins/codex/session/approval-gate.ts
+++ b/packages/oracle-runtime/src/plugins/codex/session/approval-gate.ts
@@ -1,0 +1,133 @@
+import { randomUUID } from 'node:crypto';
+import type { RuntimeContext } from '../../../plugin-api/types.js';
+import type { CodexApprovalRequest } from '../app-server/client.js';
+import type { CodexApprovalDecision } from '../app-server/protocol.js';
+import { CODEX_PROVIDER_ID } from '../domain/provider.js';
+
+/** An approval Codex is blocked on, as shown to a client. Never auto-resolved. */
+export interface PendingCodexApproval {
+  readonly id: string;
+  readonly tenant: string;
+  readonly kind: CodexApprovalRequest['kind'];
+  readonly threadId?: string;
+  readonly turnId?: string;
+  readonly command?: string;
+  readonly cwd?: string;
+  readonly reason?: string;
+  readonly requestedAt: number;
+}
+
+interface GateEntry {
+  approval: PendingCodexApproval;
+  settle: (decision: CodexApprovalDecision) => void;
+  timer: NodeJS.Timeout;
+}
+
+export interface CodexApprovalGateOptions {
+  /**
+   * How long an approval may stay open. On expiry the gate declines — the
+   * safe default. Never `accept`.
+   */
+  timeoutMs: number;
+  now?: () => number;
+}
+
+/**
+ * Holds Codex approval requests open while a human decides.
+ *
+ * Codex blocks its turn on a server→client request; the gate parks that
+ * request, emits an `action_call` event so any connected client (first- or
+ * third-party) can render the prompt, and settles when a decision arrives via
+ * `resolve`. Nothing here ever grants an approval on its own: an unanswered
+ * request expires to `decline`.
+ */
+export class CodexApprovalGate {
+  private readonly pending = new Map<string, GateEntry>();
+
+  private readonly now: () => number;
+
+  constructor(private readonly options: CodexApprovalGateOptions) {
+    this.now = options.now ?? Date.now;
+  }
+
+  open(params: {
+    tenant: string;
+    request: CodexApprovalRequest;
+    ctx: Pick<RuntimeContext, 'emit' | 'logger'>;
+  }): Promise<CodexApprovalDecision> {
+    const { tenant, request, ctx } = params;
+    const id = randomUUID();
+    const approval: PendingCodexApproval = {
+      id,
+      tenant,
+      kind: request.kind,
+      requestedAt: this.now(),
+      ...(request.params.threadId ? { threadId: request.params.threadId } : {}),
+      ...(request.params.turnId ? { turnId: request.params.turnId } : {}),
+      ...(request.params.command ? { command: request.params.command } : {}),
+      ...(request.params.cwd ? { cwd: request.params.cwd } : {}),
+      ...(request.params.reason ? { reason: request.params.reason } : {}),
+    };
+
+    return new Promise<CodexApprovalDecision>((resolvePromise) => {
+      const settle = (decision: CodexApprovalDecision) => {
+        const entry = this.pending.get(id);
+        if (!entry) return;
+        clearTimeout(entry.timer);
+        this.pending.delete(id);
+        resolvePromise(decision);
+      };
+
+      const timer = setTimeout(() => {
+        ctx.logger.warn('codex approval expired without a decision', {
+          approvalId: id,
+          kind: request.kind,
+        });
+        settle('decline');
+      }, this.options.timeoutMs);
+      timer.unref?.();
+
+      this.pending.set(id, { approval, settle, timer });
+
+      ctx.emit.actionCall({
+        provider: CODEX_PROVIDER_ID,
+        action: 'codex.approval.required',
+        approvalId: id,
+        kind: approval.kind,
+        threadId: approval.threadId,
+        turnId: approval.turnId,
+        command: approval.command,
+        cwd: approval.cwd,
+      });
+    });
+  }
+
+  /** Settle a pending approval. Tenant-scoped — a mismatch is a miss. */
+  resolve(
+    tenant: string,
+    approvalId: string,
+    decision: CodexApprovalDecision,
+  ): boolean {
+    const entry = this.pending.get(approvalId);
+    if (!entry || entry.approval.tenant !== tenant) return false;
+    entry.settle(decision);
+    return true;
+  }
+
+  /** Open approvals for one tenant, oldest first. */
+  list(tenant: string): PendingCodexApproval[] {
+    return [...this.pending.values()]
+      .filter((entry) => entry.approval.tenant === tenant)
+      .map((entry) => entry.approval)
+      .sort((a, b) => a.requestedAt - b.requestedAt);
+  }
+
+  /** Decline everything outstanding for a tenant (disconnect, mode change). */
+  declineAll(tenant: string): number {
+    const entries = [...this.pending.values()].filter(
+      (entry) => entry.approval.tenant === tenant,
+    );
+    for (const entry of entries) entry.settle('decline');
+    return entries.length;
+  }
+}

--- a/packages/oracle-runtime/src/plugins/codex/session/codex-session.test.ts
+++ b/packages/oracle-runtime/src/plugins/codex/session/codex-session.test.ts
@@ -1,0 +1,349 @@
+/**
+ * End-to-end coverage of the App Server adapter against a real child process.
+ *
+ * The fixture in `__test-fixtures__/fake-app-server.mjs` speaks the same
+ * newline-delimited JSON-RPC framing as `codex app-server`, so the stdio
+ * transport, id correlation, streaming notifications, the approval round-trip
+ * and turn completion are all exercised for real. Only the Codex binary is
+ * substituted — everything in this package runs as it does in production.
+ */
+import { mkdtemp, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { Logger, RuntimeContext } from '../../../plugin-api/types.js';
+import { preflight, type CodexRuntimePlan } from '../domain/preflight.js';
+import type { CodexTenantScope } from '../domain/provider.js';
+import { CodexApprovalGate } from './approval-gate.js';
+import { CodexSession, CodexSessionError } from './codex-session.js';
+
+const FIXTURE = join(
+  dirname(fileURLToPath(import.meta.url)),
+  '..',
+  '__test-fixtures__',
+  'fake-app-server.mjs',
+);
+
+const scope: CodexTenantScope = {
+  userDid: 'did:ixo:user1',
+  oracleEntityDid: 'did:ixo:oracle1',
+};
+
+const logger: Logger = {
+  log: vi.fn(),
+  error: vi.fn(),
+  warn: vi.fn(),
+  debug: vi.fn(),
+};
+
+const emit = () => ({
+  toolCall: vi.fn(() => {}),
+  actionCall: vi.fn(() => {}),
+  renderComponent: vi.fn(() => {}),
+  reasoning: vi.fn(() => {}),
+  browserToolCall: vi.fn(() => {}),
+  router: vi.fn(() => {}),
+  messageCacheInvalidation: vi.fn(() => {}),
+});
+
+/** Full `RuntimeContext.secrets` shape — the session only reads `getValues`. */
+const secretsWith = (
+  values: Record<string, string>,
+): RuntimeContext['secrets'] => ({
+  getIndex: async () => ({}),
+  getValues: async () => values,
+});
+
+const apiKeySecrets = secretsWith({ OPENAI_API_KEY: 'sk-fixture' });
+const noSecrets = secretsWith({});
+
+describe('CodexSession against a live App Server process', () => {
+  let homeRoot: string;
+  let sessions: CodexSession[];
+
+  beforeEach(async () => {
+    homeRoot = await mkdtemp(join(tmpdir(), 'codex-session-'));
+    sessions = [];
+    vi.clearAllMocks();
+  });
+
+  afterEach(async () => {
+    await Promise.all(sessions.map((session) => session.disconnect()));
+  });
+
+  const planFor = (overrides: Record<string, string> = {}): CodexRuntimePlan =>
+    preflight({
+      CODEX_AUTH_MODE: 'api_key',
+      CODEX_HOME_ROOT: homeRoot,
+      CODEX_APP_SERVER_COMMAND: process.execPath,
+      CODEX_APP_SERVER_ARGS: FIXTURE,
+      CODEX_STARTUP_TIMEOUT_MS: '15000',
+      CODEX_TURN_TIMEOUT_MS: '15000',
+      ...overrides,
+    });
+
+  const makeSession = (
+    plan: CodexRuntimePlan,
+    gate = new CodexApprovalGate({ timeoutMs: 5_000 }),
+  ) => {
+    const session = new CodexSession({
+      plan,
+      scope,
+      gate,
+      logger,
+      clientVersion: 'test',
+    });
+    sessions.push(session);
+    return session;
+  };
+
+  const turnCtx = (emitter = emit(), secrets = apiKeySecrets) => ({
+    emit: emitter,
+    logger,
+    abortSignal: new AbortController().signal,
+    secrets,
+  });
+
+  it('runs an API-key turn end to end and returns the agent output', async () => {
+    const session = makeSession(planFor());
+    const emitter = emit();
+
+    const result = await session.runTurn({
+      prompt: 'do the thing',
+      ctx: turnCtx(emitter),
+    });
+
+    expect(result.status).toBe('completed');
+    expect(result.text).toBe('handled: do the thing');
+    expect(result.threadId).toMatch(/^thr_/u);
+    expect(session.snapshot().status).toBe('connected');
+  });
+
+  it('streams reasoning and turn lifecycle onto the QiForge event channels', async () => {
+    const session = makeSession(planFor());
+    const emitter = emit();
+
+    await session.runTurn({ prompt: 'stream please', ctx: turnCtx(emitter) });
+
+    expect(emitter.reasoning).toHaveBeenCalledWith(
+      expect.objectContaining({ provider: 'codex', text: 'planning' }),
+    );
+    expect(emitter.router).toHaveBeenCalledWith(
+      expect.objectContaining({ phase: 'started' }),
+    );
+    expect(emitter.router).toHaveBeenCalledWith(
+      expect.objectContaining({ phase: 'completed', status: 'completed' }),
+    );
+  });
+
+  it('runs a subscription turn once the ChatGPT sign-in artefact exists', async () => {
+    const plan = planFor({ CODEX_AUTH_MODE: 'chatgpt_subscription' });
+    const session = makeSession(plan);
+    // Materialize the tenant home the way a completed `codex login` would.
+    await expect(
+      session.runTurn({ prompt: 'x', ctx: turnCtx(emit(), noSecrets) }),
+    ).rejects.toThrow(/ChatGPT sign-in/u);
+
+    const home = join(homeRoot, 'did_ixo_oracle1__did_ixo_user1');
+    await writeFile(join(home, 'auth.json'), '{"tokens":{}}');
+
+    const result = await session.runTurn({
+      prompt: 'subscription task',
+      ctx: turnCtx(emit(), noSecrets),
+    });
+
+    expect(result.status).toBe('completed');
+    expect(result.text).toBe('handled: subscription task');
+  });
+
+  it('reports requires_sign_in rather than starting without credentials', async () => {
+    const session = makeSession(planFor());
+
+    await expect(
+      session.runTurn({ prompt: 'x', ctx: turnCtx(emit(), noSecrets) }),
+    ).rejects.toThrow(CodexSessionError);
+    expect(session.snapshot().status).toBe('requires_sign_in');
+  });
+
+  it('reports invalid_credentials when the App Server has no account', async () => {
+    process.env.FAKE_CODEX_ACCOUNT = 'none';
+    try {
+      const session = makeSession(planFor());
+      await expect(
+        session.runTurn({ prompt: 'x', ctx: turnCtx() }),
+      ).rejects.toThrow(/no signed-in|rejected the configured API key/u);
+      expect(session.snapshot().status).toBe('invalid_credentials');
+    } finally {
+      delete process.env.FAKE_CODEX_ACCOUNT;
+    }
+  });
+
+  it('reuses one thread across turns and resumes it', async () => {
+    const session = makeSession(planFor());
+
+    const first = await session.runTurn({ prompt: 'one', ctx: turnCtx() });
+    const second = await session.runTurn({ prompt: 'two', ctx: turnCtx() });
+
+    expect(second.threadId).toBe(first.threadId);
+    expect(second.turnId).not.toBe(first.turnId);
+  });
+
+  it('starts a fresh thread when the requested one is gone', async () => {
+    const session = makeSession(planFor());
+
+    const result = await session.runTurn({
+      prompt: 'resume a dead thread',
+      threadId: 'thr_missing',
+      ctx: turnCtx(),
+    });
+
+    expect(result.threadId).not.toBe('thr_missing');
+    expect(result.status).toBe('completed');
+  });
+
+  describe('approvals', () => {
+    beforeEach(() => {
+      process.env.FAKE_CODEX_REQUIRE_APPROVAL = '1';
+    });
+    afterEach(() => {
+      delete process.env.FAKE_CODEX_REQUIRE_APPROVAL;
+    });
+
+    it('surfaces the request to a client and applies the human decision', async () => {
+      const gate = new CodexApprovalGate({ timeoutMs: 5_000 });
+      const session = makeSession(planFor(), gate);
+      const emitter = emit();
+      const tenant = session.tenantKey();
+
+      const turn = session.runTurn({
+        prompt: 'needs approval',
+        ctx: turnCtx(emitter),
+      });
+
+      const approvalId = await waitFor(() => gate.list(tenant)[0]?.id);
+      expect(emitter.actionCall).toHaveBeenCalledWith(
+        expect.objectContaining({
+          action: 'codex.approval.required',
+          command: 'rm -rf build',
+        }),
+      );
+
+      expect(gate.resolve(tenant, approvalId, 'accept')).toBe(true);
+
+      const result = await turn;
+      expect(result.text).toBe('handled: needs approval');
+      expect(emitter.toolCall).toHaveBeenCalledWith(
+        expect.objectContaining({ name: 'codex.commandExecution' }),
+      );
+    });
+
+    it('passes a decline through instead of silently allowing the command', async () => {
+      const gate = new CodexApprovalGate({ timeoutMs: 5_000 });
+      const session = makeSession(planFor(), gate);
+      const tenant = session.tenantKey();
+
+      const turn = session.runTurn({ prompt: 'nope', ctx: turnCtx() });
+      const approvalId = await waitFor(() => gate.list(tenant)[0]?.id);
+      gate.resolve(tenant, approvalId, 'decline');
+
+      expect((await turn).text).toBe('declined: decline');
+    });
+
+    it('declines when nobody answers in time', async () => {
+      const gate = new CodexApprovalGate({ timeoutMs: 50 });
+      const session = makeSession(planFor(), gate);
+
+      expect(
+        (await session.runTurn({ prompt: 'x', ctx: turnCtx() })).text,
+      ).toBe('declined: decline');
+    });
+
+    it('refuses a resolution from a different tenant', async () => {
+      const gate = new CodexApprovalGate({ timeoutMs: 5_000 });
+      const session = makeSession(planFor(), gate);
+      const tenant = session.tenantKey();
+
+      const turn = session.runTurn({ prompt: 'x', ctx: turnCtx() });
+      const approvalId = await waitFor(() => gate.list(tenant)[0]?.id);
+
+      expect(gate.resolve('someone_else', approvalId, 'accept')).toBe(false);
+      expect(gate.list('someone_else')).toHaveLength(0);
+
+      gate.resolve(tenant, approvalId, 'decline');
+      await turn;
+    });
+  });
+
+  describe('transport failure', () => {
+    it('fails the in-flight turn and reconnects on the next one', async () => {
+      process.env.FAKE_CODEX_EXIT_ON_TURN = '1';
+      const session = makeSession(planFor());
+
+      await expect(
+        session.runTurn({ prompt: 'crash', ctx: turnCtx() }),
+      ).rejects.toThrow();
+      expect(session.snapshot().status).toBe('error');
+
+      delete process.env.FAKE_CODEX_EXIT_ON_TURN;
+      const result = await session.runTurn({
+        prompt: 'recovered',
+        ctx: turnCtx(),
+      });
+
+      expect(result.text).toBe('handled: recovered');
+      expect(
+        session.history().some((entry) => entry.reason === 'reconnect_attempt'),
+      ).toBe(true);
+    });
+
+    it('stops reconnecting once the attempt budget is spent', async () => {
+      process.env.FAKE_CODEX_EXIT_ON_TURN = '1';
+      try {
+        const session = makeSession(
+          planFor({ CODEX_MAX_RECONNECT_ATTEMPTS: '1' }),
+        );
+
+        await expect(
+          session.runTurn({ prompt: 'a', ctx: turnCtx() }),
+        ).rejects.toThrow();
+        await expect(
+          session.runTurn({ prompt: 'b', ctx: turnCtx() }),
+        ).rejects.toThrow();
+        await expect(
+          session.runTurn({ prompt: 'c', ctx: turnCtx() }),
+        ).rejects.toThrow(/reconnect attempts/u);
+      } finally {
+        delete process.env.FAKE_CODEX_EXIT_ON_TURN;
+      }
+    });
+  });
+
+  it('switching auth mode disconnects and is recorded', async () => {
+    const session = makeSession(planFor());
+    await session.runTurn({ prompt: 'x', ctx: turnCtx() });
+
+    await session.setAuthMode('chatgpt_subscription');
+
+    expect(session.snapshot().status).toBe('disconnected');
+    expect(session.snapshot().authMode).toBe('chatgpt_subscription');
+    expect(session.currentThreadId()).toBeNull();
+    expect(
+      session.history().some((entry) => entry.reason === 'auth_mode_changed'),
+    ).toBe(true);
+  });
+});
+
+/** Poll until `read` returns a value. Approvals arrive asynchronously. */
+async function waitFor<T>(
+  read: () => T | undefined,
+  timeoutMs = 5_000,
+): Promise<T> {
+  const deadline = Date.now() + timeoutMs;
+  for (;;) {
+    const value = read();
+    if (value !== undefined) return value;
+    if (Date.now() > deadline) throw new Error('timed out waiting for value');
+    await new Promise((r) => setTimeout(r, 10));
+  }
+}

--- a/packages/oracle-runtime/src/plugins/codex/session/codex-session.test.ts
+++ b/packages/oracle-runtime/src/plugins/codex/session/codex-session.test.ts
@@ -14,7 +14,7 @@ import { dirname, join } from 'node:path';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import type { Logger, RuntimeContext } from '../../../plugin-api/types.js';
 import { preflight, type CodexRuntimePlan } from '../domain/preflight.js';
-import type { CodexTenantScope } from '../domain/provider.js';
+import { tenantScopeKey, type CodexTenantScope } from '../domain/provider.js';
 import { CodexApprovalGate } from './approval-gate.js';
 import { CodexSession, CodexSessionError } from './codex-session.js';
 
@@ -72,12 +72,20 @@ describe('CodexSession against a live App Server process', () => {
     await Promise.all(sessions.map((session) => session.disconnect()));
   });
 
-  const planFor = (overrides: Record<string, string> = {}): CodexRuntimePlan =>
+  /**
+   * `fixtureFlags` steers the fake App Server. Passing them as argv rather
+   * than env keeps each scenario local to its session — no global state to
+   * set up or tear down, and no leakage between tests.
+   */
+  const planFor = (
+    overrides: Record<string, string> = {},
+    fixtureFlags: string[] = [],
+  ): CodexRuntimePlan =>
     preflight({
       CODEX_AUTH_MODE: 'api_key',
       CODEX_HOME_ROOT: homeRoot,
       CODEX_APP_SERVER_COMMAND: process.execPath,
-      CODEX_APP_SERVER_ARGS: FIXTURE,
+      CODEX_APP_SERVER_ARGS: [FIXTURE, ...fixtureFlags].join(' '),
       CODEX_STARTUP_TIMEOUT_MS: '15000',
       CODEX_TURN_TIMEOUT_MS: '15000',
       ...overrides,
@@ -145,7 +153,7 @@ describe('CodexSession against a live App Server process', () => {
       session.runTurn({ prompt: 'x', ctx: turnCtx(emit(), noSecrets) }),
     ).rejects.toThrow(/ChatGPT sign-in/u);
 
-    const home = join(homeRoot, 'did_ixo_oracle1__did_ixo_user1');
+    const home = join(homeRoot, tenantScopeKey(scope));
     await writeFile(join(home, 'auth.json'), '{"tokens":{}}');
 
     const result = await session.runTurn({
@@ -166,17 +174,27 @@ describe('CodexSession against a live App Server process', () => {
     expect(session.snapshot().status).toBe('requires_sign_in');
   });
 
+  it('registers the API key through account/login/start', async () => {
+    // The App Server ignores OPENAI_API_KEY in its environment for account
+    // purposes; without the login call this turn would be rejected.
+    const session = makeSession(planFor({}, ['--require-login']));
+
+    const result = await session.runTurn({
+      prompt: 'needs a registered key',
+      ctx: turnCtx(),
+    });
+
+    expect(result.status).toBe('completed');
+    expect(session.snapshot().status).toBe('connected');
+  });
+
   it('reports invalid_credentials when the App Server has no account', async () => {
-    process.env.FAKE_CODEX_ACCOUNT = 'none';
-    try {
-      const session = makeSession(planFor());
-      await expect(
-        session.runTurn({ prompt: 'x', ctx: turnCtx() }),
-      ).rejects.toThrow(/no signed-in|rejected the configured API key/u);
-      expect(session.snapshot().status).toBe('invalid_credentials');
-    } finally {
-      delete process.env.FAKE_CODEX_ACCOUNT;
-    }
+    const session = makeSession(planFor({}, ['--account=none']));
+
+    await expect(
+      session.runTurn({ prompt: 'x', ctx: turnCtx() }),
+    ).rejects.toThrow(/no signed-in|rejected the configured API key/u);
+    expect(session.snapshot().status).toBe('invalid_credentials');
   });
 
   it('reuses one thread across turns and resumes it', async () => {
@@ -187,6 +205,22 @@ describe('CodexSession against a live App Server process', () => {
 
     expect(second.threadId).toBe(first.threadId);
     expect(second.turnId).not.toBe(first.turnId);
+  });
+
+  it('serializes overlapping turns instead of crossing their streams', async () => {
+    const session = makeSession(planFor());
+
+    const [first, second] = await Promise.all([
+      session.runTurn({ prompt: 'one', ctx: turnCtx() }),
+      session.runTurn({ prompt: 'two', ctx: turnCtx() }),
+    ]);
+
+    // Each turn gets its own id and its own output — neither settles on the
+    // other's completion notification.
+    expect(first.turnId).not.toBe(second.turnId);
+    expect(new Set([first.text, second.text])).toEqual(
+      new Set(['handled: one', 'handled: two']),
+    );
   });
 
   it('starts a fresh thread when the requested one is gone', async () => {
@@ -203,16 +237,11 @@ describe('CodexSession against a live App Server process', () => {
   });
 
   describe('approvals', () => {
-    beforeEach(() => {
-      process.env.FAKE_CODEX_REQUIRE_APPROVAL = '1';
-    });
-    afterEach(() => {
-      delete process.env.FAKE_CODEX_REQUIRE_APPROVAL;
-    });
+    const approvalPlan = () => planFor({}, ['--require-approval']);
 
     it('surfaces the request to a client and applies the human decision', async () => {
       const gate = new CodexApprovalGate({ timeoutMs: 5_000 });
-      const session = makeSession(planFor(), gate);
+      const session = makeSession(approvalPlan(), gate);
       const emitter = emit();
       const tenant = session.tenantKey();
 
@@ -240,7 +269,7 @@ describe('CodexSession against a live App Server process', () => {
 
     it('passes a decline through instead of silently allowing the command', async () => {
       const gate = new CodexApprovalGate({ timeoutMs: 5_000 });
-      const session = makeSession(planFor(), gate);
+      const session = makeSession(approvalPlan(), gate);
       const tenant = session.tenantKey();
 
       const turn = session.runTurn({ prompt: 'nope', ctx: turnCtx() });
@@ -252,7 +281,7 @@ describe('CodexSession against a live App Server process', () => {
 
     it('declines when nobody answers in time', async () => {
       const gate = new CodexApprovalGate({ timeoutMs: 50 });
-      const session = makeSession(planFor(), gate);
+      const session = makeSession(approvalPlan(), gate);
 
       expect(
         (await session.runTurn({ prompt: 'x', ctx: turnCtx() })).text,
@@ -261,7 +290,7 @@ describe('CodexSession against a live App Server process', () => {
 
     it('refuses a resolution from a different tenant', async () => {
       const gate = new CodexApprovalGate({ timeoutMs: 5_000 });
-      const session = makeSession(planFor(), gate);
+      const session = makeSession(approvalPlan(), gate);
       const tenant = session.tenantKey();
 
       const turn = session.runTurn({ prompt: 'x', ctx: turnCtx() });
@@ -277,15 +306,18 @@ describe('CodexSession against a live App Server process', () => {
 
   describe('transport failure', () => {
     it('fails the in-flight turn and reconnects on the next one', async () => {
-      process.env.FAKE_CODEX_EXIT_ON_TURN = '1';
-      const session = makeSession(planFor());
+      // The fixture crashes only until the marker exists, so the reconnect
+      // spawns a healthy server and recovery is observable.
+      const marker = join(homeRoot, 'crashed-once');
+      const session = makeSession(
+        planFor({}, [`--exit-on-turn-once=${marker}`]),
+      );
 
       await expect(
         session.runTurn({ prompt: 'crash', ctx: turnCtx() }),
       ).rejects.toThrow();
       expect(session.snapshot().status).toBe('error');
 
-      delete process.env.FAKE_CODEX_EXIT_ON_TURN;
       const result = await session.runTurn({
         prompt: 'recovered',
         ctx: turnCtx(),
@@ -298,24 +330,19 @@ describe('CodexSession against a live App Server process', () => {
     });
 
     it('stops reconnecting once the attempt budget is spent', async () => {
-      process.env.FAKE_CODEX_EXIT_ON_TURN = '1';
-      try {
-        const session = makeSession(
-          planFor({ CODEX_MAX_RECONNECT_ATTEMPTS: '1' }),
-        );
+      const session = makeSession(
+        planFor({ CODEX_MAX_RECONNECT_ATTEMPTS: '1' }, ['--exit-on-turn']),
+      );
 
-        await expect(
-          session.runTurn({ prompt: 'a', ctx: turnCtx() }),
-        ).rejects.toThrow();
-        await expect(
-          session.runTurn({ prompt: 'b', ctx: turnCtx() }),
-        ).rejects.toThrow();
-        await expect(
-          session.runTurn({ prompt: 'c', ctx: turnCtx() }),
-        ).rejects.toThrow(/reconnect attempts/u);
-      } finally {
-        delete process.env.FAKE_CODEX_EXIT_ON_TURN;
-      }
+      await expect(
+        session.runTurn({ prompt: 'a', ctx: turnCtx() }),
+      ).rejects.toThrow();
+      await expect(
+        session.runTurn({ prompt: 'b', ctx: turnCtx() }),
+      ).rejects.toThrow();
+      await expect(
+        session.runTurn({ prompt: 'c', ctx: turnCtx() }),
+      ).rejects.toThrow(/reconnect attempts/u);
     });
   });
 

--- a/packages/oracle-runtime/src/plugins/codex/session/codex-session.ts
+++ b/packages/oracle-runtime/src/plugins/codex/session/codex-session.ts
@@ -1,0 +1,525 @@
+import type { Logger, RuntimeContext } from '../../../plugin-api/types.js';
+import {
+  CodexAppServerClient,
+  CodexRpcError,
+  type CodexApprovalRequest,
+} from '../app-server/client.js';
+import {
+  CodexTurnTranscript,
+  emitCodexEvent,
+  mapNotification,
+  type CodexRuntimeEvent,
+} from '../app-server/event-mapper.js';
+import {
+  CODEX_METHODS,
+  accountReadResultSchema,
+  threadStartResultSchema,
+  turnStartResultSchema,
+  type CodexApprovalDecision,
+} from '../app-server/protocol.js';
+import {
+  StdioCodexTransport,
+  type CodexTransport,
+  type StdioTransportOptions,
+} from '../app-server/transport.js';
+import {
+  CodexConnectionState,
+  type CodexConnectionSnapshot,
+  type CodexTransition,
+} from '../auth/connection-state.js';
+import {
+  redactCredentialEnv,
+  resolveCodexCredentials,
+  type CodexSecretReader,
+} from '../auth/credentials.js';
+import type { CodexRuntimePlan } from '../domain/preflight.js';
+import { tenantScopeKey, type CodexTenantScope } from '../domain/provider.js';
+import type { CodexApprovalGate } from './approval-gate.js';
+
+/** Creates a started transport. Injectable so tests drive a real fixture server. */
+export type CodexTransportFactory = (
+  options: StdioTransportOptions,
+) => CodexTransport;
+
+export const defaultTransportFactory: CodexTransportFactory = (options) => {
+  const transport = new StdioCodexTransport(options);
+  transport.start();
+  return transport;
+};
+
+export interface CodexSessionOptions {
+  plan: CodexRuntimePlan;
+  scope: CodexTenantScope;
+  gate: CodexApprovalGate;
+  logger: Logger;
+  transportFactory?: CodexTransportFactory;
+  clientVersion: string;
+}
+
+/** What `connect` needs. Deliberately narrow — no graph run required. */
+export interface CodexConnectDeps {
+  secrets: CodexSecretReader;
+}
+
+/** Emit + logger for the turn currently in flight. */
+export type CodexTurnContext = Pick<RuntimeContext, 'emit' | 'logger'>;
+
+export interface CodexTurnRequest {
+  prompt: string;
+  /** Resume this thread instead of starting a new one. */
+  threadId?: string;
+  ctx: Pick<RuntimeContext, 'emit' | 'logger' | 'abortSignal' | 'secrets'>;
+}
+
+export interface CodexTurnResult {
+  readonly threadId: string;
+  readonly turnId: string;
+  readonly status: 'completed' | 'interrupted' | 'failed';
+  readonly text: string;
+  readonly error?: string;
+}
+
+export class CodexSessionError extends Error {
+  constructor(
+    message: string,
+    readonly status: CodexConnectionSnapshot['status'],
+  ) {
+    super(`codex: ${message}`);
+    this.name = 'CodexSessionError';
+  }
+}
+
+interface PendingTurn {
+  turnId?: string;
+  transcript: CodexTurnTranscript;
+  settle: (result: {
+    turnId: string;
+    status: 'completed' | 'interrupted' | 'failed';
+    error?: string;
+  }) => void;
+  fail: (error: Error) => void;
+}
+
+/**
+ * One tenant's Codex runtime: a long-lived App Server connection plus the
+ * thread it owns. All state — credentials, thread id, approvals — is scoped to
+ * the tenant key and never shared across instances.
+ */
+export class CodexSession {
+  private client: CodexAppServerClient | null = null;
+
+  private threadId: string | null = null;
+
+  private pendingTurn: PendingTurn | null = null;
+
+  /** Set only while a turn is in flight; streaming events go here. */
+  private activeCtx: CodexTurnContext | null = null;
+
+  private reconnectAttempts = 0;
+
+  private connecting: Promise<void> | null = null;
+
+  private readonly state: CodexConnectionState;
+
+  private readonly tenant: string;
+
+  private readonly transportFactory: CodexTransportFactory;
+
+  constructor(private readonly options: CodexSessionOptions) {
+    this.tenant = tenantScopeKey(options.scope);
+    this.state = new CodexConnectionState(options.scope, options.plan.authMode);
+    this.transportFactory = options.transportFactory ?? defaultTransportFactory;
+  }
+
+  snapshot(): CodexConnectionSnapshot {
+    return this.state.snapshot();
+  }
+
+  history(): readonly CodexTransition[] {
+    return this.state.history();
+  }
+
+  tenantKey(): string {
+    return this.tenant;
+  }
+
+  currentThreadId(): string | null {
+    return this.threadId;
+  }
+
+  async connect(deps: CodexConnectDeps): Promise<CodexConnectionSnapshot> {
+    if (this.client && this.state.current() === 'connected') {
+      return this.state.snapshot();
+    }
+    // A previous connection died. Reconnecting is bounded so a persistently
+    // broken binary can't spin on every turn.
+    if (this.state.current() === 'error' && !this.connecting) {
+      if (!this.canReconnect()) {
+        throw new CodexSessionError(
+          `app server unavailable after ${this.reconnectAttempts} reconnect attempts`,
+          'error',
+        );
+      }
+      this.noteReconnectAttempt();
+    }
+    // Concurrent turns must not race two App Server processes into existence.
+    this.connecting ??= this.doConnect(deps).finally(() => {
+      this.connecting = null;
+    });
+    await this.connecting;
+    return this.state.snapshot();
+  }
+
+  private async doConnect(deps: CodexConnectDeps): Promise<void> {
+    const { config } = this.options.plan;
+    this.state.transition('connecting', 'connect_requested');
+
+    const outcome = await resolveCodexCredentials({
+      config,
+      scope: this.options.scope,
+      secrets: deps.secrets,
+    });
+
+    if (outcome.kind === 'requires_sign_in') {
+      this.state.transition('requires_sign_in', 'auth_missing', {
+        detail: outcome.detail,
+      });
+      throw new CodexSessionError(outcome.detail, 'requires_sign_in');
+    }
+
+    const { credentials } = outcome;
+    this.options.logger.log('starting codex app server', {
+      tenant: this.tenant,
+      command: config.command,
+      env: redactCredentialEnv(credentials.env),
+    });
+
+    let transport: CodexTransport;
+    try {
+      transport = this.transportFactory({
+        command: config.command,
+        args: config.args,
+        cwd: config.workspaceRoot,
+        env: credentials.env,
+        onStderr: (line) =>
+          this.options.logger.warn('codex app server stderr', {
+            tenant: this.tenant,
+            line,
+          }),
+      });
+    } catch (error) {
+      const detail = error instanceof Error ? error.message : String(error);
+      this.state.transition('unsupported_environment', 'environment_unusable', {
+        detail,
+      });
+      throw new CodexSessionError(detail, 'unsupported_environment');
+    }
+
+    this.client = new CodexAppServerClient({
+      transport,
+      requestTimeoutMs: config.startupTimeoutMs,
+      clientInfo: {
+        name: 'qiforge-oracle-runtime',
+        title: 'QiForge',
+        version: this.options.clientVersion,
+      },
+      onNotification: (method, params) =>
+        this.handleNotification(method, params),
+      onApproval: (request) => this.handleApproval(request),
+      onClose: (info) => this.handleTransportClose(info),
+    });
+
+    try {
+      await this.client.initialize(config.startupTimeoutMs);
+    } catch (error) {
+      const detail = error instanceof Error ? error.message : String(error);
+      await this.teardown();
+      this.state.transition('unsupported_environment', 'environment_unusable', {
+        detail: `handshake failed — ${detail}`,
+      });
+      throw new CodexSessionError(
+        `handshake failed — ${detail}`,
+        'unsupported_environment',
+      );
+    }
+
+    await this.assertAuthenticated();
+
+    this.state.transition('connected', 'handshake_ok');
+  }
+
+  /**
+   * The App Server is the authority on whether its credentials work — a present
+   * `auth.json` or API key is necessary, not sufficient.
+   */
+  private async assertAuthenticated(): Promise<void> {
+    const client = this.client;
+    if (!client) throw new CodexSessionError('client not started', 'error');
+
+    let raw: unknown;
+    try {
+      raw = await client.request(CODEX_METHODS.accountRead, {});
+    } catch (error) {
+      const detail = error instanceof Error ? error.message : String(error);
+      await this.teardown();
+      this.state.transition('invalid_credentials', 'auth_rejected', { detail });
+      throw new CodexSessionError(detail, 'invalid_credentials');
+    }
+
+    const parsed = accountReadResultSchema.safeParse(raw);
+    if (!parsed.success || !parsed.data.account) {
+      await this.teardown();
+      const detail =
+        this.options.plan.authMode === 'chatgpt_subscription'
+          ? 'The Codex App Server reports no signed-in ChatGPT account.'
+          : 'The Codex App Server rejected the configured API key.';
+      this.state.transition('invalid_credentials', 'auth_rejected', { detail });
+      throw new CodexSessionError(detail, 'invalid_credentials');
+    }
+  }
+
+  async runTurn(request: CodexTurnRequest): Promise<CodexTurnResult> {
+    const { config, capabilities } = this.options.plan;
+    await this.connect({ secrets: request.ctx.secrets });
+
+    const client = this.client;
+    if (!client) throw new CodexSessionError('not connected', 'error');
+
+    const threadId = await this.ensureThread(request.threadId);
+
+    const transcript = new CodexTurnTranscript();
+    const completion = new Promise<{
+      turnId: string;
+      status: 'completed' | 'interrupted' | 'failed';
+      error?: string;
+    }>((resolveTurn, rejectTurn) => {
+      this.pendingTurn = { transcript, settle: resolveTurn, fail: rejectTurn };
+    });
+    this.activeCtx = { emit: request.ctx.emit, logger: request.ctx.logger };
+
+    const params: Record<string, unknown> = {
+      threadId,
+      input: [{ type: 'text', text: request.prompt }],
+      effort: config.reasoningEffort,
+    };
+    // Under a subscription the plan decides the model; sending an override
+    // yields an opaque upstream rejection instead of a useful error.
+    if (capabilities.modelOverride && config.model) {
+      params.model = config.model;
+    }
+
+    let turnId: string;
+    try {
+      const raw = await client.request(CODEX_METHODS.turnStart, params, {
+        timeoutMs: config.turnTimeoutMs,
+        signal: request.ctx.abortSignal,
+      });
+      turnId = turnStartResultSchema.parse(raw).turn.id;
+      if (this.pendingTurn) this.pendingTurn.turnId = turnId;
+    } catch (error) {
+      this.pendingTurn = null;
+      this.activeCtx = null;
+      throw this.asSessionError(error);
+    }
+
+    const abortListener = () => {
+      void this.interrupt(turnId);
+    };
+    request.ctx.abortSignal.addEventListener('abort', abortListener, {
+      once: true,
+    });
+
+    const timeout = setTimeout(() => {
+      this.pendingTurn?.fail(
+        new CodexSessionError(
+          `turn ${turnId} exceeded ${config.turnTimeoutMs}ms`,
+          'error',
+        ),
+      );
+    }, config.turnTimeoutMs);
+    timeout.unref?.();
+
+    try {
+      const outcome = await completion;
+      // A handshake alone doesn't prove health: a binary that starts and then
+      // dies every turn must still exhaust the budget. Only a turn that ran to
+      // completion earns a fresh one.
+      this.reconnectAttempts = 0;
+      return {
+        threadId,
+        turnId: outcome.turnId,
+        status: outcome.status,
+        text: transcript.text(),
+        ...(outcome.error ? { error: outcome.error } : {}),
+      };
+    } catch (error) {
+      throw this.asSessionError(error);
+    } finally {
+      clearTimeout(timeout);
+      request.ctx.abortSignal.removeEventListener('abort', abortListener);
+      this.pendingTurn = null;
+      this.activeCtx = null;
+    }
+  }
+
+  private async ensureThread(requested?: string): Promise<string> {
+    const client = this.client;
+    if (!client) throw new CodexSessionError('not connected', 'error');
+    const { config, capabilities } = this.options.plan;
+
+    const target = requested ?? this.threadId;
+    if (target) {
+      try {
+        const raw = await client.request(
+          CODEX_METHODS.threadResume,
+          { threadId: target },
+          { timeoutMs: config.startupTimeoutMs },
+        );
+        this.threadId = threadStartResultSchema.parse(raw).thread.id;
+        return this.threadId;
+      } catch (error) {
+        // A thread the App Server no longer holds is recoverable: start a new
+        // one rather than failing the user's turn.
+        this.options.logger.warn('codex thread resume failed, starting fresh', {
+          tenant: this.tenant,
+          threadId: target,
+          detail: error instanceof Error ? error.message : String(error),
+        });
+      }
+    }
+
+    const raw = await client.request(
+      CODEX_METHODS.threadStart,
+      {
+        cwd: config.workspaceRoot,
+        sandbox: config.sandboxMode,
+        approvalPolicy: config.approvalPolicy,
+        ...(capabilities.modelOverride && config.model
+          ? { model: config.model }
+          : {}),
+      },
+      { timeoutMs: config.startupTimeoutMs },
+    );
+    this.threadId = threadStartResultSchema.parse(raw).thread.id;
+    return this.threadId;
+  }
+
+  async interrupt(turnId?: string): Promise<void> {
+    const client = this.client;
+    const target = turnId ?? this.pendingTurn?.turnId;
+    if (!client || !this.threadId || !target) return;
+    try {
+      await client.request(CODEX_METHODS.turnInterrupt, {
+        threadId: this.threadId,
+        turnId: target,
+      });
+    } catch (error) {
+      this.options.logger.warn('codex interrupt failed', {
+        tenant: this.tenant,
+        detail: error instanceof Error ? error.message : String(error),
+      });
+    }
+  }
+
+  async disconnect(reason = 'disconnect_requested'): Promise<void> {
+    this.options.gate.declineAll(this.tenant);
+    await this.teardown();
+    if (this.state.current() !== 'disconnected') {
+      this.state.transition('disconnected', 'disconnect_requested', {
+        detail: reason,
+      });
+    }
+  }
+
+  /** Explicit operator mode switch. Drops the connection and audits the change. */
+  async setAuthMode(mode: CodexRuntimePlan['authMode']): Promise<void> {
+    await this.teardown();
+    this.options.gate.declineAll(this.tenant);
+    this.threadId = null;
+    this.state.setAuthMode(mode);
+  }
+
+  private async teardown(): Promise<void> {
+    const client = this.client;
+    this.client = null;
+    if (client) await client.close().catch(() => undefined);
+  }
+
+  private handleNotification(method: string, params: unknown): void {
+    const event = mapNotification(method, params);
+    if (!event) return;
+
+    const ctx = this.activeCtx;
+    if (ctx && this.threadId) emitCodexEvent(event, ctx, this.threadId);
+    this.pendingTurn?.transcript.record(event);
+    this.settleOnCompletion(event);
+  }
+
+  private settleOnCompletion(event: CodexRuntimeEvent): void {
+    if (event.type !== 'turn.completed') return;
+    const pending = this.pendingTurn;
+    if (!pending) return;
+    // Notifications can arrive before `turn/start` returns its id, so an
+    // unidentified pending turn accepts the first completion it sees.
+    if (pending.turnId && pending.turnId !== event.turnId) return;
+    pending.settle({
+      turnId: event.turnId,
+      status: event.status,
+      ...(event.error ? { error: event.error } : {}),
+    });
+  }
+
+  private async handleApproval(
+    request: CodexApprovalRequest,
+  ): Promise<CodexApprovalDecision> {
+    const ctx = this.activeCtx;
+    // No turn in flight means no client is listening for the prompt. Declining
+    // is the only safe answer — never accept on the user's behalf.
+    if (!ctx) {
+      this.options.logger.warn('codex approval arrived outside a turn', {
+        tenant: this.tenant,
+        kind: request.kind,
+      });
+      return 'decline';
+    }
+    return this.options.gate.open({ tenant: this.tenant, request, ctx });
+  }
+
+  private handleTransportClose(info: {
+    code: number | null;
+    detail?: string;
+  }): void {
+    const detail = info.detail ?? `app server exited (code ${info.code})`;
+    this.client = null;
+
+    this.pendingTurn?.fail(new CodexSessionError(detail, 'error'));
+    this.pendingTurn = null;
+    this.options.gate.declineAll(this.tenant);
+
+    if (this.state.current() === 'connected') {
+      this.state.transition('error', 'transport_closed', { detail });
+    }
+  }
+
+  /** Whether a fresh connect is worth attempting after a transport failure. */
+  canReconnect(): boolean {
+    return (
+      this.reconnectAttempts < this.options.plan.config.maxReconnectAttempts
+    );
+  }
+
+  private noteReconnectAttempt(): void {
+    this.reconnectAttempts += 1;
+    this.state.transition('connecting', 'reconnect_attempt', {
+      detail: `attempt ${this.reconnectAttempts}`,
+    });
+  }
+
+  private asSessionError(error: unknown): Error {
+    if (error instanceof CodexSessionError) return error;
+    if (error instanceof CodexRpcError) {
+      return new CodexSessionError(error.message, this.state.current());
+    }
+    return error instanceof Error ? error : new Error(String(error));
+  }
+}

--- a/packages/oracle-runtime/src/plugins/codex/session/codex-session.ts
+++ b/packages/oracle-runtime/src/plugins/codex/session/codex-session.ts
@@ -32,6 +32,7 @@ import {
   resolveCodexCredentials,
   type CodexSecretReader,
 } from '../auth/credentials.js';
+import { resolveCodexCapabilities } from '../domain/capabilities.js';
 import type { CodexRuntimePlan } from '../domain/preflight.js';
 import { tenantScopeKey, type CodexTenantScope } from '../domain/provider.js';
 import type { CodexApprovalGate } from './approval-gate.js';
@@ -125,8 +126,19 @@ export class CodexSession {
 
   private readonly transportFactory: CodexTransportFactory;
 
+  /**
+   * The effective plan. Held on the instance rather than read from
+   * `options` because `setAuthMode` rebuilds it — connection setup,
+   * diagnostics and capabilities must all follow the switch.
+   */
+  private plan: CodexRuntimePlan;
+
+  /** Serializes turns: the App Server runs one turn per thread at a time. */
+  private turnQueue: Promise<unknown> = Promise.resolve();
+
   constructor(private readonly options: CodexSessionOptions) {
     this.tenant = tenantScopeKey(options.scope);
+    this.plan = options.plan;
     this.state = new CodexConnectionState(options.scope, options.plan.authMode);
     this.transportFactory = options.transportFactory ?? defaultTransportFactory;
   }
@@ -171,7 +183,7 @@ export class CodexSession {
   }
 
   private async doConnect(deps: CodexConnectDeps): Promise<void> {
-    const { config } = this.options.plan;
+    const { config } = this.plan;
     this.state.transition('connecting', 'connect_requested');
 
     const outcome = await resolveCodexCredentials({
@@ -243,14 +255,37 @@ export class CodexSession {
       );
     }
 
+    await this.registerApiKey(credentials.apiKey);
     await this.assertAuthenticated();
 
     this.state.transition('connected', 'handshake_ok');
   }
 
   /**
+   * Register an API key with the App Server. It does not read `OPENAI_API_KEY`
+   * from its environment for account purposes — without this call
+   * `account/read` reports no account and every turn would be rejected.
+   */
+  private async registerApiKey(apiKey?: string): Promise<void> {
+    const client = this.client;
+    if (!client || !apiKey) return;
+    try {
+      await client.request(
+        CODEX_METHODS.accountLoginStart,
+        { type: 'apiKey', apiKey },
+        { timeoutMs: this.plan.config.startupTimeoutMs },
+      );
+    } catch (error) {
+      const detail = error instanceof Error ? error.message : String(error);
+      await this.teardown();
+      this.state.transition('invalid_credentials', 'auth_rejected', { detail });
+      throw new CodexSessionError(detail, 'invalid_credentials');
+    }
+  }
+
+  /**
    * The App Server is the authority on whether its credentials work — a present
-   * `auth.json` or API key is necessary, not sufficient.
+   * `auth.json` or registered key is necessary, not sufficient.
    */
   private async assertAuthenticated(): Promise<void> {
     const client = this.client;
@@ -270,7 +305,7 @@ export class CodexSession {
     if (!parsed.success || !parsed.data.account) {
       await this.teardown();
       const detail =
-        this.options.plan.authMode === 'chatgpt_subscription'
+        this.plan.authMode === 'chatgpt_subscription'
           ? 'The Codex App Server reports no signed-in ChatGPT account.'
           : 'The Codex App Server rejected the configured API key.';
       this.state.transition('invalid_credentials', 'auth_rejected', { detail });
@@ -279,7 +314,18 @@ export class CodexSession {
   }
 
   async runTurn(request: CodexTurnRequest): Promise<CodexTurnResult> {
-    const { config, capabilities } = this.options.plan;
+    // Overlapping turns would clobber `pendingTurn`/`activeCtx` and cross
+    // their streams, so each waits for the previous one to settle.
+    const run = this.turnQueue.then(
+      () => this.doRunTurn(request),
+      () => this.doRunTurn(request),
+    );
+    this.turnQueue = run.catch(() => undefined);
+    return run;
+  }
+
+  private async doRunTurn(request: CodexTurnRequest): Promise<CodexTurnResult> {
+    const { config, capabilities } = this.plan;
     await this.connect({ secrets: request.ctx.secrets });
 
     const client = this.client;
@@ -365,7 +411,7 @@ export class CodexSession {
   private async ensureThread(requested?: string): Promise<string> {
     const client = this.client;
     if (!client) throw new CodexSessionError('not connected', 'error');
-    const { config, capabilities } = this.options.plan;
+    const { config, capabilities } = this.plan;
 
     const target = requested ?? this.threadId;
     if (target) {
@@ -436,7 +482,20 @@ export class CodexSession {
     await this.teardown();
     this.options.gate.declineAll(this.tenant);
     this.threadId = null;
+    // Rebuild the plan so credential resolution, diagnostics and capabilities
+    // all follow the new mode — a label change alone would keep launching with
+    // the old mode's credentials while reporting the new one.
+    this.plan = {
+      config: { ...this.plan.config, authMode: mode },
+      authMode: mode,
+      capabilities: resolveCodexCapabilities(mode),
+    };
     this.state.setAuthMode(mode);
+  }
+
+  /** The effective plan, after any mode switch. */
+  currentPlan(): CodexRuntimePlan {
+    return this.plan;
   }
 
   private async teardown(): Promise<void> {
@@ -503,9 +562,7 @@ export class CodexSession {
 
   /** Whether a fresh connect is worth attempting after a transport failure. */
   canReconnect(): boolean {
-    return (
-      this.reconnectAttempts < this.options.plan.config.maxReconnectAttempts
-    );
+    return this.reconnectAttempts < this.plan.config.maxReconnectAttempts;
   }
 
   private noteReconnectAttempt(): void {

--- a/packages/oracle-runtime/src/plugins/codex/session/registry.ts
+++ b/packages/oracle-runtime/src/plugins/codex/session/registry.ts
@@ -39,10 +39,6 @@ export class CodexRuntimeRegistry {
     });
   }
 
-  plan(): CodexRuntimePlan {
-    return this.options.plan;
-  }
-
   for(scope: CodexTenantScope): CodexSession {
     const key = tenantScopeKey(scope);
     const existing = this.sessions.get(key);

--- a/packages/oracle-runtime/src/plugins/codex/session/registry.ts
+++ b/packages/oracle-runtime/src/plugins/codex/session/registry.ts
@@ -1,0 +1,104 @@
+import type { Logger } from '../../../plugin-api/types.js';
+import type { CodexApprovalDecision } from '../app-server/protocol.js';
+import type { CodexConnectionSnapshot } from '../auth/connection-state.js';
+import type { CodexRuntimePlan } from '../domain/preflight.js';
+import { tenantScopeKey, type CodexTenantScope } from '../domain/provider.js';
+import {
+  CodexApprovalGate,
+  type PendingCodexApproval,
+} from './approval-gate.js';
+import {
+  CodexSession,
+  type CodexConnectDeps,
+  type CodexTransportFactory,
+} from './codex-session.js';
+
+export interface CodexRegistryOptions {
+  plan: CodexRuntimePlan;
+  logger: Logger;
+  clientVersion: string;
+  transportFactory?: CodexTransportFactory;
+  approvalTimeoutMs: number;
+}
+
+/**
+ * Owns one `CodexSession` per tenant plus the shared approval gate.
+ *
+ * The registry is the only place sessions are created, which is what keeps the
+ * tenant boundary enforceable: every lookup goes through a
+ * `CodexTenantScope`, and nothing hands out a session by raw key.
+ */
+export class CodexRuntimeRegistry {
+  private readonly sessions = new Map<string, CodexSession>();
+
+  readonly gate: CodexApprovalGate;
+
+  constructor(private readonly options: CodexRegistryOptions) {
+    this.gate = new CodexApprovalGate({
+      timeoutMs: options.approvalTimeoutMs,
+    });
+  }
+
+  plan(): CodexRuntimePlan {
+    return this.options.plan;
+  }
+
+  for(scope: CodexTenantScope): CodexSession {
+    const key = tenantScopeKey(scope);
+    const existing = this.sessions.get(key);
+    if (existing) return existing;
+
+    const session = new CodexSession({
+      plan: this.options.plan,
+      scope,
+      gate: this.gate,
+      logger: this.options.logger,
+      clientVersion: this.options.clientVersion,
+      ...(this.options.transportFactory
+        ? { transportFactory: this.options.transportFactory }
+        : {}),
+    });
+    this.sessions.set(key, session);
+    return session;
+  }
+
+  snapshot(scope: CodexTenantScope): CodexConnectionSnapshot {
+    return this.for(scope).snapshot();
+  }
+
+  /** Resolve an approval for this tenant. Returns false when unknown. */
+  resolveApproval(
+    scope: CodexTenantScope,
+    approvalId: string,
+    decision: CodexApprovalDecision,
+  ): boolean {
+    return this.gate.resolve(tenantScopeKey(scope), approvalId, decision);
+  }
+
+  pendingApprovals(scope: CodexTenantScope): PendingCodexApproval[] {
+    return this.gate.list(tenantScopeKey(scope));
+  }
+
+  async connect(
+    scope: CodexTenantScope,
+    deps: CodexConnectDeps,
+  ): Promise<CodexConnectionSnapshot> {
+    return this.for(scope).connect(deps);
+  }
+
+  async disconnect(scope: CodexTenantScope): Promise<CodexConnectionSnapshot> {
+    const session = this.for(scope);
+    await session.disconnect();
+    return session.snapshot();
+  }
+
+  /** Shut every tenant down — used on module destroy. */
+  async shutdown(): Promise<void> {
+    await Promise.all(
+      [...this.sessions.values()].map((session) =>
+        session.disconnect('runtime_shutdown').catch(() => undefined),
+      ),
+    );
+    this.sessions.clear();
+  }
+}

--- a/packages/oracle-runtime/src/plugins/index.ts
+++ b/packages/oracle-runtime/src/plugins/index.ts
@@ -1,6 +1,7 @@
 import type { OraclePlugin } from '../plugin-api/oracle-plugin.js';
 import type { PluginManifest } from '../plugin-api/types.js';
 import { AGUIPlugin } from './agui/index.js';
+import { CodexPlugin } from './codex/index.js';
 import { ComposioPlugin } from './composio/index.js';
 import { CreditsPlugin } from './credits/index.js';
 import { DomainIndexerPlugin } from './domain-indexer/index.js';
@@ -40,6 +41,7 @@ export const portalPlugin = new PortalPlugin();
 export const firecrawlPlugin = new FirecrawlPlugin();
 export const domainIndexerPlugin = new DomainIndexerPlugin();
 export const composioPlugin = new ComposioPlugin();
+export const codexPlugin = new CodexPlugin();
 export const sandboxPlugin = new SandboxPlugin();
 export const skillsPlugin = new SkillsPlugin();
 export const editorPlugin = new EditorPlugin();
@@ -71,6 +73,7 @@ export const BUNDLED_PLUGINS = [
   firecrawlPlugin,
   domainIndexerPlugin,
   composioPlugin,
+  codexPlugin,
   sandboxPlugin,
   skillsPlugin,
   editorPlugin,


### PR DESCRIPTION
Adds a bundled `codex` plugin that delegates coding tasks to a user's OpenAI Codex runtime over the **App Server's bidirectional JSON-RPC interface** — the same boundary Codex's own clients drive. No UI automation, no credential reuse.

> **Reviewers:** this PR was opened, then reworked after review. The wire contract is now verified against a real `codex-cli 0.145.0` binary rather than documentation. See [this comment](https://github.com/ixoworld/qiforge/pull/241#issuecomment-5087609823) for what changed and why.

## Two design calls worth reviewing first

**1. Codex is a plugin, not an `LLMProvider`.**
`src/llm/llm-provider.ts` maps a role to a `BaseChatModel` — stateless chat completions. The App Server is an agentic runtime: long-lived threads, multi-step turns, streamed work items, approval gates that block execution. Forcing it through `getProviderChatModel` would discard exactly the parts worth integrating. `openrouter` / `nebius` are untouched.

**2. Auth is established upstream, then registered.**
There is no generic login RPC; `account/read` is authoritative. Subscription mode relies on the `auth.json` that `codex login` writes into a per-tenant `CODEX_HOME`. API-key mode must call `account/login/start` — **an API key in the child's environment does not authenticate**, verified against the real binary.

## Auth modes — never interchangeable

|  | `chatgpt_subscription` | `api_key` |
|---|---|---|
| Sign-in | ChatGPT (`codex login`) | OpenAI API key via `account/login/start` |
| Billing | Covered by the plan | Per token |
| `directModelApi` | **false** | true |
| Per-turn model override | No — the plan decides | Yes |

A ChatGPT subscription authorizes the Codex *runtime*; it does **not** grant raw OpenAI API access. `resolveCodexCapabilities` encodes that as `directModelApi: false`, so nothing infers API entitlement from the mere presence of credentials.

`CODEX_AUTH_MODE` is **required with no default** and the plugin stays off until it's set — defaulting would silently pick how a user's Codex usage is billed. Switching goes through `setAuthMode`, which rebuilds the session's plan (not just its label), drops the connection, declines outstanding approvals, and records an `auth_mode_changed` transition.

## Approvals are first-class

Codex blocks its turn on a server→client request. `CodexApprovalGate` parks it, emits an `action_call` event so any client can render the prompt, and settles when a decision arrives — via `POST /codex/approvals` or the `codex_resolve_approval` tool. Both land on the same gate.

Nothing auto-approves. Unanswered approvals expire to `decline`; malformed ones are declined; approvals arriving with no turn in flight are declined (nobody is listening); `gate.resolve` is tenant-scoped, so a cross-tenant id is a miss, not a grant.

## Determinism & tenancy

- `preflight` is the only producer of a `CodexRuntimePlan`, gating config schema → auth-mode agreement → capability resolution → tool policy. `danger-full-access` + `never` is rejected outright — that pair removes both guardrails at once.
- Turns are **serialized per session**; the App Server runs one turn per thread, so overlapping calls would clobber shared state and cross their event streams.
- Every connection transition is validated against a table and appended to a bounded audit trail (`GET /codex/transitions`). An illegal edge throws rather than corrupting the record.
- `CodexTenantScope` reduces to a readable prefix **plus a digest of the exact scope** — sanitizing alone is not injective, and this key indexes sessions, approvals and `CODEX_HOME`.
- Credential values never reach logs, events, HTTP responses or the audit trail. All `/codex/*` routes are UCAN-authenticated and derive their tenant from the authenticated DID.

## Verification

**CI green. 79 tests, 0 type errors, lint and build passing.**

The wire contract was verified by installing `@openai/codex` and driving a real `codex-cli 0.145.0` App Server — not from documentation, which turned out to be wrong about the sandbox enum. Confirmed directly:

- Sandbox values are `read-only` / `workspace-write` / `danger-full-access` (camelCase is rejected with `unknown variant`).
- Approval values are `untrusted` / `on-request` / `never`. The server also has `granular`, but it is a struct variant — the bare string is rejected — so it is not offered.
- API keys require `account/login/start`; env alone yields `{account: null, requiresOpenaiAuth: true}`.
- The server emits explicit `null` for absent fields, so schemas use `.nullish()` — a plain `.optional()` rejects `null` and silently dropped successful `turn/completed` notifications.

Every config value the plugin can emit was then round-tripped against the real server: all accepted.

`session/codex-session.test.ts` drives a **real child process** speaking the same NDJSON framing as `codex app-server`, covering both auth paths, auth failure, streaming, thread resume, concurrent turns, the approval round trip and crash/reconnect.

## ⚠️ Still unverified before production

A full **authenticated turn** against a live Codex account — real streaming items and a real approval round trip. Those paths are exercised against the fixture but not the real service, which needs a funded key or a ChatGPT sign-in. Documented in `docs/architecture/codex-provider.md`.

## Assumption to sanity-check

`codex login` is per-user against a per-tenant `CODEX_HOME`, which suits an operator-provisioned deployment. A self-service flow where end users sign in themselves would need a provisioning path the harness doesn't have. I didn't build one — out of scope and would have been speculative.

## Docs

- `docs/architecture/codex-provider.md` — design rationale, lifecycle, security/tenancy, verified protocol notes
- `packages/oracle-runtime/src/plugins/codex/README.md` — operator setup, env vars, control plane
- Changeset included (`minor` on `@ixo/oracle-runtime`)

Public docs (`ixo-docs/build-an-oracle/`) live outside this repo and still need a plugin-catalog row + env-var entries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PX7pXrQBNm5U1UntVCyZU1