### PR TITLE
feat(byo-llm): graceful provider-error handling for chat streams

### DIFF
--- a/.changeset/byo-llm-error-handling.md
+++ b/.changeset/byo-llm-error-handling.md
@@ -1,0 +1,5 @@
+---
+'@ixo/oracle-runtime': minor
+---
+
+Graceful error handling for BYO-LLM and platform model failures. Stream errors are classified server-side (`classifyLlmError`) into `rate_limit | billing | auth | timeout | server | network | unknown` with the failing account attributed (`source: byo | platform`, provider, status), and the SSE `error` event now carries the structured payload (friendly message, `retryable`, raw `detail`, `sessionId`/`requestId`) instead of raw SDK text. The stream runner's error path flushes orphaned tool spinners and closes the thinking indicator; BYO models cap retries at 2 (AsyncCaller's default of 6 left rate-limited users in "Thinking..." for a minute); silent BYO→platform fallbacks (missing credential, expired ChatGPT connection) emit a `byo_fallback` notice while the turn continues. A `/simulate-error <preset>` chat trigger (env-gated by `ALLOW_ERROR_SIMULATION`, never for deployed envs) replays faithful provider error shapes for local testing.

--- a/docs/architecture/byo-llm.md
+++ b/docs/architecture/byo-llm.md
@@ -114,9 +114,48 @@ graph LR
   → `ReasoningEvent`, `{ type: 'text', text }` → message chunks). The batch
   (Matrix) path flattens array content via `message.text`.
 
+## Error handling
+
+Provider failures (rate limits, exhausted balances, revoked keys) are
+classified server-side and surfaced as structured SSE `error` events instead
+of raw SDK messages:
+
+- **Classifier** (`llm/provider-error.ts`): `classifyLlmError` maps a thrown
+  error to `{ kind, source, provider, status, retryable, message, detail }`.
+  Kinds: `rate_limit`, `billing`, `auth`, `timeout`, `server`, `network`,
+  `unknown`. The raw upstream text always survives in `detail`. Notable
+  mappings: OpenAI billing exhaustion is a 429 with
+  `code: insufficient_quota`; Anthropic credit exhaustion is a **400** whose
+  wording ("credit balance is too low") wins over the status; DeepSeek is a
+  bare `402 Insufficient Balance`; Gemini's free-tier rate limit reuses
+  OpenAI's billing sentence and must NOT classify as billing.
+- **Wire shape**: `sendSSEError` emits
+  `{ error, kind, source, provider?, providerLabel?, status?, retryable,
+detail, sessionId, requestId, timestamp }`. `error` is a friendly English
+  fallback (Matrix/Slack clients show it as-is); the portal re-maps `kind` to
+  localized copy with provider-aware actions.
+- **Error-path cleanup**: `SseStreamRunner`'s catch flushes orphaned tool
+  spinners and closes the thinking indicator before the error event — the
+  same cleanup the success path performs.
+- **Retry cap**: BYO models set `maxRetries: 2` (LangChain's AsyncCaller
+  default is 6 with exponential backoff — a rate-limited account would sit
+  in "Thinking..." for a minute before failing).
+- **Fallback notice**: when a turn silently degrades from a BYO credential
+  to the platform model (credential missing, ChatGPT refresh failed,
+  resolution error), a `kind: 'byo_fallback'` notice (with
+  `reason: 'not_connected' | 'reconnect_required' | 'error'`) is emitted on
+  the same `error` event channel and the turn continues — the picker would
+  otherwise keep showing the BYO model with no signal that it isn't in use.
+- **Local simulation**: with `ALLOW_ERROR_SIMULATION=true` (never in a
+  deployed env), a chat message `/simulate-error <preset>` triggers a
+  faithful replica of a real provider failure
+  (`modules/messages/error-simulation.ts`) — e.g. `deepseek:billing`,
+  `anthropic:rate_limit`, `chatgpt:usage_limit`, `fallback`.
+
 ## Env
 
-| Var                     | Meaning                                       |
-| ----------------------- | --------------------------------------------- |
-| `BYO_LLM_ENABLED`       | `'true'` enables the module (companion only). |
-| `BYO_CHATGPT_CLIENT_ID` | Override the OAuth client id (testing only).  |
+| Var                      | Meaning                                                  |
+| ------------------------ | -------------------------------------------------------- |
+| `BYO_LLM_ENABLED`        | `'true'` enables the module (companion only).            |
+| `BYO_CHATGPT_CLIENT_ID`  | Override the OAuth client id (testing only).             |
+| `ALLOW_ERROR_SIMULATION` | `'true'` enables `/simulate-error` (local testing only). |

--- a/packages/oracle-runtime/package.json
+++ b/packages/oracle-runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ixo/oracle-runtime",
-  "version": "1.5.0",
+  "version": "1.6.0",
   "description": "Plugin-based runtime for QiForge oracles",
   "private": false,
   "publishConfig": {

--- a/packages/oracle-runtime/src/llm/byo-client.ts
+++ b/packages/oracle-runtime/src/llm/byo-client.ts
@@ -85,11 +85,17 @@ export function createByoChatModel(
   // params with a 400, so those branches force `temperature: undefined`
   // AFTER the spreads — the common factories inject a 0.2 default otherwise.
   const temperature = role === 'guard' ? 0 : 0.8;
+  // LangChain's AsyncCaller default is SIX retries with exponential backoff
+  // — a rate-limited BYO account would leave the user staring at
+  // "Thinking..." for a minute before any error surfaces. Two attempts keep
+  // transient-blip resilience while failing fast enough to report.
+  const maxRetries = 2;
 
   switch (credential.provider) {
     case 'openai':
       return getChatOpenAiModel({
         __includeRawResponse: true,
+        maxRetries,
         ...params,
         model: modelId,
         apiKey: credential.apiKey,
@@ -101,6 +107,7 @@ export function createByoChatModel(
       return getChatOpenAiModel({
         temperature,
         __includeRawResponse: true,
+        maxRetries,
         ...params,
         model: modelId,
         apiKey: credential.apiKey,
@@ -114,6 +121,7 @@ export function createByoChatModel(
       return getChatOpenAiModel({
         temperature,
         __includeRawResponse: true,
+        maxRetries,
         ...params,
         model: modelId,
         apiKey: credential.apiKey,
@@ -128,6 +136,7 @@ export function createByoChatModel(
         model: modelId,
         apiKey: credential.apiKey,
         temperature: undefined,
+        maxRetries,
       };
       return getChatAnthropicModel(anthropicParams);
     }
@@ -147,6 +156,7 @@ export function createByoChatModel(
       const sessionId = crypto.randomUUID();
       return getChatOpenAiModel({
         __includeRawResponse: true,
+        maxRetries,
         useResponsesApi: true,
         streaming: true,
         // Zero-data-retention mode matches the backend's mandatory

--- a/packages/oracle-runtime/src/llm/provider-error.test.ts
+++ b/packages/oracle-runtime/src/llm/provider-error.test.ts
@@ -1,0 +1,185 @@
+import { describe, expect, it } from 'vitest';
+import {
+  buildByoFallbackNotice,
+  BYO_FALLBACK_KIND,
+  classifyLlmError,
+} from './provider-error.js';
+
+/** Build an error the way the SDK stack actually throws them. */
+function sdkError(message: string, extras?: Record<string, unknown>): Error {
+  const error = new Error(message);
+  if (extras) Object.assign(error, extras);
+  return error;
+}
+
+describe('classifyLlmError — real provider error shapes', () => {
+  it('OpenAI quota exhaustion (insufficient_quota on a 429) is billing, not rate limit', () => {
+    const result = classifyLlmError(
+      sdkError(
+        '429 You exceeded your current quota, please check your plan and billing details.',
+        { status: 429, code: 'insufficient_quota' },
+      ),
+      { byoProvider: 'openai' },
+    );
+    expect(result.kind).toBe('billing');
+    expect(result.source).toBe('byo');
+    expect(result.provider).toBe('openai');
+    expect(result.status).toBe(429);
+    expect(result.retryable).toBe(false);
+  });
+
+  it("LangChain's InsufficientQuotaError wrapper (name only, no code) is billing", () => {
+    const wrapped = new Error(
+      '429 You exceeded your current quota, please check your plan and billing details.',
+    );
+    wrapped.name = 'InsufficientQuotaError';
+    expect(classifyLlmError(wrapped).kind).toBe('billing');
+  });
+
+  it('Anthropic credit exhaustion hides behind a 400 — wording wins over status', () => {
+    const result = classifyLlmError(
+      sdkError(
+        '400 {"type":"error","error":{"type":"invalid_request_error","message":"Your credit balance is too low to access the Anthropic API. Please go to Plans & Billing to upgrade or purchase credits."}}',
+        {
+          status: 400,
+          error: {
+            type: 'invalid_request_error',
+            message:
+              'Your credit balance is too low to access the Anthropic API.',
+          },
+        },
+      ),
+      { byoProvider: 'anthropic' },
+    );
+    expect(result.kind).toBe('billing');
+    expect(result.providerLabel).toBe('Anthropic API');
+  });
+
+  it('DeepSeek balance exhaustion (402 Insufficient Balance) is billing', () => {
+    const result = classifyLlmError(
+      sdkError('402 Insufficient Balance', { status: 402 }),
+      { byoProvider: 'deepseek' },
+    );
+    expect(result.kind).toBe('billing');
+    expect(result.retryable).toBe(false);
+  });
+
+  it('Anthropic rate_limit_error type maps to rate_limit', () => {
+    const result = classifyLlmError(
+      sdkError(
+        '429 {"type":"error","error":{"type":"rate_limit_error","message":"Number of request tokens has exceeded your per-minute rate limit."}}',
+        {
+          status: 429,
+          error: { type: 'rate_limit_error', message: 'rate limited' },
+        },
+      ),
+      { byoProvider: 'anthropic' },
+    );
+    expect(result.kind).toBe('rate_limit');
+    expect(result.retryable).toBe(true);
+  });
+
+  it('ChatGPT backend empty-body 429 still classifies via status prefix in the message', () => {
+    // The Codex backend reports errors with an empty body; the SDK throws
+    // with no `status` field populated on some paths — the "429 " message
+    // prefix is all there is.
+    const result = classifyLlmError(sdkError('429 status code (no body)'), {
+      byoProvider: 'chatgpt',
+    });
+    expect(result.kind).toBe('rate_limit');
+    expect(result.status).toBe(429);
+    expect(result.provider).toBe('chatgpt');
+    expect(result.message).toMatch(/ChatGPT plan/);
+  });
+
+  it('invalid API keys classify as auth for OpenAI and Anthropic shapes', () => {
+    expect(
+      classifyLlmError(
+        sdkError('401 Incorrect API key provided: sk-proj-***.', {
+          status: 401,
+          code: 'invalid_api_key',
+        }),
+        { byoProvider: 'openai' },
+      ).kind,
+    ).toBe('auth');
+    expect(
+      classifyLlmError(
+        sdkError(
+          '401 {"type":"error","error":{"type":"authentication_error","message":"invalid x-api-key"}}',
+          {
+            status: 401,
+            error: {
+              type: 'authentication_error',
+              message: 'invalid x-api-key',
+            },
+          },
+        ),
+        { byoProvider: 'anthropic' },
+      ).kind,
+    ).toBe('auth');
+  });
+
+  it('Anthropic overloaded_error (529) maps to server and is retryable', () => {
+    const result = classifyLlmError(
+      sdkError(
+        '529 {"type":"error","error":{"type":"overloaded_error","message":"Overloaded"}}',
+        {
+          status: 529,
+          error: { type: 'overloaded_error', message: 'Overloaded' },
+        },
+      ),
+      { byoProvider: 'anthropic' },
+    );
+    expect(result.kind).toBe('server');
+    expect(result.retryable).toBe(true);
+  });
+
+  it('timeouts and network failures classify without any status', () => {
+    expect(classifyLlmError(sdkError('Request timed out.')).kind).toBe(
+      'timeout',
+    );
+    expect(classifyLlmError(sdkError('fetch failed')).kind).toBe('network');
+    expect(classifyLlmError(sdkError('read ECONNRESET')).kind).toBe('network');
+  });
+
+  it('platform turns (no BYO provider) report source platform without provider fields', () => {
+    const result = classifyLlmError(
+      sdkError('429 Provider returned error', { status: 429 }),
+    );
+    expect(result.source).toBe('platform');
+    expect(result.provider).toBeUndefined();
+    expect(result.providerLabel).toBeUndefined();
+  });
+
+  it('degrades to unknown while preserving the raw text as detail', () => {
+    const result = classifyLlmError(sdkError('something inexplicable'));
+    expect(result.kind).toBe('unknown');
+    expect(result.retryable).toBe(false);
+    expect(result.detail).toBe('something inexplicable');
+  });
+
+  it('never throws on non-Error inputs', () => {
+    expect(classifyLlmError('plain string').kind).toBe('unknown');
+    expect(classifyLlmError(null).kind).toBe('unknown');
+    expect(classifyLlmError(undefined).kind).toBe('unknown');
+    expect(classifyLlmError({ weird: true }).kind).toBe('unknown');
+  });
+});
+
+describe('buildByoFallbackNotice', () => {
+  it('carries the byo_fallback kind, the provider, and a reconnect hint', () => {
+    const notice = buildByoFallbackNotice('reconnect_required', 'chatgpt');
+    expect(notice.kind).toBe(BYO_FALLBACK_KIND);
+    expect(notice.source).toBe('byo');
+    expect(notice.provider).toBe('chatgpt');
+    expect(notice.retryable).toBe(false);
+    expect(notice.error).toMatch(/platform model/);
+    expect(notice.error).toMatch(/Reconnect/);
+  });
+
+  it('handles the providerless degradation case', () => {
+    const notice = buildByoFallbackNotice('error');
+    expect(notice.provider).toBeUndefined();
+    expect(notice.error).toMatch(/platform model/);
+  });
+});

--- a/packages/oracle-runtime/src/llm/provider-error.ts
+++ b/packages/oracle-runtime/src/llm/provider-error.ts
@@ -1,0 +1,270 @@
+/**
+ * Classification of model-provider failures into a stable, wire-friendly
+ * shape. The raw errors thrown by the LangChain/OpenAI/Anthropic SDK stack
+ * are wildly inconsistent — status on `error.status` or `error.response.
+ * status` or only as a "429 ..." message prefix, billing exhaustion as a 429
+ * (OpenAI `insufficient_quota`), a 400 (Anthropic "credit balance is too
+ * low"), or a 402 (DeepSeek "Insufficient Balance") — and the ChatGPT
+ * backend frequently reports errors with an empty body. Classifying here,
+ * where the provider context is known, lets every downstream surface (SSE
+ * error events, logs, the portal banner) speak one language.
+ */
+
+import {
+  BYO_PROVIDER_INFO,
+  isByoProvider,
+  type ByoProvider,
+} from './byo-catalog.js';
+
+export type LlmErrorKind =
+  | 'rate_limit'
+  | 'billing'
+  | 'auth'
+  | 'timeout'
+  | 'server'
+  | 'network'
+  | 'unknown';
+
+export interface ClassifiedLlmError {
+  kind: LlmErrorKind;
+  /** Where the failing credential lives — the user's own account or ours. */
+  source: 'byo' | 'platform';
+  /** Set on BYO turns; lets the client name the account that failed. */
+  provider?: ByoProvider;
+  /** Human label for the provider ("OpenAI API", "ChatGPT (subscription)"). */
+  providerLabel?: string;
+  /** HTTP status when one could be recovered. */
+  status?: number;
+  /** Whether an immediate identical retry has any chance of succeeding. */
+  retryable: boolean;
+  /**
+   * Human-readable message. English fallback for clients without their own
+   * error UI (Matrix, Slack); the portal re-maps `kind` to localized copy.
+   */
+  message: string;
+  /** The raw upstream message, for the collapsible details/support view. */
+  detail: string;
+}
+
+interface ErrorParts {
+  status?: number;
+  code?: string;
+  text: string;
+}
+
+/**
+ * Pull status/code/message out of an unknown error without trusting any one
+ * SDK's shape. Checks, in order: direct fields (`status`, `code`), the
+ * OpenAI SDK's nested `error.error.{code,type}`, an axios-style
+ * `error.response.status`, and finally a leading "NNN " message prefix.
+ */
+function extractErrorParts(error: unknown): ErrorParts {
+  const text = error instanceof Error ? error.message : String(error);
+  const parts: ErrorParts = { text };
+  if (error && typeof error === 'object') {
+    const record = error as Record<string, unknown>;
+    if (typeof record.status === 'number') parts.status = record.status;
+    if (typeof record.code === 'string') parts.code = record.code;
+    if (error instanceof Error && error.name === 'InsufficientQuotaError') {
+      parts.code = 'insufficient_quota';
+    }
+    const nested = record.error;
+    if (nested && typeof nested === 'object') {
+      const nestedRecord = nested as Record<string, unknown>;
+      if (!parts.code && typeof nestedRecord.code === 'string') {
+        parts.code = nestedRecord.code;
+      }
+      // Anthropic puts the machine-readable type at `error.error.type`
+      // ("rate_limit_error", "authentication_error", "overloaded_error").
+      if (!parts.code && typeof nestedRecord.type === 'string') {
+        parts.code = nestedRecord.type;
+      }
+    }
+    const response = record.response;
+    if (
+      parts.status === undefined &&
+      response &&
+      typeof response === 'object' &&
+      typeof (response as Record<string, unknown>).status === 'number'
+    ) {
+      parts.status = (response as Record<string, unknown>).status as number;
+    }
+  }
+  if (parts.status === undefined) {
+    const prefixed = /^(\d{3})\s/.exec(text);
+    if (prefixed) parts.status = Number(prefixed[1]);
+  }
+  return parts;
+}
+
+// Deliberately does NOT match "exceeded your current quota": OpenAI's
+// billing-exhaustion 429 carries that wording but ALWAYS pairs it with
+// `code: insufficient_quota` (caught above via code/name), while Gemini's
+// free-tier RATE limit reuses the identical sentence — for a bare quota
+// message, rate-limit is the correct read.
+const BILLING_TEXT =
+  /insufficient[_ ]quota|insufficient balance|credit balance is too low|purchase credits|billing hard limit|payment required/i;
+const RATE_LIMIT_TEXT =
+  /rate[_ -]?limit|too many requests|usage[_ -]?limit|resource[_ -]?exhausted|tokens per min|requests per min/i;
+const AUTH_TEXT =
+  /incorrect api key|invalid api key|invalid x-api-key|authentication[_ ]error|permission[_ ]error|unauthorized|forbidden|token has expired|invalid bearer|account_deactivated/i;
+const TIMEOUT_TEXT = /timed?[_ ]?out|deadline exceeded|request timeout/i;
+const NETWORK_TEXT =
+  /fetch failed|network|econnrefused|econnreset|etimedout|eai_again|socket hang up|und_err/i;
+const SERVER_TEXT =
+  /internal server error|bad gateway|service unavailable|server[_ ]error|overloaded/i;
+
+function detectKind(parts: ErrorParts): LlmErrorKind {
+  const { status, code, text } = parts;
+  // Machine-readable codes are the most trustworthy signal — check first.
+  if (code === 'insufficient_quota') return 'billing';
+  if (code === 'rate_limit_error') return 'rate_limit';
+  if (code === 'authentication_error' || code === 'permission_error') {
+    return 'auth';
+  }
+  if (code === 'overloaded_error') return 'server';
+  // Message text beats bare status: billing exhaustion hides behind 400s
+  // (Anthropic) and 429s (OpenAI), so the wording is the discriminator.
+  if (BILLING_TEXT.test(text)) return 'billing';
+  if (status === 401 || status === 403) return 'auth';
+  if (status === 402) return 'billing';
+  if (status === 429 || RATE_LIMIT_TEXT.test(text)) return 'rate_limit';
+  if (status === 408 || status === 504 || TIMEOUT_TEXT.test(text)) {
+    return 'timeout';
+  }
+  if (status !== undefined && status >= 500) return 'server';
+  if (AUTH_TEXT.test(text)) return 'auth';
+  if (NETWORK_TEXT.test(text)) return 'network';
+  if (SERVER_TEXT.test(text)) return 'server';
+  return 'unknown';
+}
+
+const RETRYABLE_KINDS: ReadonlySet<LlmErrorKind> = new Set([
+  'rate_limit',
+  'timeout',
+  'server',
+  'network',
+]);
+
+/** English fallback copy per kind, personalized to the failing account. */
+function fallbackMessage(
+  kind: LlmErrorKind,
+  provider: ByoProvider | undefined,
+  providerLabel: string | undefined,
+): string {
+  const account = providerLabel
+    ? `your ${providerLabel} account`
+    : 'the model provider';
+  switch (kind) {
+    case 'billing':
+      return provider === 'chatgpt'
+        ? 'Your ChatGPT subscription has no usage left. Check your plan, or switch to another model.'
+        : `${capitalize(account)} is out of credit. Top up with the provider, or switch to another model.`;
+    case 'rate_limit':
+      return provider === 'chatgpt'
+        ? "You've hit your ChatGPT plan's usage limit. Wait for it to reset, or switch to another model."
+        : `${capitalize(account)} is being rate-limited. Wait a moment and try again.`;
+    case 'auth':
+      return providerLabel
+        ? `Your ${providerLabel} credentials were rejected. Reconnect or update the key in your Personal Agent settings.`
+        : 'The model provider rejected the credentials for this request.';
+    case 'timeout':
+      return 'The model took too long to respond. Please try again.';
+    case 'server':
+      return providerLabel
+        ? `${providerLabel} is having trouble right now. Please try again shortly.`
+        : 'The model provider is having trouble right now. Please try again shortly.';
+    case 'network':
+      return 'Could not reach the model provider. Please try again.';
+    case 'unknown':
+      return 'Something went wrong while generating the reply. Please try again.';
+  }
+}
+
+function capitalize(value: string): string {
+  return value.charAt(0).toUpperCase() + value.slice(1);
+}
+
+/**
+ * `kind` value for the notice emitted when a turn silently degrades from the
+ * user's own credential to the platform model. Rides the SSE `error` event
+ * channel (the only channel existing clients surface), but is a warning, not
+ * a failure — the turn still streams a reply.
+ */
+export const BYO_FALLBACK_KIND = 'byo_fallback';
+
+export type ByoFallbackReason =
+  | 'not_connected'
+  | 'reconnect_required'
+  | 'error';
+
+export interface ByoFallbackNoticePayload {
+  error: string;
+  kind: typeof BYO_FALLBACK_KIND;
+  source: 'byo';
+  provider?: ByoProvider;
+  providerLabel?: string;
+  reason: ByoFallbackReason;
+  retryable: false;
+  timestamp: string;
+}
+
+export function buildByoFallbackNotice(
+  reason: ByoFallbackReason,
+  provider?: ByoProvider,
+): ByoFallbackNoticePayload {
+  const providerLabel = provider
+    ? BYO_PROVIDER_INFO[provider].label
+    : undefined;
+  const account = providerLabel ?? 'your connected AI account';
+  const message =
+    reason === 'reconnect_required'
+      ? `Your ${account} connection has expired, so this reply is using the platform model instead. Reconnect it in your Personal Agent settings.`
+      : reason === 'not_connected'
+        ? `The model you selected needs a connected ${account}, so this reply is using the platform model instead. Connect it in your Personal Agent settings.`
+        : `Your connected AI account could not be used for this reply, so it is using the platform model instead.`;
+  return {
+    error: message,
+    kind: BYO_FALLBACK_KIND,
+    source: 'byo',
+    ...(provider && { provider }),
+    ...(providerLabel && { providerLabel }),
+    reason,
+    retryable: false,
+    timestamp: new Date().toISOString(),
+  };
+}
+
+export interface ClassifyLlmErrorContext {
+  /** The BYO provider active on the turn, when known. */
+  byoProvider?: ByoProvider | string | null;
+}
+
+/**
+ * Classify a model-call failure. Never throws; an unrecognizable error
+ * degrades to `kind: 'unknown'` with the raw text preserved in `detail`.
+ */
+export function classifyLlmError(
+  error: unknown,
+  ctx?: ClassifyLlmErrorContext,
+): ClassifiedLlmError {
+  const parts = extractErrorParts(error);
+  const kind = detectKind(parts);
+  const provider =
+    typeof ctx?.byoProvider === 'string' && isByoProvider(ctx.byoProvider)
+      ? ctx.byoProvider
+      : undefined;
+  const providerLabel = provider
+    ? BYO_PROVIDER_INFO[provider].label
+    : undefined;
+  return {
+    kind,
+    source: provider ? 'byo' : 'platform',
+    ...(provider && { provider }),
+    ...(providerLabel && { providerLabel }),
+    ...(parts.status !== undefined && { status: parts.status }),
+    retryable: RETRYABLE_KINDS.has(kind),
+    message: fallbackMessage(kind, provider, providerLabel),
+    detail: parts.text,
+  };
+}

--- a/packages/oracle-runtime/src/modules/byo-llm/byo-llm.service.ts
+++ b/packages/oracle-runtime/src/modules/byo-llm/byo-llm.service.ts
@@ -22,7 +22,9 @@ import {
   GEMINI_OPENAI_COMPAT_BASE_URL,
 } from '../../llm/byo-client.js';
 import type { ModelListItem } from '../../llm/model-catalog.js';
+import { buildByoFallbackNotice } from '../../llm/provider-error.js';
 import { HomeServerCache } from '../messages/homeserver-cache.js';
+import { emitSSERawEvent } from '../messages/sse.utils.js';
 import { SecretsService } from '../secrets/secrets.service.js';
 import {
   ChatGptOAuthError,
@@ -334,6 +336,12 @@ export class ByoLlmService {
         this.logger.warn(
           `BYO model "${requestedModel}" requested but no ${requested.provider} credential is connected — falling back to the platform default.`,
         );
+        // The picker still shows their BYO model — without a signal the user
+        // has no way to know this reply ran on the platform model instead.
+        emitSSERawEvent(
+          'error',
+          buildByoFallbackNotice('not_connected', requested.provider),
+        );
         return null;
       }
       return this.finalizeTurn(
@@ -374,6 +382,10 @@ export class ByoLlmService {
       if (!fresh) {
         this.logger.warn(
           `ChatGPT token refresh failed for ${userDid} — turn falls back to the platform default (user must reconnect).`,
+        );
+        emitSSERawEvent(
+          'error',
+          buildByoFallbackNotice('reconnect_required', 'chatgpt'),
         );
         return null;
       }

--- a/packages/oracle-runtime/src/modules/messages/agent-builder.ts
+++ b/packages/oracle-runtime/src/modules/messages/agent-builder.ts
@@ -12,8 +12,9 @@ import type {
 import { createMainAgent } from '../../graph/main-agent.js';
 import type { TMainAgentGraphState } from '../../graph/state.js';
 import { createByoLlmAdapter } from '../../llm/byo-adapter.js';
-import { isByoModelId } from '../../llm/byo-catalog.js';
+import { isByoModelId, type ByoProvider } from '../../llm/byo-catalog.js';
 import { isAllowedModel } from '../../llm/model-catalog.js';
+import { buildByoFallbackNotice } from '../../llm/provider-error.js';
 import { didToMatrixUserId } from '../../matrix/user-id.js';
 import type { UcanDelegation } from '../../plugin-api/types.js';
 import {
@@ -27,7 +28,7 @@ import { resolveLangsmithTracing } from './langsmith-tracing.js';
 import type { SendMessageRequest } from './messages.service.js';
 import { OracleRuntimeBundleHolder } from './oracle-runtime-bundle.js';
 import { type PreparedRequest } from './request-preparer.js';
-import { emitSSEEvent } from './sse.utils.js';
+import { emitSSEEvent, emitSSERawEvent } from './sse.utils.js';
 import { UserContextFetcher } from './user-context-fetcher.js';
 
 export interface BuildAgentArgs {
@@ -68,6 +69,12 @@ export interface BuiltAgent {
    * langgraph-specific options we pass.
    */
   langGraphConfig: Record<string, unknown>;
+  /**
+   * The BYO provider the turn runs on, or `null` for platform turns. Lets
+   * the SSE runner attribute a model-call failure to the user's own account
+   * when classifying the error it sends to the client.
+   */
+  byoProvider: ByoProvider | null;
 }
 
 /**
@@ -268,6 +275,11 @@ export class AgentBuilder {
               this.logger.warn(
                 `[AgentBuilder] BYO credential resolution failed: ${err instanceof Error ? err.message : String(err)}`,
               );
+              // The user expected their own credential (they have one
+              // connected, or explicitly picked a `byo:` model) — tell them
+              // the turn degraded to the platform model instead of failing
+              // silently. No-op outside an SSE request context.
+              emitSSERawEvent('error', buildByoFallbackNotice('error'));
               return null;
             }),
     ]);
@@ -499,7 +511,12 @@ export class AgentBuilder {
       ...(abortController && { signal: abortController.signal }),
     };
 
-    return { agent, stateInput, langGraphConfig };
+    return {
+      agent,
+      stateInput,
+      langGraphConfig,
+      byoProvider: byoTurn?.provider ?? null,
+    };
   }
 
   /**

--- a/packages/oracle-runtime/src/modules/messages/error-simulation.test.ts
+++ b/packages/oracle-runtime/src/modules/messages/error-simulation.test.ts
@@ -1,0 +1,112 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { classifyLlmError } from '../../llm/provider-error.js';
+import {
+  resolveErrorSimulation,
+  type SimulationDirective,
+} from './error-simulation.js';
+
+function asThrow(
+  directive: SimulationDirective | null,
+): Extract<SimulationDirective, { action: 'throw' }> {
+  if (directive?.action !== 'throw') {
+    throw new Error(`expected a throw directive, got ${directive?.action}`);
+  }
+  return directive;
+}
+
+function asNotice(
+  directive: SimulationDirective | null,
+): Extract<SimulationDirective, { action: 'notice' }> {
+  if (directive?.action !== 'notice') {
+    throw new Error(`expected a notice directive, got ${directive?.action}`);
+  }
+  return directive;
+}
+
+describe('resolveErrorSimulation', () => {
+  const originalFlag = process.env.ALLOW_ERROR_SIMULATION;
+
+  beforeEach(() => {
+    process.env.ALLOW_ERROR_SIMULATION = 'true';
+  });
+
+  afterEach(() => {
+    if (originalFlag === undefined) {
+      delete process.env.ALLOW_ERROR_SIMULATION;
+    } else {
+      process.env.ALLOW_ERROR_SIMULATION = originalFlag;
+    }
+  });
+
+  it('is inert when the env gate is off', () => {
+    delete process.env.ALLOW_ERROR_SIMULATION;
+    expect(resolveErrorSimulation('/simulate-error deepseek:billing')).toBe(
+      null,
+    );
+  });
+
+  it('is inert for ordinary messages', () => {
+    expect(resolveErrorSimulation('hello there')).toBe(null);
+    expect(resolveErrorSimulation(undefined)).toBe(null);
+  });
+
+  it('every throw preset classifies to the kind its name promises', () => {
+    const expectations: Record<string, string> = {
+      'openai:billing': 'billing',
+      'openai:rate_limit': 'rate_limit',
+      'openai:auth': 'auth',
+      'anthropic:billing': 'billing',
+      'anthropic:rate_limit': 'rate_limit',
+      'anthropic:auth': 'auth',
+      'deepseek:billing': 'billing',
+      'gemini:rate_limit': 'rate_limit',
+      'chatgpt:usage_limit': 'rate_limit',
+      'chatgpt:auth': 'auth',
+      server: 'server',
+      timeout: 'timeout',
+      network: 'network',
+      unknown: 'unknown',
+    };
+    const observed = Object.keys(expectations).map((preset) => {
+      const directive = asThrow(
+        resolveErrorSimulation(`/simulate-error ${preset}`),
+      );
+      const classified = classifyLlmError(directive.error, {
+        byoProvider: directive.byoProvider,
+      });
+      return {
+        preset,
+        kind: classified.kind,
+        provider: classified.provider ?? null,
+      };
+    });
+    expect(observed).toEqual(
+      Object.entries(expectations).map(([preset, kind]) => ({
+        preset,
+        kind,
+        provider: preset.includes(':') ? preset.split(':')[0] : null,
+      })),
+    );
+  });
+
+  it('fallback presets emit a notice instead of throwing', () => {
+    const reconnect = asNotice(
+      resolveErrorSimulation('/simulate-error fallback'),
+    );
+    expect(reconnect.payload.kind).toBe('byo_fallback');
+    expect(reconnect.payload.reason).toBe('reconnect_required');
+
+    const notConnected = asNotice(
+      resolveErrorSimulation('/simulate-error fallback:not_connected'),
+    );
+    expect(notConnected.payload.reason).toBe('not_connected');
+  });
+
+  it('unknown presets throw a descriptive error listing what exists', () => {
+    const directive = asThrow(
+      resolveErrorSimulation('/simulate-error nonsense'),
+    );
+    expect(directive.error.message).toMatch(/Unknown simulation preset/);
+    expect(directive.error.message).toMatch(/deepseek:billing/);
+  });
+});

--- a/packages/oracle-runtime/src/modules/messages/error-simulation.ts
+++ b/packages/oracle-runtime/src/modules/messages/error-simulation.ts
@@ -1,0 +1,181 @@
+/**
+ * Local-testing hook for the error path. Sending a chat message of the form
+ *
+ *   /simulate-error <preset>
+ *
+ * makes the turn fail with a realistic provider error (same shape the SDK
+ * stack actually throws — status/code/nested error/message all faithful to
+ * the real thing) so the classifier → SSE → client-UI chain can be exercised
+ * without burning real credentials or quota. `fallback` presets emit the
+ * BYO→platform degradation notice and let the turn continue normally.
+ *
+ * Active ONLY when the env var `ALLOW_ERROR_SIMULATION` is exactly `true` —
+ * never set it in a deployed environment.
+ */
+
+import { type ByoProvider } from '../../llm/byo-catalog.js';
+import {
+  buildByoFallbackNotice,
+  type ByoFallbackNoticePayload,
+} from '../../llm/provider-error.js';
+
+const TRIGGER_PREFIX = '/simulate-error';
+
+interface SimulatedErrorSpec {
+  message: string;
+  status?: number;
+  code?: string;
+  nested?: { type: string; message: string };
+  byoProvider?: ByoProvider;
+}
+
+/**
+ * Presets replicate real captured error shapes:
+ *  - OpenAI/DeepSeek/Gemini errors carry `status` + a "NNN ..." message (and
+ *    `code: 'insufficient_quota'` for billing exhaustion).
+ *  - Anthropic errors carry `status` + `error.type` (`rate_limit_error`,
+ *    `authentication_error`, ...) with the JSON blob in the message.
+ *  - The ChatGPT backend reports errors with an EMPTY body, so all the SDK
+ *    can say is "NNN status code (no body)".
+ */
+const PRESETS: Record<string, SimulatedErrorSpec> = {
+  'openai:billing': {
+    status: 429,
+    code: 'insufficient_quota',
+    message:
+      '429 You exceeded your current quota, please check your plan and billing details. For more information on this error, read the docs: https://platform.openai.com/docs/guides/error-codes/api-errors.',
+    byoProvider: 'openai',
+  },
+  'openai:rate_limit': {
+    status: 429,
+    code: 'rate_limit_exceeded',
+    message:
+      '429 Rate limit reached for gpt-5.2 in organization org-simulated on tokens per min (TPM): Limit 30000, Used 30000, Requested 460.',
+    byoProvider: 'openai',
+  },
+  'openai:auth': {
+    status: 401,
+    code: 'invalid_api_key',
+    message:
+      '401 Incorrect API key provided: sk-proj-***simulated. You can find your API key at https://platform.openai.com/account/api-keys.',
+    byoProvider: 'openai',
+  },
+  'anthropic:billing': {
+    status: 400,
+    nested: {
+      type: 'invalid_request_error',
+      message:
+        'Your credit balance is too low to access the Anthropic API. Please go to Plans & Billing to upgrade or purchase credits.',
+    },
+    message:
+      '400 {"type":"error","error":{"type":"invalid_request_error","message":"Your credit balance is too low to access the Anthropic API. Please go to Plans & Billing to upgrade or purchase credits."}}',
+    byoProvider: 'anthropic',
+  },
+  'anthropic:rate_limit': {
+    status: 429,
+    nested: {
+      type: 'rate_limit_error',
+      message:
+        'Number of request tokens has exceeded your per-minute rate limit.',
+    },
+    message:
+      '429 {"type":"error","error":{"type":"rate_limit_error","message":"Number of request tokens has exceeded your per-minute rate limit."}}',
+    byoProvider: 'anthropic',
+  },
+  'anthropic:auth': {
+    status: 401,
+    nested: { type: 'authentication_error', message: 'invalid x-api-key' },
+    message:
+      '401 {"type":"error","error":{"type":"authentication_error","message":"invalid x-api-key"}}',
+    byoProvider: 'anthropic',
+  },
+  'deepseek:billing': {
+    status: 402,
+    message: '402 Insufficient Balance',
+    byoProvider: 'deepseek',
+  },
+  'gemini:rate_limit': {
+    status: 429,
+    message:
+      '429 You exceeded your current quota, please check your plan and billing details. [reason: "RESOURCE_EXHAUSTED"]',
+    byoProvider: 'gemini',
+  },
+  'chatgpt:usage_limit': {
+    status: 429,
+    message: '429 status code (no body)',
+    byoProvider: 'chatgpt',
+  },
+  'chatgpt:auth': {
+    status: 401,
+    message: '401 status code (no body)',
+    byoProvider: 'chatgpt',
+  },
+  server: {
+    status: 529,
+    nested: { type: 'overloaded_error', message: 'Overloaded' },
+    message:
+      '529 {"type":"error","error":{"type":"overloaded_error","message":"Overloaded"}}',
+  },
+  timeout: { message: 'Request timed out.' },
+  network: { message: 'fetch failed' },
+  unknown: { message: 'Simulated unclassifiable failure.' },
+};
+
+export type SimulationDirective =
+  | { action: 'throw'; error: Error; byoProvider?: ByoProvider }
+  | { action: 'notice'; payload: ByoFallbackNoticePayload };
+
+function buildSimulatedError(spec: SimulatedErrorSpec): Error {
+  const error = new Error(spec.message);
+  error.name = 'SimulatedProviderError';
+  Object.assign(error, {
+    ...(spec.status !== undefined && { status: spec.status }),
+    ...(spec.code !== undefined && { code: spec.code }),
+    ...(spec.nested !== undefined && { error: spec.nested }),
+  });
+  return error;
+}
+
+/**
+ * Inspect a chat message for the simulation trigger. Returns `null` when
+ * simulation is disabled, the message is not a trigger, or the preset is
+ * unknown (an unknown preset throws a descriptive error listing the presets
+ * so the tester sees what's available instead of a silent normal turn).
+ */
+export function resolveErrorSimulation(
+  message: string | undefined,
+): SimulationDirective | null {
+  if (process.env.ALLOW_ERROR_SIMULATION !== 'true') return null;
+  const trimmed = message?.trim() ?? '';
+  if (!trimmed.startsWith(TRIGGER_PREFIX)) return null;
+
+  const preset = trimmed.slice(TRIGGER_PREFIX.length).trim() || 'unknown';
+
+  if (preset === 'fallback' || preset === 'fallback:reconnect') {
+    return {
+      action: 'notice',
+      payload: buildByoFallbackNotice('reconnect_required', 'chatgpt'),
+    };
+  }
+  if (preset === 'fallback:not_connected') {
+    return {
+      action: 'notice',
+      payload: buildByoFallbackNotice('not_connected', 'anthropic'),
+    };
+  }
+
+  const spec = PRESETS[preset];
+  if (!spec) {
+    return {
+      action: 'throw',
+      error: new Error(
+        `Unknown simulation preset "${preset}". Available: ${[...Object.keys(PRESETS), 'fallback', 'fallback:not_connected'].join(', ')}`,
+      ),
+    };
+  }
+  return {
+    action: 'throw',
+    error: buildSimulatedError(spec),
+    ...(spec.byoProvider && { byoProvider: spec.byoProvider }),
+  };
+}

--- a/packages/oracle-runtime/src/modules/messages/messages.service.ts
+++ b/packages/oracle-runtime/src/modules/messages/messages.service.ts
@@ -26,6 +26,7 @@ import {
   getModelCapabilities,
   isAllowedModel,
 } from '../../llm/index.js';
+import { classifyLlmError } from '../../llm/provider-error.js';
 import { classifyAttachment } from './attachments/classify.js';
 import {
   buildUserMessageContent,
@@ -291,9 +292,14 @@ export class MessagesService implements OnModuleInit {
           `Pre-flight failed after SSE flush — session=${params.sessionId}`,
           error instanceof Error ? error.stack : String(error),
         );
+        // Pre-flight failures are infra (session lookup, attachments, agent
+        // build), never a user credential — classify without BYO context so
+        // the payload shape matches the stream path.
         sendSSEError(
           params.res,
           error instanceof Error ? error : 'Something went wrong',
+          classifyLlmError(error),
+          { sessionId: params.sessionId },
         );
         sendSSEDone(params.res);
         if (!params.res.writableEnded) params.res.end();

--- a/packages/oracle-runtime/src/modules/messages/sse-stream-runner.test.ts
+++ b/packages/oracle-runtime/src/modules/messages/sse-stream-runner.test.ts
@@ -806,7 +806,7 @@ describe('SseStreamRunner', () => {
       expect(events.some((e) => e.event === 'done')).toBe(true);
     });
 
-    it('non-abort error caught -> emits error then done', async () => {
+    it('non-abort error caught -> emits classified error then done', async () => {
       const res = new FakeResponse();
       const { input, runner } = makeInput(
         makeThrowingFakeAgent(new Error('boom')),
@@ -820,7 +820,104 @@ describe('SseStreamRunner', () => {
       const doneIdx = events.findIndex((e) => e.event === 'done');
       expect(errIdx).toBeGreaterThanOrEqual(0);
       expect(doneIdx).toBeGreaterThan(errIdx);
-      expect((events[errIdx]!.data as { error: string }).error).toBe('boom');
+      const payload = events[errIdx]!.data as {
+        error: string;
+        kind: string;
+        source: string;
+        detail: string;
+        retryable: boolean;
+      };
+      // The wire message is the friendly classification; the raw SDK text
+      // survives in `detail` for the collapsible details view.
+      expect(payload.kind).toBe('unknown');
+      expect(payload.source).toBe('platform');
+      expect(payload.detail).toBe('boom');
+      expect(payload.retryable).toBe(false);
+      expect(payload.error).toMatch(/Something went wrong/);
+    });
+
+    it('error path closes the thinking indicator before the error event', async () => {
+      const res = new FakeResponse();
+      const { input, runner } = makeInput(
+        makeThrowingFakeAgent(new Error('boom')),
+        res,
+      );
+
+      await runner.run(input);
+
+      const events = eventsFromWrites(res.writes);
+      const completeIdx = events.findIndex(
+        (e) =>
+          e.event === 'reasoning' &&
+          (e.data as { isComplete?: boolean }).isComplete === true,
+      );
+      const errIdx = events.findIndex((e) => e.event === 'error');
+      expect(completeIdx).toBeGreaterThanOrEqual(0);
+      expect(errIdx).toBeGreaterThan(completeIdx);
+    });
+
+    it('attributes model failures to the BYO provider resolved at build time', async () => {
+      const res = new FakeResponse();
+      const providerError = Object.assign(
+        new Error('402 Insufficient Balance'),
+        {
+          status: 402,
+        },
+      );
+      const agentBuilder = {
+        build: vi.fn().mockResolvedValue({
+          agent: makeThrowingFakeAgent(providerError),
+          stateInput: {},
+          langGraphConfig: { version: 'v2' },
+          byoProvider: 'deepseek',
+        }),
+      } as unknown as AgentBuilder;
+      const runner = new SseStreamRunner(agentBuilder);
+      await runner.run({
+        payload: makePayload(),
+        prepared: makePrepared(),
+        inputMessages: [],
+        res: res as unknown as Response,
+        abortControllers: new Map<string, AbortController>(),
+      });
+
+      const events = eventsFromWrites(res.writes);
+      const errEvent = events.find((e) => e.event === 'error');
+      const payload = errEvent!.data as {
+        kind: string;
+        source: string;
+        provider: string;
+        status: number;
+        detail: string;
+      };
+      expect(payload.kind).toBe('billing');
+      expect(payload.source).toBe('byo');
+      expect(payload.provider).toBe('deepseek');
+      expect(payload.status).toBe(402);
+      expect(payload.detail).toBe('402 Insufficient Balance');
+    });
+
+    it('flushes stuck tool spinners when the stream dies mid-turn', async () => {
+      const res = new FakeResponse();
+      const agent: FakeAgent = {
+        async *streamEvents() {
+          yield toolStartEvent('run-stuck', 'searchWeb', { query: 'cats' });
+          throw new Error('boom mid-tool');
+        },
+        async invoke() {
+          return { messages: [] };
+        },
+      };
+      const { input, runner } = makeInput(agent, res);
+
+      await runner.run(input);
+
+      const events = eventsFromWrites(res.writes);
+      const toolEvents = events.filter((e) => e.event === 'tool_call');
+      expect(toolEvents).toHaveLength(2);
+      const flushed = toolEvents[1]!.data as { status: string; output: string };
+      expect(flushed.status).toBe('done');
+      expect(flushed.output).toMatch(/did not complete/);
     });
 
     it('error AFTER res.writableEnded -> emits nothing (no double-end)', async () => {

--- a/packages/oracle-runtime/src/modules/messages/sse-stream-runner.ts
+++ b/packages/oracle-runtime/src/modules/messages/sse-stream-runner.ts
@@ -6,11 +6,15 @@ import {
 import { Injectable, Logger } from '@nestjs/common';
 import type { Response } from 'express';
 import { AIMessageChunk, type BaseMessage, ToolMessage } from 'langchain';
+import { type ByoProvider } from '../../llm/byo-catalog.js';
+import { classifyLlmError } from '../../llm/provider-error.js';
 import { emojify } from '../../utils/emoji.js';
 import { AgentBuilder } from './agent-builder.js';
 import { type SendMessagePayload } from './dto/send-message.dto.js';
+import { resolveErrorSimulation } from './error-simulation.js';
 import { type PreparedRequest } from './request-preparer.js';
 import {
+  emitSSERawEvent,
   formatSSE,
   runWithSSEContext,
   sendSSEDone,
@@ -192,15 +196,36 @@ export class SseStreamRunner {
     const onClose = () => abortController.abort();
     res.on('close', onClose);
 
+    // Hoisted out of the stream closure so the catch below can flush
+    // orphaned tool spinners when the run dies mid-turn.
+    const toolCallMap = new Map<string, ToolCallEvent>();
+    const actionCallMap = new Map<string, ActionCallEvent>();
+    // The BYO provider active on this turn (null on platform turns) — set
+    // once the agent build resolves, read by the error classifier so a
+    // model failure is attributed to the user's own account.
+    let activeByoProvider: ByoProvider | null = null;
+
     try {
       await runWithSSEContext(
         res,
         async () => {
-          const { agent, stateInput, langGraphConfig } =
+          // Local-testing hook — no-op unless ALLOW_ERROR_SIMULATION=true
+          // and the message is a `/simulate-error <preset>` trigger.
+          const simulation = resolveErrorSimulation(payload.message);
+          if (simulation?.action === 'throw') {
+            activeByoProvider = simulation.byoProvider ?? null;
+            throw simulation.error;
+          }
+          if (simulation?.action === 'notice') {
+            emitSSERawEvent('error', simulation.payload);
+          }
+
+          const { agent, stateInput, langGraphConfig, byoProvider } =
             await this.agentBuilder.build(
               { payload, prepared, inputMessages },
               abortController,
             );
+          activeByoProvider = byoProvider;
 
           // ReactAgent.streamEvents returns the same `{event, data, tags}`
           // shape as LangChain's `streamEvents v2` — the v2 envelope is the
@@ -217,8 +242,6 @@ export class SseStreamRunner {
             inputTokens: 0,
             outputTokens: 0,
           };
-          const toolCallMap = new Map<string, ToolCallEvent>();
-          const actionCallMap = new Map<string, ActionCallEvent>();
           const agActionNames = new Set(
             (payload.agActions ?? []).map((a) => a.name),
           );
@@ -308,6 +331,7 @@ export class SseStreamRunner {
           }
         },
         abortController,
+        { sessionId, requestId },
       );
     } catch (error) {
       const aborted =
@@ -319,11 +343,43 @@ export class SseStreamRunner {
         if (!res.writableEnded) sendSSEDone(res);
         return;
       }
-      this.logger.error('Stream failed', error);
+      // Attribute the failure (rate limit / billing / auth / ...) to the
+      // account it belongs to, so the client can render actionable feedback
+      // instead of the raw SDK message.
+      const classified = classifyLlmError(error, {
+        byoProvider: activeByoProvider,
+      });
+      this.logger.error(
+        `Stream failed — kind=${classified.kind}, source=${classified.source}` +
+          (classified.provider ? `, provider=${classified.provider}` : '') +
+          (classified.status !== undefined
+            ? `, status=${classified.status}`
+            : ''),
+        error instanceof Error ? error.stack : String(error),
+      );
       if (!res.writableEnded && !abortController.signal.aborted) {
+        // Same cleanup the success path performs: clear stuck tool spinners
+        // and close the thinking indicator, or the FE keeps both alive
+        // forever alongside the error.
+        this.flushOrphanedToolCalls(
+          toolCallMap,
+          actionCallMap,
+          res,
+          abortController,
+        );
+        const completeEvent = ReasoningEvent.createChunk(
+          sessionId,
+          requestId,
+          '',
+          undefined,
+          true,
+        );
+        res.write(formatSSE(completeEvent.eventName, completeEvent.payload));
         sendSSEError(
           res,
           error instanceof Error ? error : 'Something went wrong',
+          classified,
+          { sessionId, requestId },
         );
         sendSSEDone(res);
       }

--- a/packages/oracle-runtime/src/modules/messages/sse.utils.ts
+++ b/packages/oracle-runtime/src/modules/messages/sse.utils.ts
@@ -1,10 +1,13 @@
 import { type AllEvents } from '@ixo/oracles-events';
 import { AsyncLocalStorage } from 'node:async_hooks';
 import { type Response } from 'express';
+import { type ClassifiedLlmError } from '../../llm/provider-error.js';
 
 interface SSEContext {
   res: Response;
   abortController?: AbortController;
+  /** Request identity, stamped onto raw events emitted from nested code. */
+  ids?: { sessionId?: string; requestId?: string };
 }
 
 const sseContextStorage = new AsyncLocalStorage<SSEContext>();
@@ -84,12 +87,42 @@ export function sendSSEDone(res: Response): void {
   }
 }
 
-/** Send an error event. */
-export function sendSSEError(res: Response, error: Error | string): void {
+/**
+ * Send an error event. With `classified` set, the payload carries the
+ * structured classification (kind/source/provider/status/retryable) next to
+ * the human-readable `error` message so clients can render provider-aware
+ * feedback instead of the raw SDK text; without it, the legacy
+ * `{error, timestamp}` shape goes out unchanged.
+ */
+export function sendSSEError(
+  res: Response,
+  error: Error | string,
+  classified?: ClassifiedLlmError,
+  ids?: { sessionId?: string; requestId?: string },
+): void {
   if (!res.writableEnded) {
     res.write(
       formatSSE('error', {
-        error: error instanceof Error ? error.message : error,
+        error: classified
+          ? classified.message
+          : error instanceof Error
+            ? error.message
+            : error,
+        ...(classified && {
+          kind: classified.kind,
+          source: classified.source,
+          ...(classified.provider && { provider: classified.provider }),
+          ...(classified.providerLabel && {
+            providerLabel: classified.providerLabel,
+          }),
+          ...(classified.status !== undefined && {
+            status: classified.status,
+          }),
+          retryable: classified.retryable,
+          detail: classified.detail,
+        }),
+        ...(ids?.sessionId && { sessionId: ids.sessionId }),
+        ...(ids?.requestId && { requestId: ids.requestId }),
         timestamp: new Date().toISOString(),
       }),
     );
@@ -105,8 +138,9 @@ export function runWithSSEContext<T>(
   res: Response,
   callback: () => Promise<T>,
   abortController?: AbortController,
+  ids?: { sessionId?: string; requestId?: string },
 ): Promise<T> {
-  return sseContextStorage.run({ res, abortController }, callback);
+  return sseContextStorage.run({ res, abortController, ids }, callback);
 }
 
 /** Emit an SSE event from anywhere within the active SSE context. */
@@ -114,6 +148,24 @@ export function emitSSEEvent(event: AllEvents): void {
   const context = sseContextStorage.getStore();
   if (context?.res && !context.res.writableEnded) {
     context.res.write(formatSSEEvent(event));
+  }
+}
+
+/**
+ * Emit a raw event/payload pair from within the active SSE context, for
+ * one-off notices that have no event class (e.g. the BYO-fallback warning).
+ * Object payloads are stamped with the context's sessionId/requestId so
+ * clients can attribute the event. No-op outside an SSE request (batch
+ * path, Matrix path).
+ */
+export function emitSSERawEvent(eventName: string, data: unknown): void {
+  const context = sseContextStorage.getStore();
+  if (context?.res && !context.res.writableEnded) {
+    const payload =
+      data && typeof data === 'object' && !Array.isArray(data)
+        ? { ...context.ids, ...(data as Record<string, unknown>) }
+        : data;
+    context.res.write(formatSSE(eventName, payload));
   }
 }
 

--- a/turbo.json
+++ b/turbo.json
@@ -2,6 +2,7 @@
   "$schema": "https://turbo.build/schema.json",
   "globalDependencies": ["**/.env"],
   "globalEnv": [
+    "ALLOW_ERROR_SIMULATION",
     "TEST_USER_MNEMONIC",
     "SQLITE_DATABASE_PATH",
     "FIRECRAWL_MCP_URL",


### PR DESCRIPTION
Follow-up to #242. When a user's own provider account fails mid-chat (out of credit, rate limit, revoked key), the portal previously showed the raw SDK message in a bubble that vanished on refetch — and rate limits stalled ~1 minute in retries before surfacing anything.

## What changed

- **Server-side classification** (`llm/provider-error.ts`): every stream failure maps to `{ kind: rate_limit|billing|auth|timeout|server|network|unknown, source: byo|platform, provider, status, retryable, message, detail }`. Handles the real shapes: OpenAI billing exhaustion is a 429 + `insufficient_quota`, Anthropic billing is a **400** whose wording wins over the status, DeepSeek is a bare `402 Insufficient Balance`, Gemini's free-tier rate limit reuses OpenAI's billing sentence (kept out of billing), and the ChatGPT backend's empty-body errors classify via the status prefix.
- **Structured SSE `error` events**: friendly message + classification + raw `detail` + `sessionId`/`requestId`, replacing raw SDK text on the wire. Legacy `{error, timestamp}` shape preserved when no classification exists.
- **Clean failure path**: the runner's catch flushes orphaned tool spinners and emits the reasoning completion marker before the error — same cleanup as the success path, so the FE never keeps spinners alive next to an error.
- **Fast failure**: BYO models set `maxRetries: 2` (LangChain AsyncCaller defaults to 6 with exponential backoff).
- **No silent fallback**: turns that degrade from a BYO credential to the platform model (credential missing, ChatGPT refresh failed, resolution error) emit a `kind: byo_fallback` notice with a reason while the reply still streams.
- **Local testing**: `/simulate-error <preset>` chat trigger, gated by `ALLOW_ERROR_SIMULATION=true` (never set in deployed envs), replays faithful provider error shapes end to end.
- `@ixo/oracle-runtime` 1.5.0 → **1.6.0** + changeset.

## Verification

- 1043/1043 unit tests (22 new: classifier shapes per provider, simulation presets, runner error path incl. BYO attribution, tool-spinner flush, completion marker ordering).
- Lint 0 errors, prettier clean, tsc clean.
- Live smoke on the local oracle: `deepseek:billing` → full structured payload on the wire; `fallback` → notice + normal reply continues; `chatgpt:usage_limit` → friendly copy from an empty-body 429; plain turns unaffected.

Portal counterpart (classified persistent error banner consuming these payloads) ships separately in impacts-x-web.

Authored by: Michael Pretorius <michael@ixo.world>